### PR TITLE
fix: wrap details widget with ScanBoundary to prevent text rendering bug

### DIFF
--- a/lib/widgets/content/discourse_html_content/builders/details_builder.dart
+++ b/lib/widgets/content/discourse_html_content/builders/details_builder.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'scan_boundary.dart';
 
 /// 构建 Discourse details 折叠块
 /// 
@@ -32,12 +33,14 @@ Widget buildDetails({
   // 检查是否有 open 属性（默认展开）
   final isOpenByDefault = element.attributes.containsKey('open');
 
-  return _DetailsWidget(
-    theme: theme,
-    summaryText: summaryText,
-    contentHtml: contentHtml,
-    htmlBuilder: htmlBuilder,
-    initiallyExpanded: isOpenByDefault,
+  return ScanBoundary(
+    child: _DetailsWidget(
+      theme: theme,
+      summaryText: summaryText,
+      contentHtml: contentHtml,
+      htmlBuilder: htmlBuilder,
+      initiallyExpanded: isOpenByDefault,
+    ),
   );
 }
 


### PR DESCRIPTION
Closes #66

The CombinedDecoratorOverlay scans the full render tree including content inside collapsed <details\> sections (clipped to 0-height via Align+heightFactor). It draws inline-code backgrounds at those computed coordinates, making hidden text appear to leak out of collapsed sections.

Fix: wrap _DetailsWidget in ScanBoundary, the same pattern already used for tables. The nested DiscourseHtmlContent (via htmlBuilder) has its own CombinedDecoratorOverlay and handles code/spoiler rendering when the section is expanded.

![Screenshot_2026-02-24-19-05-12-57_29305c99cd67c0c1777e67766570ca85](https://github.com/user-attachments/assets/e88868be-9b5b-4084-bf78-9b7cc9a6e77d)
