### PR TITLE
🐛 修复 macOS 14 版本判断错误

### DIFF
--- a/lib/services/network/doh/network_settings_service.dart
+++ b/lib/services/network/doh/network_settings_service.dart
@@ -591,7 +591,7 @@ class NetworkSettingsService {
   Future<void> _applyWebViewProxy() async {
     if (!shouldRunLocalProxy) return;
     // macOS 14 以下 / iOS 17 以下调用 setProxyOverride 可能报错
-    if (!Platform.isAndroid && !await isMacOS14OrAbove() && !await isiOS17OrAbove()) return;
+    if (!Platform.isAndroid && !await _isMacOS14OrAbove() && !await _isiOS17OrAbove()) return;
     final port = _activeProxyPort;
     if (port == null) return;
     try {
@@ -611,7 +611,7 @@ class NetworkSettingsService {
 
   Future<void> _clearWebViewProxy() async {
     if (!_webViewProxySet) return;
-    if (!Platform.isAndroid && !await isMacOS14OrAbove() && !await isiOS17OrAbove()) return;
+    if (!Platform.isAndroid && !await _isMacOS14OrAbove() && !await _isiOS17OrAbove()) return;
     try {
       await inappwebview.ProxyController.instance().clearProxyOverride();
       _webViewProxySet = false;
@@ -623,18 +623,18 @@ class NetworkSettingsService {
 
   static bool? _isMacOS14OrAboveCache;
 
-  Future<bool> isMacOS14OrAbove() async {
+  Future<bool> _isMacOS14OrAbove() async {
     if (!Platform.isMacOS) return false;
     if (_isMacOS14OrAboveCache != null) return _isMacOS14OrAboveCache!;
     final info = await DeviceInfoPlugin().macOsInfo;
-    // Darwin 23 对应 macOS 14 (Sonoma)
-    _isMacOS14OrAboveCache = info.majorVersion >= 23;
+    // 修复：majorVersion 对应 macOS 大版本，如 macOS 14 (Sonoma) => majorVersion == 14 ≠ Darwin 23
+    _isMacOS14OrAboveCache = info.majorVersion >= 14;
     return _isMacOS14OrAboveCache!;
   }
 
   static bool? _isiOS17OrAboveCache;
 
-  Future<bool> isiOS17OrAbove() async {
+  Future<bool> _isiOS17OrAbove() async {
     if (!Platform.isIOS) return false;
     if (_isiOS17OrAboveCache != null) return _isiOS17OrAboveCache!;
     final info = await DeviceInfoPlugin().iosInfo;


### PR DESCRIPTION
<img width="2100" height="1106" alt="ScreenShot_2026-03-26_014638_698" src="https://github.com/user-attachments/assets/e2c0c091-3cef-4dc0-8b3d-0d9922243693" />

> 你听我解（狡）释（辩），我说我被 ChatGPT 骗了你信吗？🙈

人麻了，我问他怎么判断 macOS 14 以上，跟我说 majorVersion 是 Darwin 版本，判断 majorVersion >= 23 🤦‍♂️。今天掉登录了才发现 WebView 访问不了 linux.do，昨天是已经登录了数据走的都是 Dio 所以能正常使用。

我的问题，没测试充分，太相信它了，以后还是得辩证一下🤦‍♂️。（我吐了，这么简单的问题都出错😧）

这次我测试直接看代理服务器的流量情况了，在 App 里面用 WebView 访问了一下 linux.do 和 github.com 都确认通过 App 设置的代理端点走向代理服务器了