### PR TITLE
优化被动登出逻辑，缓解 Android 上误掉登录问题

### DIFF
--- a/.github/workflows/android-ci-test.yaml
+++ b/.github/workflows/android-ci-test.yaml
@@ -1,0 +1,118 @@
+name: Android CI Test APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/conservative-auth-invalidation
+
+permissions:
+  contents: write
+
+env:
+  CI_TEST_TAG: ci-android-test
+  APK_NAME: fluxdo-arm64-test.apk
+
+jobs:
+  build-android-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.38.9'
+          cache: true
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Android build environment
+        run: |
+          rustup target add aarch64-linux-android
+          cargo install cargo-ndk
+          sudo apt-get update && sudo apt-get install -y cmake
+
+      - name: Setup Android NDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'ndk;25.2.9519653'
+
+      - name: Generate temporary signing key
+        run: |
+          keytool -genkeypair \
+            -v \
+            -keystore android/app/upload-keystore.jks \
+            -alias ci-test \
+            -storepass android \
+            -keypass android \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity 10000 \
+            -dname "CN=Fluxdo CI, OU=CI, O=Fluxdo, L=Internet, S=Internet, C=US"
+          cat > android/key.properties <<'EOF'
+          storePassword=android
+          keyPassword=android
+          keyAlias=ci-test
+          storeFile=upload-keystore.jks
+          EOF
+
+      - name: Generate CA certificates
+        working-directory: core/doh_proxy
+        run: cargo run --bin gen_ca
+
+      - name: Build DOH Proxy
+        working-directory: core/doh_proxy
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_SDK_ROOT }}/ndk/25.2.9519653
+        run: cargo ndk -t arm64-v8a --platform 28 build --release --features ech
+
+      - name: Copy native libraries
+        run: |
+          mkdir -p android/app/src/main/jniLibs/arm64-v8a
+          cp core/doh_proxy/target/aarch64-linux-android/release/libdoh_proxy.so android/app/src/main/jniLibs/arm64-v8a/
+          mkdir -p android/app/src/main/res/raw
+          cp core/doh_proxy/certs/ca.der android/app/src/main/res/raw/proxy_ca.der
+
+      - name: Get dependencies
+        run: flutter pub get
+
+      - name: Build Android APK
+        run: |
+          flutter build apk --release --target-platform android-arm64 --dart-define=cronetHttpNoPlay=true
+          mkdir -p dist
+          cp build/app/outputs/flutter-apk/app-release.apk dist/${{ env.APK_NAME }}
+
+      - name: Publish test APK release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.CI_TEST_TAG }}
+          name: Android CI Test APK
+          body: |
+            Automated Android arm64 test build from branch `${{ github.ref_name }}`.
+            This APK is signed with a temporary CI key for testing only.
+          prerelease: true
+          make_latest: false
+          files: |
+            dist/${{ env.APK_NAME }}
+          fail_on_unmatched_files: true
+          overwrite_files: true
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-arm64-test-apk
+          path: dist/${{ env.APK_NAME }}
+          if-no-files-found: error
+          overwrite: true

--- a/lib/providers/core_providers.dart
+++ b/lib/providers/core_providers.dart
@@ -72,9 +72,9 @@ class CurrentUserNotifier extends AsyncNotifier<User?> {
         _saveCache(prefs, user);
         return user;
       }
