### PR TITLE
支持邀请链接并记住 AI 助手模型

### DIFF
--- a/lib/models/invite_link.dart
+++ b/lib/models/invite_link.dart
@@ -1,0 +1,52 @@
+import '../utils/time_utils.dart';
+
+class InviteLinkResponse {
+  final String inviteLink;
+  final InviteLinkDetails? invite;
+
+  const InviteLinkResponse({
+    required this.inviteLink,
+    this.invite,
+  });
+
+  factory InviteLinkResponse.fromJson(Map<String, dynamic> json) {
+    return InviteLinkResponse(
+      inviteLink: json['invite_link'] as String? ?? '',
+      invite: json['invite'] is Map<String, dynamic>
+          ? InviteLinkDetails.fromJson(json['invite'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+class InviteLinkDetails {
+  final int? id;
+  final String? inviteKey;
+  final int? maxRedemptionsAllowed;
+  final int? redemptionCount;
+  final bool? expired;
+  final DateTime? createdAt;
+  final DateTime? expiresAt;
+
+  const InviteLinkDetails({
+    this.id,
+    this.inviteKey,
+    this.maxRedemptionsAllowed,
+    this.redemptionCount,
+    this.expired,
+    this.createdAt,
+    this.expiresAt,
+  });
+
+  factory InviteLinkDetails.fromJson(Map<String, dynamic> json) {
+    return InviteLinkDetails(
+      id: json['id'] as int?,
+      inviteKey: json['invite_key'] as String?,
+      maxRedemptionsAllowed: json['max_redemptions_allowed'] as int?,
+      redemptionCount: json['redemption_count'] as int?,
+      expired: json['expired'] as bool?,
+      createdAt: TimeUtils.parseUtcTime(json['created_at'] as String?),
+      expiresAt: TimeUtils.parseUtcTime(json['expires_at'] as String?),
+    );
+  }
+}

--- a/lib/pages/invite_links_page.dart
+++ b/lib/pages/invite_links_page.dart
@@ -1,0 +1,585 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/invite_link.dart';
+import '../providers/discourse_providers.dart';
+import '../services/toast_service.dart';
+import '../utils/time_utils.dart';
+
+enum _InviteExpiryPreset { days1, days7, days30, days90, never }
+
+extension on _InviteExpiryPreset {
+  String get label {
+    switch (this) {
+      case _InviteExpiryPreset.days1:
+        return '1 天';
+      case _InviteExpiryPreset.days7:
+        return '7 天';
+      case _InviteExpiryPreset.days30:
+        return '30 天';
+      case _InviteExpiryPreset.days90:
+        return '90 天';
+      case _InviteExpiryPreset.never:
+        return '从不';
+    }
+  }
+
+  Duration? get duration {
+    switch (this) {
+      case _InviteExpiryPreset.days1:
+        return const Duration(days: 1);
+      case _InviteExpiryPreset.days7:
+        return const Duration(days: 7);
+      case _InviteExpiryPreset.days30:
+        return const Duration(days: 30);
+      case _InviteExpiryPreset.days90:
+        return const Duration(days: 90);
+      case _InviteExpiryPreset.never:
+        return null;
+    }
+  }
+}
+
+class InviteLinksPage extends ConsumerStatefulWidget {
+  const InviteLinksPage({super.key});
+
+  @override
+  ConsumerState<InviteLinksPage> createState() => _InviteLinksPageState();
+}
+
+class _InviteLinksPageState extends ConsumerState<InviteLinksPage> {
+  static const int _maxRedemptionsAllowed = 1;
+  static const String _defaultRateLimitWait = '21 小时';
+
+  final TextEditingController _descriptionController = TextEditingController();
+  final TextEditingController _restrictionController = TextEditingController();
+
+  _InviteExpiryPreset _expiryPreset = _InviteExpiryPreset.days1;
+  bool _showAdvancedOptions = false;
+  bool _isSubmitting = false;
+  String? _error;
+  InviteLinkResponse? _latestInvite;
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    _restrictionController.dispose();
+    super.dispose();
+  }
+
+  DateTime? get _expiresAt {
+    final duration = _expiryPreset.duration;
+    if (duration == null) return null;
+    return DateTime.now().add(duration);
+  }
+
+  String get _summaryText {
+    if (_expiryPreset == _InviteExpiryPreset.never) {
+      return '链接最多可用于 1 个用户，并且永不过期。';
+    }
+    return '链接最多可用于 1 个用户，并且将在 ${_expiryPreset.label} 后到期。';
+  }
+
+  bool get _hasInviteLink =>
+      (_latestInvite?.inviteLink.trim().isNotEmpty ?? false);
+
+  Future<void> _createInviteLink({bool useAdvancedOptions = false}) async {
+    final user = ref.read(currentUserProvider).value;
+    if (user == null) {
+      ToastService.showError('请先登录');
+      return;
+    }
+    if (user.trustLevel < 3) {
+      ToastService.showError('当前账号尚未达到 L3，无法创建邀请链接');
+      return;
+    }
+
+    final description = useAdvancedOptions
+        ? _descriptionController.text.trim()
+        : '';
+    final email = useAdvancedOptions ? _restrictionController.text.trim() : '';
+
+    setState(() {
+      _isSubmitting = true;
+      _error = null;
+    });
+
+    try {
+      final result = await ref
+          .read(discourseServiceProvider)
+          .createInviteLink(
+            maxRedemptionsAllowed: _maxRedemptionsAllowed,
+            expiresAt: _expiresAt,
+            description: description,
+            email: email.isEmpty ? null : email,
+          );
+      if (!mounted) return;
+      setState(() {
+        _latestInvite = result.inviteLink.trim().isEmpty ? null : result;
+      });
+      ToastService.showSuccess(
+        result.inviteLink.trim().isNotEmpty ? '邀请链接已生成' : '邀请已创建',
+      );
+    } catch (error) {
+      if (!mounted) return;
+      final message = _normalizeErrorMessage(error);
+      setState(() => _error = message);
+      ToastService.showError(message);
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  Future<void> _copyInviteLink() async {
+    final inviteLink = _latestInvite?.inviteLink;
+    if (inviteLink == null || inviteLink.isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: inviteLink));
+    ToastService.showSuccess('邀请链接已复制');
+  }
+
+  void _shareInviteLink() {
+    final inviteLink = _latestInvite?.inviteLink;
+    if (inviteLink == null || inviteLink.isEmpty) return;
+    SharePlus.instance.share(
+      ShareParams(text: inviteLink, subject: 'Linux.do 邀请链接'),
+    );
+  }
+
+  String _normalizeErrorMessage(Object error) {
+    final message = _extractErrorMessage(error);
+    final rateLimitMessage = _buildRateLimitMessage(error, message);
+    if (rateLimitMessage != null) {
+      return rateLimitMessage;
+    }
+    if (message.contains('You are not permitted') ||
+        message.contains('not permitted')) {
+      return '服务端拒绝了当前账号的邀请权限';
+    }
+    return message.isEmpty ? '生成邀请链接失败' : message;
+  }
+
+  String _extractErrorMessage(Object error) {
+    if (error is DioException) {
+      final data = error.response?.data;
+      if (data is Map &&
+          data['errors'] is List &&
+          (data['errors'] as List).isNotEmpty) {
+        return (data['errors'] as List).join('\n');
+      }
+      if (data is Map && data['message'] is String) {
+        return data['message'] as String;
+      }
+      if (data is String && data.trim().isNotEmpty) {
+        return data.trim();
+      }
+      return (error.message ?? error.toString()).trim();
+    }
+    return error.toString().replaceFirst(RegExp(r'^Exception:\s*'), '').trim();
+  }
+
+  String? _buildRateLimitMessage(Object error, String message) {
+    final normalized = message.toLowerCase();
+    final dioError = error is DioException ? error : null;
+    final isRateLimited =
+        normalized.contains('too many times') ||
+        normalized.contains('rate limit') ||
+        normalized.contains('request too many') ||
+        message.contains('请求过多') ||
+        message.contains('次数过多') ||
+        dioError?.response?.statusCode == 429;
+
+    if (!isRateLimited) return null;
+
+    if (message.contains('您执行此操作的次数过多')) {
+      return message.startsWith('出错了：') ? message : '出错了：$message';
+    }
+
+    final waitText =
+        _extractWaitText(message) ??
+        _extractWaitTextFromData(dioError?.response?.data) ??
+        _defaultRateLimitWait;
+    return '出错了：您执行此操作的次数过多。请等待 $waitText 后再试。';
+  }
+
+  String? _extractWaitTextFromData(dynamic data) {
+    if (data is Map) {
+      final errors = data['errors'];
+      if (errors is List) {
+        for (final item in errors) {
+          final text = _extractWaitText(item.toString());
+          if (text != null) return text;
+        }
+      }
+      final extras = data['extras'];
+      if (extras is Map) {
+        final waitSecondsRaw = extras['wait_seconds'] ?? extras['time_left'];
+        final waitSeconds = int.tryParse(waitSecondsRaw?.toString() ?? '');
+        if (waitSeconds != null && waitSeconds > 0) {
+          return _formatWaitDuration(waitSeconds);
+        }
+      }
+    }
+    if (data is String) {
+      return _extractWaitText(data);
+    }
+    return null;
+  }
+
+  String? _extractWaitText(String message) {
+    final chineseMatch = RegExp(
+      r'请等待\s*([0-9]+\s*(?:小时|分钟|天|秒))\s*后再试',
+    ).firstMatch(message);
+    if (chineseMatch != null) {
+      return chineseMatch.group(1);
+    }
+
+    final englishMatch = RegExp(
+      r'Please wait\s+(\d+)\s+(second|seconds|minute|minutes|hour|hours|day|days)\s+before trying again',
+      caseSensitive: false,
+    ).firstMatch(message);
+    if (englishMatch != null) {
+      final value = int.tryParse(englishMatch.group(1) ?? '');
+      final unit = englishMatch.group(2)?.toLowerCase();
+      if (value == null || unit == null) return null;
+      if (unit.startsWith('day')) return '$value 天';
+      if (unit.startsWith('hour')) return '$value 小时';
+      if (unit.startsWith('minute')) return '$value 分钟';
+      return '$value 秒';
+    }
+
+    return null;
+  }
+
+  String _formatWaitDuration(int seconds) {
+    if (seconds >= 86400) {
+      return '${(seconds / 86400).ceil()} 天';
+    }
+    if (seconds >= 3600) {
+      return '${(seconds / 3600).ceil()} 小时';
+    }
+    if (seconds >= 60) {
+      return '${(seconds / 60).ceil()} 分钟';
+    }
+    return '$seconds 秒';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('邀请链接')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildSummaryCard(theme),
+          if (_error != null) ...[
+            const SizedBox(height: 16),
+            _buildErrorCard(theme),
+          ],
+          if (_showAdvancedOptions) ...[
+            const SizedBox(height: 16),
+            _buildAdvancedOptionsCard(theme),
+          ],
+          if (_hasInviteLink) ...[
+            const SizedBox(height: 16),
+            _buildResultCard(theme),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard(ThemeData theme) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '创建邀请链接',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _summaryText,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextButton(
+              onPressed: () =>
+                  setState(() => _showAdvancedOptions = !_showAdvancedOptions),
+              style: TextButton.styleFrom(padding: EdgeInsets.zero),
+              child: Text(_showAdvancedOptions ? '收起链接选项' : '编辑链接选项或通过电子邮件发送。'),
+            ),
+            if (!_showAdvancedOptions) ...[
+              const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: _isSubmitting ? null : () => _createInviteLink(),
+                  icon: _isSubmitting
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.link_rounded),
+                  label: Text(_isSubmitting ? '创建中...' : '创建链接'),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdvancedOptionsCard(ThemeData theme) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '邀请成员',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _descriptionController,
+              maxLength: 100,
+              decoration: const InputDecoration(
+                labelText: '描述 (可选)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _restrictionController,
+              keyboardType: TextInputType.emailAddress,
+              decoration: const InputDecoration(
+                labelText: '限制为 (可选)',
+                hintText: 'name@example.com 或者 example.com',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '最大使用次数',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            _buildReadOnlyField(theme, value: '1'),
+            const SizedBox(height: 16),
+            Text(
+              '有效截止时间',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _InviteExpiryPreset.values.map((preset) {
+                return ChoiceChip(
+                  label: Text(preset.label),
+                  selected: _expiryPreset == preset,
+                  onSelected: (_) => setState(() => _expiryPreset = preset),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 20),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _isSubmitting
+                    ? null
+                    : () => _createInviteLink(useAdvancedOptions: true),
+                icon: _isSubmitting
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.link_rounded),
+                label: Text(_isSubmitting ? '创建中...' : '创建链接'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorCard(ThemeData theme) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        _error!,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.error,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReadOnlyField(ThemeData theme, {required String value}) {
+    return InputDecorator(
+      decoration: const InputDecoration(
+        border: OutlineInputBorder(),
+        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+      ),
+      child: Row(
+        children: [
+          Expanded(child: Text(value, style: theme.textTheme.bodyLarge)),
+          Text(
+            '固定',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultCard(ThemeData theme) {
+    final invite = _latestInvite!;
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '最新生成结果',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.45,
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: SelectableText(
+                invite.inviteLink,
+                style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                _MetaChip(
+                  icon: Icons.repeat_rounded,
+                  label:
+                      '可用 ${invite.invite?.maxRedemptionsAllowed ?? _maxRedemptionsAllowed} 次',
+                ),
+                if (invite.invite?.expiresAt != null)
+                  _MetaChip(
+                    icon: Icons.schedule_rounded,
+                    label:
+                        '截止 ${TimeUtils.formatDetailTime(invite.invite!.expiresAt)}',
+                  )
+                else
+                  const _MetaChip(
+                    icon: Icons.all_inclusive_rounded,
+                    label: '无过期时间',
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: _copyInviteLink,
+                    icon: const Icon(Icons.copy_rounded),
+                    label: const Text('复制链接'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton.icon(
+                    onPressed: _shareInviteLink,
+                    icon: const Icon(Icons.share_rounded),
+                    label: const Text('分享'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+
+  const _MetaChip({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: 0.45,
+        ),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -25,6 +25,7 @@ import '../providers/app_state_refresher.dart';
 import 'metaverse_page.dart';
 import 'package:ai_model_manager/ai_model_manager.dart';
 import 'drafts_page.dart';
+import 'invite_links_page.dart';
 import '../providers/ldc_providers.dart';
 import '../widgets/ldc_balance_card.dart';
 import '../providers/cdk_providers.dart';
@@ -357,7 +358,10 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
             ),
 
             if (isLoggedIn) ...[
-              _buildOptionsCard(theme),
+              _buildOptionsCard(
+                theme,
+                canAccessInviteLinks: (user?.trustLevel ?? 0) >= 3,
+              ),
               const SizedBox(height: 20),
             ],
             _buildAboutCard(theme),
@@ -450,7 +454,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
     );
   }
 
-  Widget _buildOptionsCard(ThemeData theme) {
+  Widget _buildOptionsCard(ThemeData theme, {required bool canAccessInviteLinks}) {
     return Card(
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
@@ -488,6 +492,16 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
             title: '信任要求', 
             onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const TrustLevelRequirementsPage()))
           ),
+          if (canAccessInviteLinks)
+            _buildOptionTile(
+              icon: Icons.link_rounded,
+              iconColor: Colors.cyan,
+              title: '邀请链接',
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const InviteLinksPage()),
+              ),
+            ),
           _buildOptionTile(
             icon: Icons.history_rounded,
             iconColor: Colors.purple,

--- a/lib/pages/topic_detail_page/widgets/ai_chat_page.dart
+++ b/lib/pages/topic_detail_page/widgets/ai_chat_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ai_model_manager/ai_model_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -53,8 +55,7 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
     final detail = widget.detail;
     if (detail == null || _isLoadingContext) return;
 
-    final scope =
-        ref.read(topicAiContextScopeProvider(widget.topicId));
+    final scope = ref.read(topicAiContextScopeProvider(widget.topicId));
 
     // 计算需要多少条帖子
     final stream = detail.postStream.stream;
@@ -69,8 +70,9 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
     }
 
     // 找出缺失的帖子 ID
-    final missingIds =
-        neededIds.where((id) => !_fetchedPostIds.contains(id)).toList();
+    final missingIds = neededIds
+        .where((id) => !_fetchedPostIds.contains(id))
+        .toList();
     if (missingIds.isEmpty) return;
 
     setState(() => _isLoadingContext = true);
@@ -86,11 +88,13 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
       for (final id in missingIds) {
         final post = loadedMap[id];
         if (post != null) {
-          fromLoaded.add(TopicPostContext(
-            postNumber: post.postNumber,
-            username: post.username,
-            cooked: post.cooked,
-          ));
+          fromLoaded.add(
+            TopicPostContext(
+              postNumber: post.postNumber,
+              username: post.username,
+              cooked: post.cooked,
+            ),
+          );
           _fetchedPostIds.add(id);
         } else {
           stillMissing.add(id);
@@ -104,17 +108,20 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
         final service = DiscourseService();
         // getPosts 一次最多获取合理数量，分批获取
         for (var i = 0; i < stillMissing.length; i += 20) {
-          final batch =
-              stillMissing.sublist(i, (i + 20).clamp(0, stillMissing.length));
-          final postStream =
-              await service.getPosts(widget.topicId, batch);
+          final batch = stillMissing.sublist(
+            i,
+            (i + 20).clamp(0, stillMissing.length),
+          );
+          final postStream = await service.getPosts(widget.topicId, batch);
           for (final post in postStream.posts) {
             if (!_fetchedPostIds.contains(post.id)) {
-              _contextPosts.add(TopicPostContext(
-                postNumber: post.postNumber,
-                username: post.username,
-                cooked: post.cooked,
-              ));
+              _contextPosts.add(
+                TopicPostContext(
+                  postNumber: post.postNumber,
+                  username: post.username,
+                  cooked: post.cooked,
+                ),
+              );
               _fetchedPostIds.add(post.id);
             }
           }
@@ -139,9 +146,8 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
 
   /// 当 scope 变更时检查是否需要加载更多帖子
   void _onScopeChanged(ContextScope newScope) {
-    ref
-        .read(topicAiContextScopeProvider(widget.topicId).notifier)
-        .state = newScope;
+    ref.read(topicAiContextScopeProvider(widget.topicId).notifier).state =
+        newScope;
 
     final detail = widget.detail;
     if (detail == null) return;
@@ -174,12 +180,26 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
         .setContextPosts(title, _contextPosts);
   }
 
+  ({AiProvider provider, AiModel model})? _currentModel() {
+    final selected = ref.read(topicSelectedAiModelProvider(widget.topicId));
+    final lastUsed = ref.read(lastUsedAiAssistantModelProvider);
+    final defaultModel = ref.read(defaultAiModelProvider);
+    return selected ?? lastUsed ?? defaultModel;
+  }
+
+  void _rememberModel(({AiProvider provider, AiModel model}) model) {
+    ref.read(topicSelectedAiModelProvider(widget.topicId).notifier).state =
+        model;
+    unawaited(
+      setLastUsedAiAssistantModel(ref, model.provider.id, model.model.id),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final chatState = ref.watch(topicAiChatProvider(widget.topicId));
-    final chatNotifier =
-        ref.read(topicAiChatProvider(widget.topicId).notifier);
+    final chatNotifier = ref.read(topicAiChatProvider(widget.topicId).notifier);
 
     // 首次 build 且有 detail 时加载上下文
     if (widget.detail != null && _lastLoadedScope == null) {
@@ -192,8 +212,10 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
     final bottomInset = mediaQuery.viewInsets.bottom;
     final screenHeight = mediaQuery.size.height;
     // 内容区高度：键盘弹出时收缩，确保不超过屏幕顶部状态栏
-    final contentHeight = (screenHeight * 0.9)
-        .clamp(0.0, screenHeight - widget.topPadding - bottomInset);
+    final contentHeight = (screenHeight * 0.9).clamp(
+      0.0,
+      screenHeight - widget.topPadding - bottomInset,
+    );
 
     return Padding(
       padding: EdgeInsets.only(bottom: bottomInset),
@@ -206,131 +228,157 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
         child: SafeArea(
           bottom: false,
           child: Column(
-          children: [
-            // 顶部拖动条
-            Container(
-              margin: const EdgeInsets.symmetric(vertical: 12),
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-            
-            // 自定义标题栏
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.auto_awesome, size: 20, color: theme.colorScheme.primary),
-                      const SizedBox(width: 8),
-                      const Text(
-                        'AI 助手',
-                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-                      ),
-                    ],
+            children: [
+              // 顶部拖动条
+              Container(
+                margin: const EdgeInsets.symmetric(vertical: 12),
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.onSurfaceVariant.withValues(
+                    alpha: 0.3,
                   ),
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Consumer(
-                        builder: (context, ref, _) {
-                          final scope = ref.watch(topicAiContextScopeProvider(widget.topicId));
-                          return AiContextSelector(
-                            currentScope: scope,
-                            onChanged: _onScopeChanged,
-                          );
-                        },
-                      ),
-                      if (chatState.messages.isNotEmpty)
-                        IconButton(
-                          icon: const Icon(Icons.delete_outline),
-                          tooltip: '清空聊天',
-                          onPressed: () => _confirmClear(context, chatNotifier),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+
+              // 自定义标题栏
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.auto_awesome,
+                          size: 20,
+                          color: theme.colorScheme.primary,
                         ),
-                    ],
-                  ),
-                ],
+                        const SizedBox(width: 8),
+                        const Text(
+                          'AI 助手',
+                          style: TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Consumer(
+                          builder: (context, ref, _) {
+                            final scope = ref.watch(
+                              topicAiContextScopeProvider(widget.topicId),
+                            );
+                            return AiContextSelector(
+                              currentScope: scope,
+                              onChanged: _onScopeChanged,
+                            );
+                          },
+                        ),
+                        if (chatState.messages.isNotEmpty)
+                          IconButton(
+                            icon: const Icon(Icons.delete_outline),
+                            tooltip: '清空聊天',
+                            onPressed: () =>
+                                _confirmClear(context, chatNotifier),
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(height: 8),
+              const SizedBox(height: 8),
 
-            // 上下文加载提示
-            if (_isLoadingContext)
-              LinearProgressIndicator(
-                minHeight: 2,
-                color: theme.colorScheme.primary,
+              // 上下文加载提示
+              if (_isLoadingContext)
+                LinearProgressIndicator(
+                  minHeight: 2,
+                  color: theme.colorScheme.primary,
+                ),
+
+              // 聊天主要内容区
+              Expanded(
+                child: chatState.messages.isEmpty
+                    ? _buildEmptyState(context, theme)
+                    : _buildMessageList(context, ref, chatState),
               ),
 
-            // 聊天主要内容区
-            Expanded(
-              child: chatState.messages.isEmpty
-                  ? _buildEmptyState(context, theme)
-                  : _buildMessageList(context, ref, chatState),
-            ),
-
-            // 底部输入区
-            AiChatInput(
-              isGenerating: chatState.isGenerating,
-              onSend: (content) {
-                final scope = ref.read(topicAiContextScopeProvider(widget.topicId));
-                final selected = ref.read(topicSelectedAiModelProvider(widget.topicId));
-                final defaultModel = ref.read(defaultAiModelProvider);
-                final model = selected ?? defaultModel;
-                if (model == null) return;
-                chatNotifier.sendMessage(content, scope, selectedModel: model);
-              },
-              onStop: chatNotifier.stopGeneration,
-              bottomLeading: Consumer(
-                builder: (context, ref, _) {
-                  final allModels = ref.watch(allAvailableAiModelsProvider);
-                  final selected =
-                      ref.watch(topicSelectedAiModelProvider(widget.topicId));
-                  final defaultModel = ref.watch(defaultAiModelProvider);
-                  final current = selected ?? defaultModel;
-                  if (allModels.length <= 1 || current == null) {
-                    return const SizedBox.shrink();
-                  }
-                  return _AiModelSelector(
-                    allModels: allModels,
-                    current: current,
-                    onChanged: (model) {
-                      ref
-                          .read(topicSelectedAiModelProvider(widget.topicId)
-                              .notifier)
-                          .state = model;
-                    },
+              // 底部输入区
+              AiChatInput(
+                isGenerating: chatState.isGenerating,
+                onSend: (content) {
+                  final scope = ref.read(
+                    topicAiContextScopeProvider(widget.topicId),
+                  );
+                  final model = _currentModel();
+                  if (model == null) return;
+                  _rememberModel(model);
+                  chatNotifier.sendMessage(
+                    content,
+                    scope,
+                    selectedModel: model,
                   );
                 },
+                onStop: chatNotifier.stopGeneration,
+                bottomLeading: Consumer(
+                  builder: (context, ref, _) {
+                    final allModels = ref.watch(allAvailableAiModelsProvider);
+                    final selected = ref.watch(
+                      topicSelectedAiModelProvider(widget.topicId),
+                    );
+                    final lastUsedModel = ref.watch(
+                      lastUsedAiAssistantModelProvider,
+                    );
+                    final defaultModel = ref.watch(defaultAiModelProvider);
+                    final current = selected ?? lastUsedModel ?? defaultModel;
+                    if (allModels.length <= 1 || current == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return _AiModelSelector(
+                      allModels: allModels,
+                      current: current,
+                      onChanged: _rememberModel,
+                    );
+                  },
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
       ),
     );
   }
 
   /// 常用对话
   static const _quickPrompts = [
-    (icon: Icons.summarize_outlined, label: '总结这个话题', prompt: '请简要总结这个话题的主要内容和讨论要点。'),
+    (
+      icon: Icons.summarize_outlined,
+      label: '总结这个话题',
+      prompt: '请简要总结这个话题的主要内容和讨论要点。',
+    ),
     (icon: Icons.translate_outlined, label: '翻译主帖', prompt: '请将主帖内容翻译成英文。'),
-    (icon: Icons.question_answer_outlined, label: '列出主要观点', prompt: '请列出这个话题中各楼层的主要观点和立场。'),
-    (icon: Icons.lightbulb_outlined, label: '有什么值得关注的', prompt: '这个话题中有哪些值得关注的信息或亮点？'),
+    (
+      icon: Icons.question_answer_outlined,
+      label: '列出主要观点',
+      prompt: '请列出这个话题中各楼层的主要观点和立场。',
+    ),
+    (
+      icon: Icons.lightbulb_outlined,
+      label: '有什么值得关注的',
+      prompt: '这个话题中有哪些值得关注的信息或亮点？',
+    ),
   ];
 
   void _sendQuickPrompt(String prompt) {
     final scope = ref.read(topicAiContextScopeProvider(widget.topicId));
-    final selected =
-        ref.read(topicSelectedAiModelProvider(widget.topicId));
-    final defaultModel = ref.read(defaultAiModelProvider);
-    final model = selected ?? defaultModel;
+    final model = _currentModel();
     if (model == null) return;
+    _rememberModel(model);
     ref
         .read(topicAiChatProvider(widget.topicId).notifier)
         .sendMessage(prompt, scope, selectedModel: model);
@@ -359,8 +407,9 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
             Text(
               'AI 会基于话题内容为你解答',
               style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant
-                    .withValues(alpha: 0.7),
+                color: theme.colorScheme.onSurfaceVariant.withValues(
+                  alpha: 0.7,
+                ),
               ),
             ),
             const SizedBox(height: 28),
@@ -398,13 +447,12 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
           message: message,
           onRetry: message.status == MessageStatus.error
               ? () {
-                  final scope = ref
-                      .read(topicAiContextScopeProvider(widget.topicId));
-                  final selected = ref
-                      .read(topicSelectedAiModelProvider(widget.topicId));
-                  final defaultModel = ref.read(defaultAiModelProvider);
-                  final model = selected ?? defaultModel;
+                  final scope = ref.read(
+                    topicAiContextScopeProvider(widget.topicId),
+                  );
+                  final model = _currentModel();
                   if (model == null) return;
+                  _rememberModel(model);
                   ref
                       .read(topicAiChatProvider(widget.topicId).notifier)
                       .retryLastMessage(scope, selectedModel: model);
@@ -463,8 +511,11 @@ class _AiModelSelector extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.auto_awesome,
-                size: 16, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.auto_awesome,
+              size: 16,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
             const SizedBox(width: 4),
             ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 100),
@@ -476,8 +527,11 @@ class _AiModelSelector extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ),
-            Icon(Icons.unfold_more,
-                size: 14, color: theme.colorScheme.onSurfaceVariant),
+            Icon(
+              Icons.unfold_more,
+              size: 14,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
           ],
         ),
       ),
@@ -485,7 +539,8 @@ class _AiModelSelector extends StatelessWidget {
         return allModels.asMap().entries.map((entry) {
           final index = entry.key;
           final item = entry.value;
-          final isCurrent = item.provider.id == current.provider.id &&
+          final isCurrent =
+              item.provider.id == current.provider.id &&
               item.model.id == current.model.id;
           return PopupMenuItem<int>(
             value: index,
@@ -501,13 +556,17 @@ class _AiModelSelector extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text(item.model.name ?? item.model.id,
-                          style: const TextStyle(fontSize: 14)),
-                      Text(item.provider.name,
-                          style: TextStyle(
-                            fontSize: 11,
-                            color: theme.colorScheme.onSurfaceVariant,
-                          )),
+                      Text(
+                        item.model.name ?? item.model.id,
+                        style: const TextStyle(fontSize: 14),
+                      ),
+                      Text(
+                        item.provider.name,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/services/discourse/_users.dart
+++ b/lib/services/discourse/_users.dart
@@ -14,7 +14,10 @@ mixin _UsersMixin on _DiscourseServiceBase {
       final currentUser = await preloaded.getCurrentUser();
       if (currentUser != null && currentUser['username'] != null) {
         _username = currentUser['username'] as String;
-        await _storage.write(key: DiscourseService._usernameKey, value: _username!);
+        await _storage.write(
+          key: DiscourseService._usernameKey,
+          value: _username!,
+        );
         return _username;
       }
     } catch (e) {
@@ -41,7 +44,10 @@ mixin _UsersMixin on _DiscourseServiceBase {
         currentUserNotifier.value = user;
         if (user.username.isNotEmpty) {
           _username = user.username;
-          await _storage.write(key: DiscourseService._usernameKey, value: _username!);
+          await _storage.write(
+            key: DiscourseService._usernameKey,
+            value: _username!,
+          );
         }
         return user;
       }
@@ -63,12 +69,16 @@ mixin _UsersMixin on _DiscourseServiceBase {
   }
 
   /// 获取用户统计数据（带缓存，按用户名区分）
-  Future<UserSummary> getUserSummary(String username, {bool forceRefresh = false}) async {
+  Future<UserSummary> getUserSummary(
+    String username, {
+    bool forceRefresh = false,
+  }) async {
     if (!forceRefresh &&
         _cachedUserSummary != null &&
         _cachedUserSummaryUsername == username &&
         _userSummaryCacheTime != null &&
-        DateTime.now().difference(_userSummaryCacheTime!) < DiscourseService._summaryCacheDuration) {
+        DateTime.now().difference(_userSummaryCacheTime!) <
+            DiscourseService._summaryCacheDuration) {
       return _cachedUserSummary!;
     }
 
@@ -83,7 +93,11 @@ mixin _UsersMixin on _DiscourseServiceBase {
   }
 
   /// 获取用户动态
-  Future<UserActionResponse> getUserActions(String username, {String? filter, int offset = 0}) async {
+  Future<UserActionResponse> getUserActions(
+    String username, {
+    String? filter,
+    int offset = 0,
+  }) async {
     final queryParams = <String, dynamic>{
       'username': username,
       'offset': offset,
@@ -91,32 +105,43 @@ mixin _UsersMixin on _DiscourseServiceBase {
     if (filter != null) {
       queryParams['filter'] = filter;
     }
-    final response = await _dio.get('/user_actions.json', queryParameters: queryParams);
+    final response = await _dio.get(
+      '/user_actions.json',
+      queryParameters: queryParams,
+    );
     return UserActionResponse.fromJson(response.data);
   }
 
   /// 获取用户回应列表
-  Future<UserReactionsResponse> getUserReactions(String username, {int? beforeReactionUserId}) async {
-    final queryParams = <String, dynamic>{
-      'username': username,
-    };
+  Future<UserReactionsResponse> getUserReactions(
+    String username, {
+    int? beforeReactionUserId,
+  }) async {
+    final queryParams = <String, dynamic>{'username': username};
     if (beforeReactionUserId != null) {
       queryParams['before_reaction_user_id'] = beforeReactionUserId;
     }
-    final response = await _dio.get('/discourse-reactions/posts/reactions.json', queryParameters: queryParams);
+    final response = await _dio.get(
+      '/discourse-reactions/posts/reactions.json',
+      queryParameters: queryParams,
+    );
     return UserReactionsResponse.fromJson(response.data);
   }
 
   /// 获取用户关注列表
   Future<List<FollowUser>> getFollowing(String username) async {
     final response = await _dio.get('/u/$username/follow/following');
-    return (response.data as List).map((json) => FollowUser.fromJson(json)).toList();
+    return (response.data as List)
+        .map((json) => FollowUser.fromJson(json))
+        .toList();
   }
 
   /// 获取用户粉丝列表
   Future<List<FollowUser>> getFollowers(String username) async {
     final response = await _dio.get('/u/$username/follow/followers');
-    return (response.data as List).map((json) => FollowUser.fromJson(json)).toList();
+    return (response.data as List)
+        .map((json) => FollowUser.fromJson(json))
+        .toList();
   }
 
   /// 关注用户
@@ -138,14 +163,18 @@ mixin _UsersMixin on _DiscourseServiceBase {
   }
 
   /// 设置用户订阅级别（normal/mute/ignore）
-  Future<void> updateUserNotificationLevel(String username, {
+  Future<void> updateUserNotificationLevel(
+    String username, {
     required String level,
     String? expiringAt,
   }) async {
-    await _dio.put('/u/$username/notification_level.json', data: {
-      'notification_level': level,
-      if (expiringAt != null) 'expiring_at': expiringAt,
-    });
+    await _dio.put(
+      '/u/$username/notification_level.json',
+      data: {
+        'notification_level': level,
+        if (expiringAt case final expiringAt?) 'expiring_at': expiringAt,
+      },
+    );
   }
 
   /// 获取用户浏览历史
@@ -200,7 +229,10 @@ mixin _UsersMixin on _DiscourseServiceBase {
   }
 
   /// 获取徽章的所有获得者
-  Future<BadgeDetailResponse> getBadgeUsers({required int badgeId, String? username}) async {
+  Future<BadgeDetailResponse> getBadgeUsers({
+    required int badgeId,
+    String? username,
+  }) async {
     final queryParams = <String, dynamic>{'badge_id': badgeId};
     if (username != null) {
       queryParams['username'] = username;
@@ -212,5 +244,30 @@ mixin _UsersMixin on _DiscourseServiceBase {
     );
 
     return BadgeDetailResponse.fromJson(response.data);
+  }
+
+  /// 生成邀请链接
+  Future<InviteLinkResponse> createInviteLink({
+    required int maxRedemptionsAllowed,
+    DateTime? expiresAt,
+    String? description,
+    String? email,
+  }) async {
+    try {
+      final response = await _dio.post(
+        '/invites',
+        data: {
+          'max_redemptions_allowed': maxRedemptionsAllowed,
+          if (expiresAt != null)
+            'expires_at': expiresAt.toUtc().toIso8601String(),
+          if (description != null && description.trim().isNotEmpty)
+            'description': description.trim(),
+          if (email != null && email.trim().isNotEmpty) 'email': email.trim(),
+        },
+      );
+      return InviteLinkResponse.fromJson(response.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      _throwApiError(e);
+    }
   }
 }

--- a/lib/services/discourse/discourse_service.dart
+++ b/lib/services/discourse/discourse_service.dart
@@ -16,6 +16,7 @@ import '../../models/badge.dart';
 import '../../models/tag_search_result.dart';
 import '../../models/mention_user.dart';
 import '../../models/draft.dart';
+import '../../models/invite_link.dart';
 
 import '../../constants.dart';
 import '../../providers/message_bus_providers.dart';

--- a/packages/ai_model_manager/lib/providers/ai_chat_providers.dart
+++ b/packages/ai_model_manager/lib/providers/ai_chat_providers.dart
@@ -10,6 +10,25 @@ import '../models/ai_chat_message.dart';
 import '../services/ai_chat_service.dart';
 import 'ai_provider_providers.dart';
 
+const _lastUsedAiAssistantModelKey = 'ai_assistant_last_model';
+
+({AiProvider provider, AiModel model})? _findAiModelByKey(
+  List<({AiProvider provider, AiModel model})> all,
+  String? key,
+) {
+  if (key == null || key.isEmpty) return null;
+
+  final parts = key.split(':');
+  if (parts.length != 2) return null;
+
+  for (final item in all) {
+    if (item.provider.id == parts[0] && item.model.id == parts[1]) {
+      return item;
+    }
+  }
+  return null;
+}
+
 /// 所有可用的 AI 模型列表（供应商 + 模型）
 final allAvailableAiModelsProvider =
     Provider<List<({AiProvider provider, AiModel model})>>(
@@ -35,18 +54,39 @@ final defaultAiModelProvider =
     if (all.isEmpty) return null;
 
     final defaultKey = ref.watch(defaultAiModelKeyProvider);
-    if (defaultKey != null) {
-      final parts = defaultKey.split(':');
-      if (parts.length == 2) {
-        final match = all.where(
-          (m) => m.provider.id == parts[0] && m.model.id == parts[1],
-        );
-        if (match.isNotEmpty) return match.first;
-      }
-    }
-    return all.first;
+    return _findAiModelByKey(all, defaultKey) ?? all.first;
   },
 );
+
+/// AI 助手上次使用的模型 key（providerId:modelId）
+final lastUsedAiAssistantModelKeyProvider = StateProvider<String?>((ref) {
+  final prefs = ref.watch(aiSharedPreferencesProvider);
+  return prefs.getString(_lastUsedAiAssistantModelKey);
+});
+
+/// AI 助手上次使用的模型
+final lastUsedAiAssistantModelProvider =
+    Provider<({AiProvider provider, AiModel model})?>(
+  (ref) {
+    final all = ref.watch(allAvailableAiModelsProvider);
+    if (all.isEmpty) return null;
+
+    final lastUsedKey = ref.watch(lastUsedAiAssistantModelKeyProvider);
+    return _findAiModelByKey(all, lastUsedKey);
+  },
+);
+
+/// 设置 AI 助手上次使用的模型
+Future<void> setLastUsedAiAssistantModel(
+  WidgetRef ref,
+  String providerId,
+  String modelId,
+) async {
+  final prefs = ref.read(aiSharedPreferencesProvider);
+  final key = '$providerId:$modelId';
+  await prefs.setString(_lastUsedAiAssistantModelKey, key);
+  ref.read(lastUsedAiAssistantModelKeyProvider.notifier).state = key;
+}
 
 /// 第一个可用的 AI 模型（向后兼容）
 final firstAvailableAiModelProvider =
@@ -62,7 +102,7 @@ final hasAvailableAiModelProvider = Provider<bool>(
 /// 话题选中的 AI 模型（独立管理，避免切换时影响消息列表）
 final topicSelectedAiModelProvider = StateProvider.autoDispose
     .family<({AiProvider provider, AiModel model})?, int>(
-  (ref, topicId) => null, // null 表示使用默认模型
+  (ref, topicId) => null, // null 表示使用记忆模型或默认模型
 );
 
 /// AI 聊天服务


### PR DESCRIPTION
## 变更
- 支持三级用户在个人页进入邀请链接页面
- 邀请链接默认行为、限频提示和高级选项尽量对齐 Linux.do
- AI 助手记住上次选择的模型，下次进入默认继续使用

## 验证
- 定点 `flutter analyze`
- 已打包并在手机上测试 APK