### PR TITLE
🐛 修复 macOS 下 per-device CA 未启用导致 WKWebView 证书验证失败

### DIFF
--- a/lib/services/network/doh_proxy/cert_preference_service.dart
+++ b/lib/services/network/doh_proxy/cert_preference_service.dart
@@ -21,16 +21,16 @@ class CertPreferenceService {
 
   /// 是否使用 per-device CA
   ///
-  /// iOS 强制返回 true，其他平台读取用户偏好
+  /// iOS/macOS 强制返回 true（平台要求），其他平台读取用户偏好
   static Future<bool> usePerDevice() async {
-    if (Platform.isIOS) return true;
+    if (isPerDeviceRequired) return true;
     final prefs = await SharedPreferences.getInstance();
     return prefs.getBool(_usePerDeviceKey) ?? false;
   }
 
-  /// 设置是否使用 per-device CA（仅对非 iOS 平台生效）
+  /// 设置是否使用 per-device CA（仅对非 iOS/macOS 平台生效）
   static Future<void> setUsePerDevice(bool value) async {
-    if (Platform.isIOS) return;
+    if (isPerDeviceRequired) return;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_usePerDeviceKey, value);
   }


### PR DESCRIPTION
# 🐛 修复 macOS 上 per-device CA 未启用导致 WKWebView 证书验证失败

## 背景

macOS（尤其 26 Tahoe）上启用 DOH 代理后，WKWebView 与其他基于 CFNetwork 的组件对 HTTPS 请求一律报：

> The certificate for this server is invalid. You might be connecting to a server that is pretending to be "linux.do" which could put your confidential information at risk.

该问题在 iOS / Windows 上不存在。

## 根因

`CertPreferenceService.usePerDevice()` 仅对 `Platform.isIOS` 强制返回 `true`，而 macOS 走默认 SharedPreferences（默认为 `false`）。

于是 `NetworkSettingsService._start()` 里这段逻辑在 macOS 永远走 else 分支：

```dart
if (await CertPreferenceService.usePerDevice()) {
  final certService = PerDeviceCertService.instance;
  if (certService.isLoaded || await certService.ensureCaCert()) {
    caCertPem = certService.certPem;
    caKeyPem = certService.keyPem;
  }
}
```

结果：
1. `ca_cert_pem` / `ca_key_pem` 没有传给 Rust 代理；
2. Rust 端 `DohProxyServer::new()` 回退到 `CertManager::new()`，使用编译时 embedded CA；
3. 同时 `ProxyCertificate.ensureKeychainTrust()` 会调用 `PerDeviceCertService.ensureCaCert()` 生成并信任**运行时** per-device CA；
4. WebView 收到的叶子证书 AKI 指向 **embedded CA 的 SKI**，钥匙串里信任的却是 **per-device CA 的 SKI** → `SecTrust` 报 `MissingIntermediate` → WKWebView 拒绝。

这与同一文件里注释声明的意图（"macOS: WKWebView CONNECT 代理需要系统钥匙串信任，per-device CA 避免每次更新都要重新信任"）以及 `isPerDeviceRequired = Platform.isIOS || Platform.isMacOS` 的声明自相矛盾。

## 修复

让 `usePerDevice()` / `setUsePerDevice()` 都走 `isPerDeviceRequired` 而非硬编码的 `Platform.isIOS`，保持与同文件 `isPerDeviceRequired` 的定义一致。

## 验证

1. macOS 26.4.1，删除 SharedPreferences 中 `cert_use_per_device` 键（模拟全新用户）
2. 启动 app 开启 DOH 代理访问 linux.do
3. 修复前：证书错误 / 加载失败
4. 修复后：正常加载；`openssl s_client` 抓取的证书链 `Authority Key Identifier` 与磁盘 `Application Support/com.github.lingyan000.fluxdo/certs/ca.crt` 的 `Subject Key Identifier` 一致

## 配套依赖

需要搭配 `fluxdo_doh` 仓库的叶子证书合规性修复（398 天有效期 + AKI 扩展）才能在 macOS 26 上彻底解决；单独合入本补丁仍会因叶子证书有效期不合规被 CFNetwork 拒绝。

## 变更范围

仅 `lib/services/network/doh_proxy/cert_preference_service.dart`，2 处条件表达式变更，不引入新 API，不影响 Windows / Linux / Android / iOS 行为。

---

**配套 PR**：https://github.com/Lingyan000/fluxdo_doh/pull/2（叶子证书 398 天 + AKI 扩展），两个 PR 需一起合入才能彻底修复 macOS 26 Tahoe 上的证书错误。