### PR TITLE
禁用 iOS MessageBus 实时轮询以缓解发热

### DIFF
--- a/lib/services/message_bus_service.dart
+++ b/lib/services/message_bus_service.dart
@@ -31,6 +31,9 @@ class MessageBusMessage {
 /// MessageBus 频道订阅
 typedef MessageBusCallback = void Function(MessageBusMessage message);
 
+bool get _disableRealtimeOnIOS =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS;
+
 class _ChannelSubscription {
   final String channel;
   int lastMessageId;
@@ -142,6 +145,11 @@ class MessageBusService {
 
   /// 订阅频道
   void subscribe(String channel, MessageBusCallback callback, {int lastMessageId = -1}) {
+    if (_disableRealtimeOnIOS) {
+      debugPrint('[MessageBus] iOS realtime disabled, skip $channel');
+      return;
+    }
+
     if (!_subscriptions.containsKey(channel)) {
       _subscriptions[channel] = _ChannelSubscription(
         channel: channel,
@@ -180,6 +188,11 @@ class MessageBusService {
 
   /// 使用指定的 messageId 订阅
   void subscribeWithMessageId(String channel, MessageBusCallback callback, int messageId) {
+    if (_disableRealtimeOnIOS) {
+      debugPrint('[MessageBus] iOS realtime disabled, skip $channel');
+      return;
+    }
+
     if (_subscriptions.containsKey(channel)) {
       _subscriptions[channel]!.callbacks.add(callback);
       if (messageId > _subscriptions[channel]!.lastMessageId) {

--- a/test/services/message_bus_service_test.dart
+++ b/test/services/message_bus_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/message_bus_service.dart';
+
+void main() {
+  setUp(() {
+    debugDefaultTargetPlatformOverride = null;
+    MessageBusService().stopAll();
+  });
+
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    MessageBusService().stopAll();
+  });
+
+  group('MessageBusService iOS realtime guard', () {
+    test('subscribe does not start polling on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final service = MessageBusService();
+
+      service.subscribe('/latest', (_) {});
+
+      expect(service.isPolling, isFalse);
+    });
+
+    test('subscribeWithMessageId does not start polling on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      final service = MessageBusService();
+
+      service.subscribeWithMessageId('/notification/1', (_) {}, 42);
+
+      expect(service.isPolling, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 背景

iOS 端登录后会启动 MessageBus 实时订阅。当前实现只要存在任意订阅，就会持续对 `/message-bus/{clientId}/poll` 发起长轮询；在 iPhone 实机上该路径容易导致明显发热。

本 PR 先采用最保守的客户端降温策略：在 iOS 上从 `MessageBusService` 订阅入口直接跳过实时订阅，避免其他 provider 重新打开长轮询。普通 HTTP 请求、手动刷新、看帖和回复不受影响。

## 改动

- 在 `MessageBusService.subscribe()` 和 `subscribeWithMessageId()` 入口增加 iOS 保护。
- 增加单测，确认 iOS 下调用订阅不会启动轮询。

## 影响

此改动会在 iOS 上停用 MessageBus 实时能力，包括：

- 通知/提醒实时推送
- 首页 `/latest`、`/new` 实时更新
- 帖内新回复、reactions 实时更新
- presence / 正在输入状态

这些能力仍可通过普通页面刷新或重新进入页面获取最新状态。Android、桌面和 Web 不受影响。

## 验证

- 已执行 `git diff --cached --check`，无空白错误。
- 本地环境未安装 Flutter/Dart SDK，未能在本机运行 `flutter test`。新增测试将在 CI 环境中验证。

## 后续

更完整的长期方案可以考虑把离屏通知迁移到 APNs，并仅在当前前台页面按需启用 MessageBus。这个 PR 先解决 iOS 实机发热的高优先级问题。