-      // 网络确认未登录，清除缓存并返回 null
-      await prefs.remove(_cacheKey);
-      await prefs.remove(_cacheUserKey);
+      // 当前轮请求未拿到用户时，不立刻清缓存；只有在已确认没有 token 的分支才清理。
+      // 这样可以避免短暂鉴权抖动把 UI 误判成已登出。
+      if (cachedUser != null) return cachedUser;
       return null;
     } catch (e) {
       // 网络失败，返回缓存

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -617,8 +617,58 @@ mixin _AuthMixin on _DiscourseServiceBase {
   Future<bool> isLoggedIn() async {
     final tToken = await _cookieJar.getTToken();
     if (tToken == null || tToken.isEmpty) return false;
+
+    final username = await _storage.read(key: DiscourseService._usernameKey);
+    if (username == null || username.isEmpty) {
+      return false;
+    }
+
+    // 启动恢复时不能只信任本地 _t；否则服务端已撤销会话但本地 cookie 仍在时，
+    // UI 会进入“假在线”状态。这里做一次轻量私有接口探测：
+    // - 200 且用户名匹配：确认仍在线
+    // - 401/403/not_logged_in/discourse-logged-out：承认已掉线并清理本地状态
+    // - 网络/挑战态等不确定错误：保守保留本地状态，避免冷启动误退
+    try {
+      final response = await _dio.get(
+        '/u/$username.json',
+        options: Options(
+          extra: const {
+            'skipAuthCheck': true,
+            'allowStaleSession': true,
+          },
+        ),
+      );
+      final data = response.data;
+      if (response.statusCode == 200 &&
+          data is Map &&
+          data['user'] is Map &&
+          (data['user']['username']?.toString().toLowerCase() ==
+              username.toLowerCase())) {
+        _tToken = tToken;
+        _username = username;
+        _resetAuthInvalidState();
+        return true;
+      }
+    } on DioException catch (e) {
+      final response = e.response;
+      final data = response?.data;
+      final hasNotLoggedInError =
+          data is Map && data['error_type'] == 'not_logged_in';
+      final hasLoggedOutHeader =
+          response?.headers.value('discourse-logged-out')?.isNotEmpty == true;
+      final privateAuthDenied =
+          response != null &&
+          (response.statusCode == 401 || response.statusCode == 403);
+      if (hasNotLoggedInError || hasLoggedOutHeader || privateAuthDenied) {
+        await logout(callApi: false, refreshPreload: false);
+        return false;
+      }
+    } catch (_) {
+      // ignore and fall back to conservative local restore below
+    }
+
     _tToken = tToken;
-    _username = await _storage.read(key: DiscourseService._usernameKey);
+    _username = username;
     _resetAuthInvalidState();
     return true;
   }

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -2,6 +2,147 @@ part of 'discourse_service.dart';
 
 /// 认证相关
 mixin _AuthMixin on _DiscourseServiceBase {
+  static const Duration _authInvalidStrikeWindow = Duration(seconds: 45);
+  int _authInvalidStrikeCount = 0;
+  DateTime? _lastAuthInvalidAt;
+  Future<bool?>? _authRecheckFuture;
+
+  void _resetAuthInvalidState() {
+    _authInvalidStrikeCount = 0;
+    _lastAuthInvalidAt = null;
+  }
+
+  int _registerAuthInvalidStrike() {
+    final now = DateTime.now();
+    if (_lastAuthInvalidAt == null ||
+        now.difference(_lastAuthInvalidAt!) > _authInvalidStrikeWindow) {
+      _authInvalidStrikeCount = 1;
+    } else {
+      _authInvalidStrikeCount += 1;
+    }
+    _lastAuthInvalidAt = now;
+    return _authInvalidStrikeCount;
+  }
+
+  Future<bool?> _probeSessionStillValid({
+    required String source,
+    String? triggerInfo,
+  }) {
+    final inFlight = _authRecheckFuture;
+    if (inFlight != null) return inFlight;
+
+    final future = _probeSessionStillValidImpl(
+      source: source,
+      triggerInfo: triggerInfo,
+    );
+    _authRecheckFuture = future;
+    future.whenComplete(() {
+      if (identical(_authRecheckFuture, future)) {
+        _authRecheckFuture = null;
+      }
+    });
+    return future;
+  }
+
+  Future<bool?> _probeSessionStillValidImpl({
+    required String source,
+    String? triggerInfo,
+  }) async {
+    try {
+      final response = await _dio.get(
+        '/session/current.json',
+        queryParameters: {'_': DateTime.now().millisecondsSinceEpoch},
+        options: Options(
+          extra: {
+            'skipAuthCheck': true,
+            'skipCsrf': true,
+          },
+        ),
+      );
+
+      final data = response.data;
+      if (data is! Map<String, dynamic>) {
+        LogWriter.instance.write({
+          'timestamp': DateTime.now().toIso8601String(),
+          'level': 'warning',
+          'type': 'auth',
+          'event': 'auth_recheck_inconclusive',
+          'message': '会话复检返回了非预期数据结构，暂不执行登出',
+          'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'statusCode': response.statusCode,
+          'dataType': data.runtimeType.toString(),
+        });
+        return null;
+      }
+
+      final currentUser = data['current_user'];
+      if (currentUser is Map<String, dynamic>) {
+        final user = User.fromJson(currentUser);
+        currentUserNotifier.value = user;
+        if (user.username.isNotEmpty) {
+          _username = user.username;
+          await _storage.write(
+            key: DiscourseService._usernameKey,
+            value: user.username,
+          );
+        }
+        final liveToken = await _cookieJar.getTToken();
+        if (liveToken != null && liveToken.isNotEmpty) {
+          _tToken = liveToken;
+        }
+        LogWriter.instance.write({
+          'timestamp': DateTime.now().toIso8601String(),
+          'level': 'info',
+          'type': 'auth',
+          'event': 'auth_recovered_after_probe',
+          'message': '会话复检成功，保留当前登录态',
+          'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'username': user.username,
+        });
+        return true;
+      }
+
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'warning',
+        'type': 'auth',
+        'event': 'auth_recheck_failed',
+        'message': '会话复检确认 current_user 不存在',
+        'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'statusCode': response.statusCode,
+      });
+      return false;
+    } on DioException catch (e) {
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'warning',
+        'type': 'auth',
+        'event': 'auth_recheck_inconclusive',
+        'message': '会话复检请求失败，暂不执行登出',
+        'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'statusCode': e.response?.statusCode,
+        'errorType': e.type.toString(),
+        'url': e.requestOptions.uri.toString(),
+      });
+      return null;
+    } catch (e) {
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'warning',
+        'type': 'auth',
+        'event': 'auth_recheck_inconclusive',
+        'message': '会话复检发生异常，暂不执行登出',
+        'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'error': e.toString(),
+      });
+      return null;
+    }
+  }
 
   /// 初始化拦截器
   void _initInterceptors() {
@@ -71,18 +212,18 @@ mixin _AuthMixin on _DiscourseServiceBase {
           final tToken = await _cookieJar.getTToken();
           if (tToken != null && tToken.isNotEmpty) {
             _tToken = tToken;
+            _resetAuthInvalidState();
           } else if (_tToken != null && _tToken!.isNotEmpty) {
             LogWriter.instance.write({
               'timestamp': DateTime.now().toIso8601String(),
               'level': 'warning',
               'type': 'auth',
               'event': 'token_missing_after_response',
-              'message': '响应后 CookieJar 中未检测到 _t，已清空内存 token',
+              'message': '响应后 CookieJar 中未检测到 _t，本次仅记录告警，不立即清空内存 token',
               'method': response.requestOptions.method,
               'url': response.requestOptions.uri.toString(),
               'memTokenLen': _tToken?.length,
             });
-            _tToken = null;
           }
 
           final username = response.headers.value('x-discourse-username');
@@ -187,9 +328,10 @@ mixin _AuthMixin on _DiscourseServiceBase {
   /// 1. 有 _t cookie 但 UserAuthToken.lookup 找不到对应用户（token 已失效）
   /// 2. 没有 _t cookie 但请求带了 Discourse-Logged-In header
   ///
-  /// Discourse 官方前端：弹对话框 → window.location 刷新，不做二次验证。
-  /// 我们也直接信任此信号触发登出。之前的二次验证（请求首页检查 currentUser）
-  /// 会清除 CDN URL 等基础数据，导致头像 URL 降级到主域名 → 403 → 雪崩。
+  /// 这里不再“一次命中就立刻登出”，而是进入保守确认流程：
+  /// - 先记录 strike
+  /// - 复检 /session/current.json
+  /// - 仅在短时间内连续确认失效时才真正清会话
   Future<void> _onDiscourseLoggedOut({
     required String source,
     required String triggerInfo,
@@ -257,37 +399,74 @@ mixin _AuthMixin on _DiscourseServiceBase {
     int? sentTLen,
   }) async {
     if (_isLoggingOut) return;
+
+    final strike = _registerAuthInvalidStrike();
+    final jarTToken = await _cookieJar.getTToken();
+    final csrfToken = _cookieSync.csrfToken;
+
+    LogWriter.instance.write({
+      'timestamp': DateTime.now().toIso8601String(),
+      'level': strike >= 2 ? 'warning' : 'info',
+      'type': 'auth',
+      'event': 'auth_invalid_detected',
+      'message': strike >= 2 ? '登录异常再次出现，准备执行会话复检' : '检测到一次登录异常，先暂缓登出并执行会话复检',
+      'reason': message,
+      if (source != null) 'source': source,
+      if (triggerInfo != null) 'trigger': triggerInfo,
+      'strike': strike,
+      'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+      'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+      'jarTokenLen': jarTToken?.length,
+      'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+      if (sentHasT != null) 'sentHasT': sentHasT,
+      if (sentTLen != null) 'sentTLen': sentTLen,
+    });
+
+    final probeResult = await _probeSessionStillValid(
+      source: source ?? 'unknown',
+      triggerInfo: triggerInfo,
+    );
+
+    if (probeResult == true) {
+      _resetAuthInvalidState();
+      return;
+    }
+
+    if (probeResult == null && strike < 3) {
+      return;
+    }
+
+    if (probeResult == false && strike < 2) {
+      return;
+    }
+
     _isLoggingOut = true;
 
     // ===== 第一步：立即切断所有在途请求 =====
     // 先于 logout 执行，防止用户在失效状态下继续操作产生更多 403
     AuthSession().advance();
 
-    // 收集 _t cookie 诊断信息（不含实际值，仅状态）
-    final jarTToken = await _cookieJar.getTToken();
-    final csrfToken = _cookieSync.csrfToken;
-
-    // 记录被动退出日志（含触发来源，方便排查）
     LogWriter.instance.write({
       'timestamp': DateTime.now().toIso8601String(),
       'level': 'warning',
       'type': 'lifecycle',
       'event': 'logout_passive',
-      'message': '登录失效被动退出',
+      'message': '登录失效被动退出（已通过保守复检确认）',
       'reason': message,
       if (source != null) 'source': source,
       if (triggerInfo != null) 'trigger': triggerInfo,
-      // _t cookie 诊断（仅记录有无和长度，不记录实际值）
+      'strike': strike,
+      'probeResult': probeResult,
       'memHasToken': _tToken != null && _tToken!.isNotEmpty,
       'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
       'jarTokenLen': jarTToken?.length,
       'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
-      // 实际请求中 Cookie header 的 _t 状态（仅 discourse-logged-out 触发时有值）
       if (sentHasT != null) 'sentHasT': sentHasT,
       if (sentTLen != null) 'sentTLen': sentTLen,
     });
 
     await logout(callApi: false, refreshPreload: true);
+    _resetAuthInvalidState();
     _isLoggingOut = false;
     _authErrorController.add(message);
   }
@@ -298,6 +477,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
     if (tToken == null || tToken.isEmpty) return false;
     _tToken = tToken;
     _username = await _storage.read(key: DiscourseService._usernameKey);
+    _resetAuthInvalidState();
     return true;
   }
 

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -624,42 +624,55 @@ mixin _AuthMixin on _DiscourseServiceBase {
     }
 
     // 启动恢复时不能只信任本地 _t；否则服务端已撤销会话但本地 cookie 仍在时，
-    // UI 会进入“假在线”状态。这里做一次轻量私有接口探测：
-    // - 200 且用户名匹配：确认仍在线
-    // - 401/403/not_logged_in/discourse-logged-out：承认已掉线并清理本地状态
+    // UI 会进入“假在线”状态。
+    // 但这里也不能再用 /u/{username}.json 这种公开资料接口做判断：未登录时它也可能 200，
+    // 从而把匿名态误判成仍在线。改为直接探测严格鉴权的 /session/current.json：
+    // - current_user 存在：确认仍在线
+    // - current_user 缺失/null、401/403、not_logged_in：确认已掉线
     // - 网络/挑战态等不确定错误：保守保留本地状态，避免冷启动误退
     try {
       final response = await _dio.get(
-        '/u/$username.json',
+        '/session/current.json',
+        queryParameters: {'_': DateTime.now().millisecondsSinceEpoch},
         options: Options(
           extra: const {
             'skipAuthCheck': true,
+            'skipCsrf': true,
             'allowStaleSession': true,
           },
         ),
       );
       final data = response.data;
-      if (response.statusCode == 200 &&
-          data is Map &&
-          data['user'] is Map &&
-          (data['user']['username']?.toString().toLowerCase() ==
-              username.toLowerCase())) {
-        _tToken = tToken;
-        _username = username;
-        _resetAuthInvalidState();
-        return true;
+      if (data is Map && data['current_user'] is Map) {
+        final currentUser = data['current_user'] as Map;
+        final liveUsername = currentUser['username']?.toString();
+        if (liveUsername != null && liveUsername.isNotEmpty) {
+          _tToken = tToken;
+          _username = liveUsername;
+          await _storage.write(
+            key: DiscourseService._usernameKey,
+            value: liveUsername,
+          );
+          _resetAuthInvalidState();
+          return true;
+        }
+      }
+
+      if (data is Map && data.containsKey('current_user')) {
+        await logout(callApi: false, refreshPreload: false);
+        return false;
       }
     } on DioException catch (e) {
       final response = e.response;
       final data = response?.data;
       final hasNotLoggedInError =
           data is Map && data['error_type'] == 'not_logged_in';
-      final hasLoggedOutHeader =
-          response?.headers.value('discourse-logged-out')?.isNotEmpty == true;
+      final hasAnonymousSessionPayload =
+          data is Map && data.containsKey('current_user') && data['current_user'] == null;
       final privateAuthDenied =
           response != null &&
           (response.statusCode == 401 || response.statusCode == 403);
-      if (hasNotLoggedInError || hasLoggedOutHeader || privateAuthDenied) {
+      if (hasNotLoggedInError || hasAnonymousSessionPayload || privateAuthDenied) {
         await logout(callApi: false, refreshPreload: false);
         return false;
       }

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -49,6 +49,26 @@ mixin _AuthMixin on _DiscourseServiceBase {
     String? triggerInfo,
   }) async {
     try {
+      try {
+        await BoundarySyncService.instance.syncFromWebView(
+          cookieNames: {'_t', '_forum_session', 'cf_clearance'},
+        );
+      } catch (e) {
+        LogWriter.instance.write({
+          'timestamp': DateTime.now().toIso8601String(),
+          'level': 'info',
+          'type': 'auth',
+          'event': 'auth_recheck_boundary_sync_failed',
+          'message': '会话复检前的 WebView→CookieJar 同步失败，继续尝试 session 复检',
+          'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'error': e.toString(),
+        });
+      }
+
+      final tTokenBeforeProbe = await _cookieJar.getTToken();
+      final cfClearanceBeforeProbe = await _cookieJar.getCfClearance();
+
       final response = await _dio.get(
         '/session/current.json',
         queryParameters: {'_': DateTime.now().millisecondsSinceEpoch},
@@ -100,6 +120,8 @@ mixin _AuthMixin on _DiscourseServiceBase {
           'source': source,
           if (triggerInfo != null) 'trigger': triggerInfo,
           'username': user.username,
+          'hasTBeforeProbe': tTokenBeforeProbe != null && tTokenBeforeProbe.isNotEmpty,
+          'hasCfClearanceBeforeProbe': cfClearanceBeforeProbe != null && cfClearanceBeforeProbe.isNotEmpty,
         });
         return true;
       }

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -24,6 +24,17 @@ mixin _AuthMixin on _DiscourseServiceBase {
     return _authInvalidStrikeCount;
   }
 
+  int _registerAuthInvalidStrikeForEvent() {
+    // 同一轮会话复检进行中时，把并发异常折叠成同一次 strike。
+    // 否则一次首页刷新触发的多个并发请求，可能在同一个「不确定」复检结果上
+    // 直接把 strike 叠满，误触发被动登出。
+    if (_authRecheckFuture != null && _authInvalidStrikeCount > 0) {
+      _lastAuthInvalidAt = DateTime.now();
+      return _authInvalidStrikeCount;
+    }
+    return _registerAuthInvalidStrike();
+  }
+
   Future<bool?> _probeSessionStillValid({
     required String source,
     String? triggerInfo,
@@ -422,7 +433,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
   }) async {
     if (_isLoggingOut) return;
 
-    final strike = _registerAuthInvalidStrike();
+    final strike = _registerAuthInvalidStrikeForEvent();
     final jarTToken = await _cookieJar.getTToken();
     final csrfToken = _cookieSync.csrfToken;
 
@@ -454,11 +465,45 @@ mixin _AuthMixin on _DiscourseServiceBase {
       return;
     }
 
-    if (probeResult == null && strike < 3) {
+    if (probeResult == null) {
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'info',
+        'type': 'auth',
+        'event': 'auth_inconclusive_abort_logout',
+        'message': '会话复检结果不确定，本次保持登录态并等待后续独立异常再次确认',
+        'reason': message,
+        if (source != null) 'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'strike': strike,
+        'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+        'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+        'jarTokenLen': jarTToken?.length,
+        'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+        if (sentHasT != null) 'sentHasT': sentHasT,
+        if (sentTLen != null) 'sentTLen': sentTLen,
+      });
       return;
     }
 
     if (probeResult == false && strike < 2) {
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'info',
+        'type': 'auth',
+        'event': 'auth_recheck_failed_but_deferred_logout',
+        'message': '会话复检确认失效，但首次命中仅记录告警，暂不立即登出',
+        'reason': message,
+        if (source != null) 'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'strike': strike,
+        'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+        'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+        'jarTokenLen': jarTToken?.length,
+        'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+        if (sentHasT != null) 'sentHasT': sentHasT,
+        if (sentTLen != null) 'sentTLen': sentTLen,
+      });
       return;
     }
 

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -111,6 +111,9 @@ mixin _AuthMixin on _DiscourseServiceBase {
 
       final tTokenBeforeProbe = await _cookieJar.getTToken();
       final cfClearanceBeforeProbe = await _cookieJar.getCfClearance();
+      final previousStrikeCount = _authInvalidStrikeCount;
+      final previousAuthInvalidAt = _lastAuthInvalidAt;
+      final previousInconclusiveAt = _lastAuthRecheckInconclusiveAt;
 
       final response = await _dio.get(
         '/session/current.json',
@@ -179,6 +182,9 @@ mixin _AuthMixin on _DiscourseServiceBase {
         if (triggerInfo != null) 'trigger': triggerInfo,
         'statusCode': response.statusCode,
       });
+      _authInvalidStrikeCount = previousStrikeCount;
+      _lastAuthInvalidAt = previousAuthInvalidAt;
+      _lastAuthRecheckInconclusiveAt = previousInconclusiveAt;
       return false;
     } on DioException catch (e) {
       LogWriter.instance.write({
@@ -193,6 +199,9 @@ mixin _AuthMixin on _DiscourseServiceBase {
         'errorType': e.type.toString(),
         'url': e.requestOptions.uri.toString(),
       });
+      _authInvalidStrikeCount = previousStrikeCount;
+      _lastAuthInvalidAt = previousAuthInvalidAt;
+      _lastAuthRecheckInconclusiveAt = previousInconclusiveAt;
       return null;
     } catch (e) {
       LogWriter.instance.write({
@@ -205,6 +214,9 @@ mixin _AuthMixin on _DiscourseServiceBase {
         if (triggerInfo != null) 'trigger': triggerInfo,
         'error': e.toString(),
       });
+      _authInvalidStrikeCount = previousStrikeCount;
+      _lastAuthInvalidAt = previousAuthInvalidAt;
+      _lastAuthRecheckInconclusiveAt = previousInconclusiveAt;
       return null;
     }
   }
@@ -283,7 +295,6 @@ mixin _AuthMixin on _DiscourseServiceBase {
           final tToken = await _cookieJar.getTToken();
           if (tToken != null && tToken.isNotEmpty) {
             _tToken = tToken;
-            _resetAuthInvalidState();
           } else if (_tToken != null && _tToken!.isNotEmpty) {
             LogWriter.instance.write({
               'timestamp': DateTime.now().toIso8601String(),

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -391,6 +391,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
                 source: 'error_response_body',
                 triggerInfo:
                     '${error.requestOptions.method} ${error.requestOptions.uri} → ${error.response?.statusCode}, error_type=${data['error_type']}',
+                strongEvidence: true,
               ),
               event: 'auth_error_body_background_failed',
               source: 'error_response_body',
@@ -458,6 +459,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
       triggerInfo: triggerInfo,
       sentHasT: sentHasT,
       sentTLen: sentTLen,
+      strongEvidence: statusCode == 401 || statusCode == 403,
     );
   }
 
@@ -480,10 +482,12 @@ mixin _AuthMixin on _DiscourseServiceBase {
     String? triggerInfo,
     bool? sentHasT,
     int? sentTLen,
+    bool strongEvidence = false,
   }) async {
     if (_isLoggingOut) return;
 
-    if (_shouldSuppressAuthInvalidDuringInconclusiveCooldown()) {
+    if (_shouldSuppressAuthInvalidDuringInconclusiveCooldown() &&
+        !strongEvidence) {
       final jarTToken = await _cookieJar.getTToken();
       final csrfToken = _cookieSync.csrfToken;
       LogWriter.instance.write({
@@ -496,6 +500,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
         if (source != null) 'source': source,
         if (triggerInfo != null) 'trigger': triggerInfo,
         'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
+        'strongEvidence': strongEvidence,
         'memHasToken': _tToken != null && _tToken!.isNotEmpty,
         'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
         'jarTokenLen': jarTToken?.length,
@@ -520,6 +525,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
       if (source != null) 'source': source,
       if (triggerInfo != null) 'trigger': triggerInfo,
       'strike': strike,
+      'strongEvidence': strongEvidence,
       'memHasToken': _tToken != null && _tToken!.isNotEmpty,
       'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
       'jarTokenLen': jarTToken?.length,
@@ -539,26 +545,48 @@ mixin _AuthMixin on _DiscourseServiceBase {
     }
 
     if (probeResult == null) {
-      _lastAuthRecheckInconclusiveAt = DateTime.now();
-      LogWriter.instance.write({
-        'timestamp': _lastAuthRecheckInconclusiveAt!.toIso8601String(),
-        'level': 'info',
-        'type': 'auth',
-        'event': 'auth_inconclusive_abort_logout',
-        'message': '会话复检结果不确定，本次保持登录态并等待后续独立异常再次确认',
-        'reason': message,
-        if (source != null) 'source': source,
-        if (triggerInfo != null) 'trigger': triggerInfo,
-        'strike': strike,
-        'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
-        'memHasToken': _tToken != null && _tToken!.isNotEmpty,
-        'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
-        'jarTokenLen': jarTToken?.length,
-        'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
-        if (sentHasT != null) 'sentHasT': sentHasT,
-        if (sentTLen != null) 'sentTLen': sentTLen,
-      });
-      return;
+      if (strongEvidence && strike >= 2) {
+        LogWriter.instance.write({
+          'timestamp': DateTime.now().toIso8601String(),
+          'level': 'warning',
+          'type': 'auth',
+          'event': 'auth_inconclusive_escalated_to_logout',
+          'message': '会话复检不确定，但强失效证据重复出现，升级为执行登出',
+          'reason': message,
+          if (source != null) 'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'strike': strike,
+          'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
+          'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+          'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+          'jarTokenLen': jarTToken?.length,
+          'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+          if (sentHasT != null) 'sentHasT': sentHasT,
+          if (sentTLen != null) 'sentTLen': sentTLen,
+        });
+      } else {
+        _lastAuthRecheckInconclusiveAt = DateTime.now();
+        LogWriter.instance.write({
+          'timestamp': _lastAuthRecheckInconclusiveAt!.toIso8601String(),
+          'level': 'info',
+          'type': 'auth',
+          'event': 'auth_inconclusive_abort_logout',
+          'message': '会话复检结果不确定，本次保持登录态并等待后续独立异常再次确认',
+          'reason': message,
+          if (source != null) 'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'strike': strike,
+          'strongEvidence': strongEvidence,
+          'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
+          'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+          'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+          'jarTokenLen': jarTToken?.length,
+          'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+          if (sentHasT != null) 'sentHasT': sentHasT,
+          if (sentTLen != null) 'sentTLen': sentTLen,
+        });
+        return;
+      }
     }
 
     if (probeResult == false && strike < 2) {
@@ -599,6 +627,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
       if (triggerInfo != null) 'trigger': triggerInfo,
       'strike': strike,
       'probeResult': probeResult,
+      'strongEvidence': strongEvidence,
       'memHasToken': _tToken != null && _tToken!.isNotEmpty,
       'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
       'jarTokenLen': jarTToken?.length,

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -3,13 +3,22 @@ part of 'discourse_service.dart';
 /// 认证相关
 mixin _AuthMixin on _DiscourseServiceBase {
   static const Duration _authInvalidStrikeWindow = Duration(seconds: 45);
+  static const Duration _authInconclusiveCooldown = Duration(seconds: 30);
   int _authInvalidStrikeCount = 0;
   DateTime? _lastAuthInvalidAt;
   Future<bool?>? _authRecheckFuture;
+  DateTime? _lastAuthRecheckInconclusiveAt;
 
   void _resetAuthInvalidState() {
     _authInvalidStrikeCount = 0;
     _lastAuthInvalidAt = null;
+    _lastAuthRecheckInconclusiveAt = null;
+  }
+
+  bool _shouldSuppressAuthInvalidDuringInconclusiveCooldown() {
+    final last = _lastAuthRecheckInconclusiveAt;
+    if (last == null) return false;
+    return DateTime.now().difference(last) <= _authInconclusiveCooldown;
   }
 
   int _registerAuthInvalidStrike() {
@@ -433,6 +442,29 @@ mixin _AuthMixin on _DiscourseServiceBase {
   }) async {
     if (_isLoggingOut) return;
 
+    if (_shouldSuppressAuthInvalidDuringInconclusiveCooldown()) {
+      final jarTToken = await _cookieJar.getTToken();
+      final csrfToken = _cookieSync.csrfToken;
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'info',
+        'type': 'auth',
+        'event': 'auth_invalid_suppressed_after_inconclusive',
+        'message': '距离上次会话复检不确定结果过近，暂时抑制重复登录异常处理',
+        'reason': message,
+        if (source != null) 'source': source,
+        if (triggerInfo != null) 'trigger': triggerInfo,
+        'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
+        'memHasToken': _tToken != null && _tToken!.isNotEmpty,
+        'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
+        'jarTokenLen': jarTToken?.length,
+        'hasCsrf': csrfToken != null && csrfToken.isNotEmpty,
+        if (sentHasT != null) 'sentHasT': sentHasT,
+        if (sentTLen != null) 'sentTLen': sentTLen,
+      });
+      return;
+    }
+
     final strike = _registerAuthInvalidStrikeForEvent();
     final jarTToken = await _cookieJar.getTToken();
     final csrfToken = _cookieSync.csrfToken;
@@ -466,8 +498,9 @@ mixin _AuthMixin on _DiscourseServiceBase {
     }
 
     if (probeResult == null) {
+      _lastAuthRecheckInconclusiveAt = DateTime.now();
       LogWriter.instance.write({
-        'timestamp': DateTime.now().toIso8601String(),
+        'timestamp': _lastAuthRecheckInconclusiveAt!.toIso8601String(),
         'level': 'info',
         'type': 'auth',
         'event': 'auth_inconclusive_abort_logout',
@@ -476,6 +509,7 @@ mixin _AuthMixin on _DiscourseServiceBase {
         if (source != null) 'source': source,
         if (triggerInfo != null) 'trigger': triggerInfo,
         'strike': strike,
+        'cooldownSeconds': _authInconclusiveCooldown.inSeconds,
         'memHasToken': _tToken != null && _tToken!.isNotEmpty,
         'jarHasToken': jarTToken != null && jarTToken.isNotEmpty,
         'jarTokenLen': jarTToken?.length,

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -21,6 +21,29 @@ mixin _AuthMixin on _DiscourseServiceBase {
     return DateTime.now().difference(last) <= _authInconclusiveCooldown;
   }
 
+  void _runAuthHandlingInBackground(
+    Future<void> Function() task, {
+    required String event,
+    String? source,
+    String? triggerInfo,
+  }) {
+    unawaited(
+      task().catchError((Object error, StackTrace stackTrace) {
+        LogWriter.instance.write({
+          'timestamp': DateTime.now().toIso8601String(),
+          'level': 'warning',
+          'type': 'auth',
+          'event': event,
+          'message': '后台认证异常处理任务失败',
+          if (source != null) 'source': source,
+          if (triggerInfo != null) 'trigger': triggerInfo,
+          'error': error.toString(),
+          'stackTrace': stackTrace.toString(),
+        });
+      }),
+    );
+  }
+
   int _registerAuthInvalidStrike() {
     final now = DateTime.now();
     if (_lastAuthInvalidAt == null ||
@@ -240,13 +263,19 @@ mixin _AuthMixin on _DiscourseServiceBase {
               loggedOut != null &&
               loggedOut.isNotEmpty &&
               !_isLoggingOut) {
-            await _onDiscourseLoggedOut(
+            _runAuthHandlingInBackground(
+              () => _onDiscourseLoggedOut(
+                source: 'response_header',
+                triggerInfo:
+                    '${response.requestOptions.method} ${response.requestOptions.uri} → ${response.statusCode}',
+                requestOptions: response.requestOptions,
+                statusCode: response.statusCode,
+                responseHeaders: response.headers.map,
+              ),
+              event: 'auth_response_header_background_failed',
               source: 'response_header',
               triggerInfo:
                   '${response.requestOptions.method} ${response.requestOptions.uri} → ${response.statusCode}',
-              requestOptions: response.requestOptions,
-              statusCode: response.statusCode,
-              responseHeaders: response.headers.map,
             );
             return handler.next(response);
           }
@@ -319,13 +348,19 @@ mixin _AuthMixin on _DiscourseServiceBase {
               loggedOut != null &&
               loggedOut.isNotEmpty &&
               !_isLoggingOut) {
-            await _onDiscourseLoggedOut(
+            _runAuthHandlingInBackground(
+              () => _onDiscourseLoggedOut(
+                source: 'error_response_header',
+                triggerInfo:
+                    '${error.requestOptions.method} ${error.requestOptions.uri} → ${error.response?.statusCode}',
+                requestOptions: error.requestOptions,
+                statusCode: error.response?.statusCode,
+                responseHeaders: error.response?.headers.map,
+              ),
+              event: 'auth_error_header_background_failed',
               source: 'error_response_header',
               triggerInfo:
                   '${error.requestOptions.method} ${error.requestOptions.uri} → ${error.response?.statusCode}',
-              requestOptions: error.requestOptions,
-              statusCode: error.response?.statusCode,
-              responseHeaders: error.response?.headers.map,
             );
             return handler.next(error);
           }
@@ -350,8 +385,14 @@ mixin _AuthMixin on _DiscourseServiceBase {
             final message =
                 (data['errors'] as List?)?.first?.toString() ??
                 S.current.auth_loginExpiredRelogin;
-            await _handleAuthInvalid(
-              message,
+            _runAuthHandlingInBackground(
+              () => _handleAuthInvalid(
+                message,
+                source: 'error_response_body',
+                triggerInfo:
+                    '${error.requestOptions.method} ${error.requestOptions.uri} → ${error.response?.statusCode}, error_type=${data['error_type']}',
+              ),
+              event: 'auth_error_body_background_failed',
               source: 'error_response_body',
               triggerInfo:
                   '${error.requestOptions.method} ${error.requestOptions.uri} → ${error.response?.statusCode}, error_type=${data['error_type']}',

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -91,6 +91,10 @@ mixin _AuthMixin on _DiscourseServiceBase {
     required String source,
     String? triggerInfo,
   }) async {
+    final previousStrikeCount = _authInvalidStrikeCount;
+    final previousAuthInvalidAt = _lastAuthInvalidAt;
+    final previousInconclusiveAt = _lastAuthRecheckInconclusiveAt;
+
     try {
       try {
         await BoundarySyncService.instance.syncFromWebView(
@@ -111,9 +115,6 @@ mixin _AuthMixin on _DiscourseServiceBase {
 
       final tTokenBeforeProbe = await _cookieJar.getTToken();
       final cfClearanceBeforeProbe = await _cookieJar.getCfClearance();
-      final previousStrikeCount = _authInvalidStrikeCount;
-      final previousAuthInvalidAt = _lastAuthInvalidAt;
-      final previousInconclusiveAt = _lastAuthRecheckInconclusiveAt;
 
       final response = await _dio.get(
         '/session/current.json',

--- a/lib/services/discourse/_auth.dart
+++ b/lib/services/discourse/_auth.dart
@@ -97,8 +97,10 @@ mixin _AuthMixin on _DiscourseServiceBase {
 
     try {
       try {
+        // 复检时只同步 cf_clearance，不再把 WebView 中的 _t/_forum_session
+        // 回灌到 CookieJar；否则 mixed-signal / 半失效态下，可能把坏会话再次写回。
         await BoundarySyncService.instance.syncFromWebView(
-          cookieNames: {'_t', '_forum_session', 'cf_clearance'},
+          cookieNames: {'cf_clearance'},
         );
       } catch (e) {
         LogWriter.instance.write({

--- a/lib/services/discourse/_users.dart
+++ b/lib/services/discourse/_users.dart
@@ -74,12 +74,18 @@ mixin _UsersMixin on _DiscourseServiceBase {
   /// 获取当前用户信息
   /// 网络错误时会抛出异常，由调用方决定如何处理
   Future<User?> getCurrentUser() async {
+    final cached = currentUserNotifier.value;
     final username = await getUsername();
-    if (username == null) return null;
+    if (username == null) return cached;
 
-    final user = await getUser(username);
-    currentUserNotifier.value = user;
-    return user;
+    try {
+      final user = await getUser(username);
+      currentUserNotifier.value = user;
+      return user;
+    } catch (e) {
+      debugPrint('[DiscourseService] getCurrentUser failed, keep cached user: $e');
+      return cached;
+    }
   }
 
   /// 获取用户统计数据（带缓存，按用户名区分）

--- a/lib/services/discourse/discourse_service.dart
+++ b/lib/services/discourse/discourse_service.dart
@@ -21,6 +21,7 @@ import '../../constants.dart';
 import '../../providers/message_bus_providers.dart';
 import '../auth_session.dart';
 import '../cf_clearance_refresh_service.dart';
+import '../network/cookie/boundary_sync_service.dart';
 import '../network/cookie/csrf_token_service.dart';
 import '../network/cookie/cookie_jar_service.dart';
 import '../cf_challenge_service.dart';

--- a/lib/services/network/cookie/android_cdp_feature.dart
+++ b/lib/services/network/cookie/android_cdp_feature.dart
@@ -8,27 +8,36 @@ class AndroidCdpFeature {
   AndroidCdpFeature._();
 
   static const String prefKey = 'pref_android_native_cdp';
+  static const bool _forceDisabled = true;
   static bool _enabled = false;
   static bool _initialized = false;
 
-  static bool get isEnabled => Platform.isAndroid && _enabled;
+  static bool get isEnabled =>
+      Platform.isAndroid && !_forceDisabled && _enabled;
 
   static Future<void> initialize(SharedPreferences prefs) async {
-    _enabled = prefs.getBool(prefKey) ?? false;
+    _enabled = _forceDisabled ? false : (prefs.getBool(prefKey) ?? false);
+    if (_forceDisabled && prefs.getBool(prefKey) != false) {
+      await prefs.setBool(prefKey, false);
+    }
     _initialized = true;
     AppLogger.info(
-      'Android native CDP ${_enabled ? 'enabled' : 'disabled'}',
+      _forceDisabled
+          ? 'Android native CDP force disabled'
+          : 'Android native CDP ${_enabled ? 'enabled' : 'disabled'}',
       tag: 'AndroidCdp',
     );
   }
 
   static Future<void> setEnabled(bool enabled) async {
-    _enabled = enabled;
+    _enabled = _forceDisabled ? false : enabled;
     _initialized = true;
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(prefKey, enabled);
+    await prefs.setBool(prefKey, _enabled);
     AppLogger.warning(
-      'Android native CDP switched ${enabled ? 'on' : 'off'}',
+      _forceDisabled
+          ? 'Android native CDP force disabled'
+          : 'Android native CDP switched ${enabled ? 'on' : 'off'}',
       tag: 'AndroidCdp',
     );
   }

--- a/lib/services/network/cookie/app_cookie_manager.dart
+++ b/lib/services/network/cookie/app_cookie_manager.dart
@@ -355,6 +355,10 @@ class AppCookieManager extends Interceptor {
         (response.statusCode != null && response.statusCode! < 400) &&
         !hasNotLoggedInError &&
         !hasAnonymousSessionPayload;
+    final shouldBlockSessionSet =
+        hasLoggedOutHeader &&
+        !hasNotLoggedInError &&
+        !hasAnonymousSessionPayload;
     final shouldTrustSessionDeletion =
         hasNotLoggedInError ||
         hasAnonymousSessionPayload ||
@@ -372,17 +376,17 @@ class AppCookieManager extends Interceptor {
             cookie.value == 'del' || cookie.value.isEmpty || isExpired;
         final uri = response.requestOptions.uri;
         final allowDeletion = isDeletion && shouldTrustSessionDeletion;
-        final shouldBlockSessionSet = !isDeletion && ambiguousLoggedOutOnSuccess;
+        final blockThisSessionSet = !isDeletion && shouldBlockSessionSet;
         debugPrint('[CookieManager] ${cookie.name} '
-            '${shouldBlockSessionSet ? "SET(blocked)" : (!isDeletion ? "SET" : (allowDeletion ? "DEL(accepted)" : "DEL(blocked)"))} '
+            '${blockThisSessionSet ? "SET(blocked)" : (!isDeletion ? "SET" : (allowDeletion ? "DEL(accepted)" : "DEL(blocked)"))} '
             'from ${response.requestOptions.method} ${uri.host}${uri.path} '
             '(status=${response.statusCode}, len=${cookie.value.length}, '
             'domain=${cookie.domain}, hasLoggedIn=${response.requestOptions.headers['Discourse-Logged-In']})');
         LogWriter.instance.write({
           'timestamp': DateTime.now().toIso8601String(),
-          'level': (isDeletion || shouldBlockSessionSet) ? 'warning' : 'info',
+          'level': (isDeletion || blockThisSessionSet) ? 'warning' : 'info',
           'type': 'cookie_change',
-          'event': shouldBlockSessionSet
+          'event': blockThisSessionSet
               ? 'token_cookie_update_blocked_ambiguous_success'
               : (!isDeletion
                     ? 'token_cookie_updated'
@@ -391,7 +395,7 @@ class AppCookieManager extends Interceptor {
                           : (ambiguousLoggedOutOnSuccess
                                 ? 'token_cookie_delete_blocked_ambiguous_success'
                                 : 'token_cookie_delete_blocked'))),
-          'message': shouldBlockSessionSet
+          'message': blockThisSessionSet
               ? '${cookie.name} 更新被拦截（2xx 响应中的 mixed auth signal）'
               : (!isDeletion
                     ? '${cookie.name} cookie 被更新'
@@ -414,7 +418,7 @@ class AppCookieManager extends Interceptor {
           'isStrictAuthEndpoint': isStrictAuthEndpoint,
           'ambiguousLoggedOutOnSuccess': ambiguousLoggedOutOnSuccess,
         });
-        if ((isDeletion && !allowDeletion) || shouldBlockSessionSet) {
+        if ((isDeletion && !allowDeletion) || blockThisSessionSet) {
           continue;
         }
       }

--- a/lib/services/network/cookie/app_cookie_manager.dart
+++ b/lib/services/network/cookie/app_cookie_manager.dart
@@ -323,12 +323,15 @@ class AppCookieManager extends Interceptor {
         .map((str) => Cookie.fromSetCookieValue(str))
         .toList();
 
-    // 会话 cookie 删除指令不能再一刀切拦截。
-    // 旧逻辑会把服务端已经明确撤销会话的证据挡在外面，造成客户端“假在线”：
-    // 首页等公开页还能 200，但私有接口已 403，本地 UI 仍显示已登录。
-    // 现在改为：
-    // - 证据不足时：仍可暂时拦截删除，避免偶发抖动导致误退
-    // - 证据足够强时：允许删除真正落库，让客户端承认会话已经失效
+    // 会话 cookie 删除指令仍需非常保守。
+    // 实测里服务端会在 200 响应的公开/半公开接口上带 discourse-logged-out，
+    // 甚至同时返回可渲染数据；如果此时直接接受 _t 删除，会把“混合信号”放大成
+    // 真掉线，造成频繁退出，甚至出现“页面还在、真实会话已被本地删掉”的假状态。
+    // 因此这里只信任以下强证据：
+    // - 响应体明确 error_type=not_logged_in
+    // - /session/current 明确返回 current_user=null
+    // - 明确需要登录的接口直接返回 401/403
+    // 单独的 discourse-logged-out header（尤其是 2xx 成功响应）不再直接删除会话 cookie。
     final filteredCookies = <Cookie>[];
     final filteredSetCookieHeaders = <String>[];
     final responseBody = response.data;
@@ -336,18 +339,27 @@ class AppCookieManager extends Interceptor {
         responseBody is Map && responseBody['error_type'] == 'not_logged_in';
     final hasLoggedOutHeader =
         response.headers.value('discourse-logged-out')?.isNotEmpty == true;
-    final isPrivateEndpoint =
-        requestUri.path.startsWith('/u/') ||
-        requestUri.path.startsWith('/user_actions') ||
+    final hasAnonymousSessionPayload =
+        responseBody is Map &&
+        responseBody.containsKey('current_user') &&
+        responseBody['current_user'] == null;
+    final isStrictAuthEndpoint =
         requestUri.path.startsWith('/presence/') ||
         requestUri.path.startsWith('/topics/timings') ||
         requestUri.path.startsWith('/notifications') ||
+        requestUri.path.startsWith('/bookmarks') ||
+        requestUri.path.startsWith('/drafts') ||
         requestUri.path.startsWith('/session/current');
+    final ambiguousLoggedOutOnSuccess =
+        hasLoggedOutHeader &&
+        (response.statusCode != null && response.statusCode! < 400) &&
+        !hasNotLoggedInError &&
+        !hasAnonymousSessionPayload;
     final shouldTrustSessionDeletion =
-        hasLoggedOutHeader ||
         hasNotLoggedInError ||
+        hasAnonymousSessionPayload ||
         ((response.statusCode == 401 || response.statusCode == 403) &&
-            isPrivateEndpoint);
+            isStrictAuthEndpoint);
 
     for (var i = 0; i < cookies.length; i++) {
       final cookie = cookies[i];
@@ -373,12 +385,16 @@ class AppCookieManager extends Interceptor {
               ? 'token_cookie_updated'
               : (allowDeletion
                     ? 'token_cookie_delete_accepted'
-                    : 'token_cookie_delete_blocked'),
+                    : (ambiguousLoggedOutOnSuccess
+                          ? 'token_cookie_delete_blocked_ambiguous_success'
+                          : 'token_cookie_delete_blocked')),
           'message': !isDeletion
               ? '${cookie.name} cookie 被更新'
               : (allowDeletion
                     ? '${cookie.name} 删除已接受（服务端会话失效证据充分）'
-                    : '${cookie.name} 删除被拦截'),
+                    : (ambiguousLoggedOutOnSuccess
+                          ? '${cookie.name} 删除被拦截（2xx 响应中的 mixed auth signal）'
+                          : '${cookie.name} 删除被拦截')),
           'valueLength': cookie.value.length,
           'isExpired': isExpired,
           'method': response.requestOptions.method,
@@ -389,7 +405,9 @@ class AppCookieManager extends Interceptor {
           'hasLoggedInHeader': response.requestOptions.headers['Discourse-Logged-In'] == 'true',
           'hasLoggedOutHeader': hasLoggedOutHeader,
           'hasNotLoggedInError': hasNotLoggedInError,
-          'isPrivateEndpoint': isPrivateEndpoint,
+          'hasAnonymousSessionPayload': hasAnonymousSessionPayload,
+          'isStrictAuthEndpoint': isStrictAuthEndpoint,
+          'ambiguousLoggedOutOnSuccess': ambiguousLoggedOutOnSuccess,
         });
         if (isDeletion && !allowDeletion) {
           continue;

--- a/lib/services/network/cookie/app_cookie_manager.dart
+++ b/lib/services/network/cookie/app_cookie_manager.dart
@@ -372,29 +372,34 @@ class AppCookieManager extends Interceptor {
             cookie.value == 'del' || cookie.value.isEmpty || isExpired;
         final uri = response.requestOptions.uri;
         final allowDeletion = isDeletion && shouldTrustSessionDeletion;
+        final shouldBlockSessionSet = !isDeletion && ambiguousLoggedOutOnSuccess;
         debugPrint('[CookieManager] ${cookie.name} '
-            '${!isDeletion ? "SET" : (allowDeletion ? "DEL(accepted)" : "DEL(blocked)")} '
+            '${shouldBlockSessionSet ? "SET(blocked)" : (!isDeletion ? "SET" : (allowDeletion ? "DEL(accepted)" : "DEL(blocked)"))} '
             'from ${response.requestOptions.method} ${uri.host}${uri.path} '
             '(status=${response.statusCode}, len=${cookie.value.length}, '
             'domain=${cookie.domain}, hasLoggedIn=${response.requestOptions.headers['Discourse-Logged-In']})');
         LogWriter.instance.write({
           'timestamp': DateTime.now().toIso8601String(),
-          'level': isDeletion ? 'warning' : 'info',
+          'level': (isDeletion || shouldBlockSessionSet) ? 'warning' : 'info',
           'type': 'cookie_change',
-          'event': !isDeletion
-              ? 'token_cookie_updated'
-              : (allowDeletion
-                    ? 'token_cookie_delete_accepted'
-                    : (ambiguousLoggedOutOnSuccess
-                          ? 'token_cookie_delete_blocked_ambiguous_success'
-                          : 'token_cookie_delete_blocked')),
-          'message': !isDeletion
-              ? '${cookie.name} cookie 被更新'
-              : (allowDeletion
-                    ? '${cookie.name} 删除已接受（服务端会话失效证据充分）'
-                    : (ambiguousLoggedOutOnSuccess
-                          ? '${cookie.name} 删除被拦截（2xx 响应中的 mixed auth signal）'
-                          : '${cookie.name} 删除被拦截')),
+          'event': shouldBlockSessionSet
+              ? 'token_cookie_update_blocked_ambiguous_success'
+              : (!isDeletion
+                    ? 'token_cookie_updated'
+                    : (allowDeletion
+                          ? 'token_cookie_delete_accepted'
+                          : (ambiguousLoggedOutOnSuccess
+                                ? 'token_cookie_delete_blocked_ambiguous_success'
+                                : 'token_cookie_delete_blocked'))),
+          'message': shouldBlockSessionSet
+              ? '${cookie.name} 更新被拦截（2xx 响应中的 mixed auth signal）'
+              : (!isDeletion
+                    ? '${cookie.name} cookie 被更新'
+                    : (allowDeletion
+                          ? '${cookie.name} 删除已接受（服务端会话失效证据充分）'
+                          : (ambiguousLoggedOutOnSuccess
+                                ? '${cookie.name} 删除被拦截（2xx 响应中的 mixed auth signal）'
+                                : '${cookie.name} 删除被拦截'))),
           'valueLength': cookie.value.length,
           'isExpired': isExpired,
           'method': response.requestOptions.method,
@@ -409,7 +414,7 @@ class AppCookieManager extends Interceptor {
           'isStrictAuthEndpoint': isStrictAuthEndpoint,
           'ambiguousLoggedOutOnSuccess': ambiguousLoggedOutOnSuccess,
         });
-        if (isDeletion && !allowDeletion) {
+        if ((isDeletion && !allowDeletion) || shouldBlockSessionSet) {
           continue;
         }
       }

--- a/lib/services/network/cookie/app_cookie_manager.dart
+++ b/lib/services/network/cookie/app_cookie_manager.dart
@@ -323,22 +323,45 @@ class AppCookieManager extends Interceptor {
         .map((str) => Cookie.fromSetCookieValue(str))
         .toList();
 
-    // 拦截服务端对关键 cookie 的删除指令。
-    // 服务端可能在 200 响应中通过 Set-Cookie 删除 _t（设置为过期/空值），
-    // 如果无条件写入 CookieJar，会导致验证机制还没判断完 _t 就已经丢了。
-    // 只过滤「删除」操作，正常的「更新」（有值且未过期）仍然放行。
+    // 会话 cookie 删除指令不能再一刀切拦截。
+    // 旧逻辑会把服务端已经明确撤销会话的证据挡在外面，造成客户端“假在线”：
+    // 首页等公开页还能 200，但私有接口已 403，本地 UI 仍显示已登录。
+    // 现在改为：
+    // - 证据不足时：仍可暂时拦截删除，避免偶发抖动导致误退
+    // - 证据足够强时：允许删除真正落库，让客户端承认会话已经失效
     final filteredCookies = <Cookie>[];
     final filteredSetCookieHeaders = <String>[];
+    final responseBody = response.data;
+    final hasNotLoggedInError =
+        responseBody is Map && responseBody['error_type'] == 'not_logged_in';
+    final hasLoggedOutHeader =
+        response.headers.value('discourse-logged-out')?.isNotEmpty == true;
+    final isPrivateEndpoint =
+        requestUri.path.startsWith('/u/') ||
+        requestUri.path.startsWith('/user_actions') ||
+        requestUri.path.startsWith('/presence/') ||
+        requestUri.path.startsWith('/topics/timings') ||
+        requestUri.path.startsWith('/notifications') ||
+        requestUri.path.startsWith('/session/current');
+    final shouldTrustSessionDeletion =
+        hasLoggedOutHeader ||
+        hasNotLoggedInError ||
+        ((response.statusCode == 401 || response.statusCode == 403) &&
+            isPrivateEndpoint);
+
     for (var i = 0; i < cookies.length; i++) {
       final cookie = cookies[i];
-      final isSessionCookie = cookie.name == '_t' || cookie.name == '_forum_session';
+      final isSessionCookie =
+          cookie.name == '_t' || cookie.name == '_forum_session';
       if (isSessionCookie) {
         final isExpired = cookie.expires != null &&
             cookie.expires!.isBefore(DateTime.now());
         final isDeletion =
             cookie.value == 'del' || cookie.value.isEmpty || isExpired;
         final uri = response.requestOptions.uri;
-        debugPrint('[CookieManager] _t ${isDeletion ? "DEL(blocked)" : "SET"} '
+        final allowDeletion = isDeletion && shouldTrustSessionDeletion;
+        debugPrint('[CookieManager] ${cookie.name} '
+            '${!isDeletion ? "SET" : (allowDeletion ? "DEL(accepted)" : "DEL(blocked)")} '
             'from ${response.requestOptions.method} ${uri.host}${uri.path} '
             '(status=${response.statusCode}, len=${cookie.value.length}, '
             'domain=${cookie.domain}, hasLoggedIn=${response.requestOptions.headers['Discourse-Logged-In']})');
@@ -346,8 +369,16 @@ class AppCookieManager extends Interceptor {
           'timestamp': DateTime.now().toIso8601String(),
           'level': isDeletion ? 'warning' : 'info',
           'type': 'cookie_change',
-          'event': isDeletion ? 'token_cookie_delete_blocked' : 'token_cookie_updated',
-          'message': isDeletion ? '${cookie.name} 删除被拦截' : '${cookie.name} cookie 被更新',
+          'event': !isDeletion
+              ? 'token_cookie_updated'
+              : (allowDeletion
+                    ? 'token_cookie_delete_accepted'
+                    : 'token_cookie_delete_blocked'),
+          'message': !isDeletion
+              ? '${cookie.name} cookie 被更新'
+              : (allowDeletion
+                    ? '${cookie.name} 删除已接受（服务端会话失效证据充分）'
+                    : '${cookie.name} 删除被拦截'),
           'valueLength': cookie.value.length,
           'isExpired': isExpired,
           'method': response.requestOptions.method,
@@ -356,9 +387,11 @@ class AppCookieManager extends Interceptor {
           'statusCode': response.statusCode,
           'cookieDomain': cookie.domain,
           'hasLoggedInHeader': response.requestOptions.headers['Discourse-Logged-In'] == 'true',
+          'hasLoggedOutHeader': hasLoggedOutHeader,
+          'hasNotLoggedInError': hasNotLoggedInError,
+          'isPrivateEndpoint': isPrivateEndpoint,
         });
-        if (isDeletion) {
-          // 不写入 CookieJar，由业务层（_handleAuthInvalid）决定是否真正清除
+        if (isDeletion && !allowDeletion) {
           continue;
         }
       }

--- a/lib/services/preloaded_data_service.dart
+++ b/lib/services/preloaded_data_service.dart
@@ -375,7 +375,9 @@ class PreloadedDataService {
     }
 
     _loaded = true;
-    CfClearanceRefreshService().start();
+    if (_currentUser != null) {
+      CfClearanceRefreshService().start();
+    }
     debugPrint('[PreloadedData] 已从 HTML 快照恢复数据');
     return true;
   }
@@ -444,8 +446,10 @@ class PreloadedDataService {
       await _parsePreloadedDataFromHtml(html);
       debugPrint('[PreloadedData] 数据加载成功');
       _loaded = true;
-      // 预热完成，sitekey 已提取，启动 cf_clearance 自动续期
-      CfClearanceRefreshService().start();
+      // 仅在预加载里已确认 current_user 存在时才启动自动续期，避免启动抖动期放大鉴权误判。
+      if (_currentUser != null) {
+        CfClearanceRefreshService().start();
+      }
     } catch (e) {
       debugPrint('[PreloadedData] 加载失败: $e');
       rethrow;

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -45,16 +45,6 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
           onChanged: (ref, v) =>
               ref.read(preferencesProvider.notifier).setCfClearanceRefresh(v),
         ),
-        if (Platform.isAndroid)
-          SwitchModel(
-            id: 'androidNativeCdp',
-            title: l10n.preferences_androidNativeCdp,
-            subtitle: l10n.preferences_androidNativeCdpDesc,
-            icon: Icons.developer_board_rounded,
-            getValue: (ref) => ref.watch(preferencesProvider).androidNativeCdp,
-            onChanged: (ref, v) =>
-                ref.read(preferencesProvider.notifier).setAndroidNativeCdp(v),
-          ),
         PlatformConditionalModel(
           inner: SwitchModel(
             id: 'portraitLock',


### PR DESCRIPTION
## 变更说明

这个 PR 主要针对 Android 上短时鉴权/会话抖动导致的误掉登录问题，重点是让被动登出（passive logout）的处理更保守，在真正清理会话前增加确认流程，减少误判。

我这边实际遇到的现象是：

- 客户端有时会因为单次 `not_logged_in` / `discourse-logged-out` / Cookie 短暂不同步
很快进入被动登出流程
- 但从实际表现看，WebView 中的 Cookie、会话状态当时并不一定真正失效
- 最终表现就是“客户端先把自己登出了”，需要重新登录

这个 PR 的目标不是重构整套鉴权系统，而是在现有逻辑上做保守修正，尽量避免短时异常被直接放大成掉登录。

---

## 主要改动

### 1. 单次鉴权异常不再立即触发被动登出
- 增加短时间窗口内的 auth invalid strike 计数
- 第一次命中 auth invalid 时不再直接执行 passive logout
- 改为先进入会话复检流程
- 只有连续异常或复检确认失效后，才真正执行被动登出

### 2. 被动登出前先复检 `/session/current.json`
- 检测到登录失效信号后，先请求 `/session/current.json`
- 如果 `current_user` 仍然存在，则保留当前会话
- 只有在重复异常或复检明确失败后，才继续走登出流程

### 3. 会话复检前先同步 WebView -> CookieJar 的关键 Cookie
在执行 `/session/current.json` 复检前，先同步以下关键 Cookie：
- `_t`
- `_forum_session`
- `cf_clearance`

这样可以缓解 Android 上 WebView Cookie 实际仍有效，但 app 侧 CookieJar 短暂落后的情况。

### 4. `_t` 短暂缺失时不再立即清空内存 token
- 之前在某些响应后，如果 CookieJar 里短暂没有读到 `_t`，会更激进地清空内存 token
- 现在改成只记录 warning，不立刻清空内存 token

### 5. current user / cache 在短时抖动时优先保留
- `getCurrentUser()` 短暂失败时，优先保留已有 `currentUserNotifier`
- auth 瞬时返回 null 时，不立即清除 current user cache
- 避免 UI 过快误判成“已经掉登录”

### 6. `cf_clearance` 自动续期启动条件更保守
- 预加载阶段不再无条件启动 `cf_clearance` 自动续期
- 改为仅在 `_currentUser != null` 时才启动
- 这样可以避免启动抖动期放大鉴权误判

### 7. 增加 Android 测试 APK workflow
本 PR 一并加入了一个测试用 GitHub Actions workflow：

- `.github/workflows/android-ci-test.yaml`

用途是：
- 直接生成 Android arm64 测试 APK
- 方便在真实 Android 设备上快速验证鉴权/会话稳定性
- 降低此类问题的真机验证成本

这个 workflow 使用临时 CI 签名，定位是测试验证流程，不是正式发布流程。

---

## 变更原因

我在 Android 上实际观察到的问题更像是：

1. WebView 中的 Cookie 和会话有时仍然有效
2. 但 app 侧某一瞬间会读到短时异常状态
3. 客户端随后较快清掉 session / current user / token
4. 最终表现为“掉登录”

也就是说，这里很多时候更像是：
- 短时抖动
- Cookie 同步时序问题
- 启动阶段状态恢复不一致

而不一定是真正的 session 已经完全失效。

因此这次改动的核心思路是：
> 在真正执行 passive logout 前，增加更保守的确认流程。

---

## 涉及文件

本次改动主要涉及以下文件：

- `lib/services/discourse/_auth.dart`
- `lib/services/discourse/discourse_service.dart`
- `lib/services/discourse/_users.dart`
- `lib/providers/core_providers.dart`
- `lib/services/preloaded_data_service.dart`
- `.github/workflows/android-ci-test.yaml`

---

## 测试情况

测试环境：
- Android
- 基于分支 `fix/conservative-auth-invalidation` 构建测试 APK

实测结果：
- 持续测试了一上午
- 截至目前**没有复现掉登录**
- `cf_clearance` 自动续期测试正常
- `WebView Cookie 同步` 测试正常
- 日常浏览、切换页面、继续使用过程中，登录态相比之前明显更稳定

实际体感上：
- 之前更像“短时异常就被立即踢下线”
- 现在更像“短时异常会先尝试恢复，不会立刻误登出”

---

## 影响范围

这次改动主要集中在：
- passive logout 判定
- session recheck
- WebView / CookieJar 同步前置
- current user / cache 保留策略
- Android 测试验证流程

没有重做整套登录架构，整体仍然是在现有逻辑上进行保守修正。

---

## 提交目的

本次提交是一次性提交完整改动，包含：
- 问题缓解逻辑
- 状态保留逻辑
- Cookie 同步前置
- 启动阶段保守处理
- Android 测试 APK workflow

这样可以让这组问题和验证链路一起被完整评估，而不是拆成多个上下文分散的改动。
