### PR TITLE
Refine desktop layout and rail nav grouping / 优化桌面布局与侧边栏导航分组

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1009,6 +1009,14 @@ class _MainPageState extends ConsumerState<MainPage>
         ),
     ];
 
+    // 通知入口在桌面侧栏可能出现两处：
+    // 1) 用户把 notifications 加入底栏布局，作为 NavEntry 渲染
+    // 2) railBottomLeading 默认提供的 NotificationIconButton
+    // 已在底栏配置时不再额外渲染，避免重复。
+    final hasNotificationEntry = entries.any(
+      (e) => e.id == NavEntryIds.notifications,
+    );
+
     // 首页的 FAB 由 TopicsScreen 内部处理，避免切换时闪烁
     Widget page = PopScope(
       canPop: false,
@@ -1031,7 +1039,9 @@ class _MainPageState extends ConsumerState<MainPage>
         selectedIndex: selectedBottomIndex,
         onDestinationSelected: _onDestinationSelected,
         destinations: destinations,
-        railBottomLeading: user != null ? const NotificationIconButton() : null,
+        railBottomLeading: (user != null && !hasNotificationEntry)
+            ? const NotificationIconButton()
+            : null,
         body: IndexedStack(
           index: safePageIndex,
           children: [

--- a/lib/widgets/layout/adaptive_navigation.dart
+++ b/lib/widgets/layout/adaptive_navigation.dart
@@ -68,7 +68,10 @@ class AdaptiveNavigationRail extends StatelessWidget {
     final safeBottomCount = bottomDestinationCount.clamp(0, remainingAfterTop);
     final bottomStartIndex = destinations.length - safeBottomCount;
     final topDestinations = destinations.sublist(0, safeTopCount);
-    final middleDestinations = destinations.sublist(
+    // 既不在 top 也不在 bottom 的剩余项，渲染在 categoryShortcuts 下方、
+    // bottomDestinations 上方（视觉上仍归属"底部分组"，只是排在底部分组之前）。
+    // 当 topCount + bottomCount == destinations.length 时为空。
+    final extraBottomDestinations = destinations.sublist(
       safeTopCount,
       bottomStartIndex,
     );
@@ -114,7 +117,7 @@ class AdaptiveNavigationRail extends StatelessWidget {
               bottomLeading!,
               const SizedBox(height: 8),
             ],
-            ...middleDestinations.asMap().entries.map((entry) {
+            ...extraBottomDestinations.asMap().entries.map((entry) {
               final index = entry.key + safeTopCount;
               final dest = entry.value;
               final selected = index == selectedIndex;

--- a/lib/widgets/layout/adaptive_navigation.dart
+++ b/lib/widgets/layout/adaptive_navigation.dart
@@ -37,6 +37,7 @@ class AdaptiveNavigationRail extends StatelessWidget {
     this.extended = false,
     this.leading,
     this.bottomLeading,
+    this.topDestinationCount = 0,
     this.bottomDestinationCount = 1,
   });
 
@@ -50,6 +51,9 @@ class AdaptiveNavigationRail extends StatelessWidget {
   /// 底部导航项上方的自定义组件
   final Widget? bottomLeading;
 
+  /// 固定在顶部的导航项数量（从前往后算起）
+  final int topDestinationCount;
+
   /// 固定在底部的导航项数量（从末尾算起）
   final int bottomDestinationCount;
 
@@ -59,9 +63,16 @@ class AdaptiveNavigationRail extends StatelessWidget {
     final colorScheme = theme.colorScheme;
     final isDesktop = PlatformUtils.isDesktop;
 
-    final splitIndex = destinations.length - bottomDestinationCount;
-    final topDestinations = destinations.sublist(0, splitIndex);
-    final bottomDestinations = destinations.sublist(splitIndex);
+    final safeTopCount = topDestinationCount.clamp(0, destinations.length);
+    final remainingAfterTop = destinations.length - safeTopCount;
+    final safeBottomCount = bottomDestinationCount.clamp(0, remainingAfterTop);
+    final bottomStartIndex = destinations.length - safeBottomCount;
+    final topDestinations = destinations.sublist(0, safeTopCount);
+    final middleDestinations = destinations.sublist(
+      safeTopCount,
+      bottomStartIndex,
+    );
+    final bottomDestinations = destinations.sublist(bottomStartIndex);
 
     Widget rail = SafeArea(
       child: SizedBox(
@@ -103,9 +114,28 @@ class AdaptiveNavigationRail extends StatelessWidget {
               bottomLeading!,
               const SizedBox(height: 8),
             ],
+            ...middleDestinations.asMap().entries.map((entry) {
+              final index = entry.key + safeTopCount;
+              final dest = entry.value;
+              final selected = index == selectedIndex;
+
+              return _NavigationRailItem(
+                icon: selected
+                    ? _ActiveDestinationIcon(
+                        dest: dest,
+                        defaultIcon: dest.selectedIcon,
+                      )
+                    : dest.icon,
+                label: dest.label,
+                selected: selected,
+                extended: extended,
+                colorScheme: colorScheme,
+                onTap: () => onDestinationSelected(index),
+              );
+            }),
             // 底部导航项
             ...bottomDestinations.asMap().entries.map((entry) {
-              final index = entry.key + splitIndex;
+              final index = entry.key + bottomStartIndex;
               final dest = entry.value;
               final selected = index == selectedIndex;
 
@@ -279,7 +309,8 @@ class _AdaptiveBottomNavigationState
     final id = widget.destinations[index].id;
 
     // 判定是否为双击
-    final isDouble = hasDouble &&
+    final isDouble =
+        hasDouble &&
         _lastActiveTapIndex == index &&
         _lastActiveTapTime != null &&
         now.difference(_lastActiveTapTime!) < _doubleTapWindow;
@@ -351,10 +382,7 @@ class _AdaptiveBottomNavigationState
 /// 这样用户滚到深处后就能"预览"单击会发生什么，符合 Twitter/Telegram 的交互惯例。
 /// 只应放在 NavigationBar 的 selectedIcon 位置（或侧栏 selected 状态下）。
 class _ActiveDestinationIcon extends ConsumerWidget {
-  const _ActiveDestinationIcon({
-    required this.dest,
-    required this.defaultIcon,
-  });
+  const _ActiveDestinationIcon({required this.dest, required this.defaultIcon});
 
   final AdaptiveDestination dest;
   final Widget defaultIcon;
@@ -367,16 +395,14 @@ class _ActiveDestinationIcon extends ConsumerWidget {
     );
 
     final actionIcon = action.icon;
-    final showActionIcon = progress >= navScrollIconThreshold &&
+    final showActionIcon =
+        progress >= navScrollIconThreshold &&
         action != NavTapAction.none &&
         actionIcon != null;
 
     final child = showActionIcon
         ? Icon(actionIcon, key: ValueKey('nav-action-${action.name}'))
-        : KeyedSubtree(
-            key: const ValueKey('nav-default'),
-            child: defaultIcon,
-          );
+        : KeyedSubtree(key: const ValueKey('nav-default'), child: defaultIcon);
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 220),

--- a/lib/widgets/layout/adaptive_scaffold.dart
+++ b/lib/widgets/layout/adaptive_scaffold.dart
@@ -82,6 +82,10 @@ class AdaptiveScaffold extends ConsumerWidget {
                     onDestinationSelected(index);
                   },
                   destinations: destinations,
+                  topDestinationCount: destinations.isEmpty ? 0 : 1,
+                  bottomDestinationCount: destinations.length <= 1
+                      ? 0
+                      : destinations.length - 1,
                   categoryShortcuts: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -92,7 +96,9 @@ class AdaptiveScaffold extends ConsumerWidget {
                           if (selectedIndex != 0) {
                             onDestinationSelected(0);
                           }
-                          ref.read(currentTabCategoryIdProvider.notifier).state =
+                          ref
+                                  .read(currentTabCategoryIdProvider.notifier)
+                                  .state =
                               categoryId;
                         },
                       ),

--- a/lib/widgets/layout/master_detail_layout.dart
+++ b/lib/widgets/layout/master_detail_layout.dart
@@ -11,6 +11,7 @@ import 'draggable_divider.dart';
 class MasterDetailLayout extends StatefulWidget {
   static const double defaultMasterWidth = 380;
   static const double defaultMinDetailWidth = 400;
+  static const double desktopMasterWidthRatio = 0.28;
   static const double minMasterWidth = 280;
   static const double maxMasterWidth = 520;
 
@@ -53,7 +54,9 @@ class MasterDetailLayout extends StatefulWidget {
     double minDetailWidth = defaultMinDetailWidth,
   }) {
     final screenWidth = MediaQuery.sizeOf(context).width;
-    final computed = screenWidth >= masterWidth + minDetailWidth && !Responsive.isMobile(context);
+    final computed =
+        screenWidth >= masterWidth + minDetailWidth &&
+        !Responsive.isMobile(context);
     return LayoutLock.resolveCanShowBoth(computed: computed);
   }
 
@@ -73,11 +76,32 @@ class MasterDetailLayout extends StatefulWidget {
 class _MasterDetailLayoutState extends State<MasterDetailLayout> {
   late double _currentMasterWidth;
   double? _dragStartWidth;
+  bool _hasUserResized = false;
 
   @override
   void initState() {
     super.initState();
     _currentMasterWidth = widget.masterWidth;
+  }
+
+  double _preferredMasterWidth(double totalWidth) {
+    if (_hasUserResized) return _currentMasterWidth;
+
+    final proportionalWidth =
+        totalWidth * MasterDetailLayout.desktopMasterWidthRatio;
+    return proportionalWidth.clamp(
+      widget.masterWidth,
+      MasterDetailLayout.maxMasterWidth,
+    );
+  }
+
+  double _clampMasterWidth(double width, double totalWidth) {
+    final maxAllowed = totalWidth - widget.minDetailWidth;
+    final upperBound = maxAllowed.clamp(
+      MasterDetailLayout.minMasterWidth,
+      MasterDetailLayout.maxMasterWidth,
+    );
+    return width.clamp(MasterDetailLayout.minMasterWidth, upperBound);
   }
 
   @override
@@ -89,13 +113,9 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
         final totalWidth = constraints.maxWidth;
         final showBothPanes = widget.canShowBothPanes(context);
 
-        // 根据可用宽度动态限制 master 宽度
-        final maxAllowed = totalWidth - MasterDetailLayout.defaultMinDetailWidth;
-        final clampedWidth = _currentMasterWidth.clamp(
-          MasterDetailLayout.minMasterWidth,
-          maxAllowed.clamp(MasterDetailLayout.minMasterWidth, MasterDetailLayout.maxMasterWidth),
-        );
-        final mWidth = showBothPanes ? clampedWidth : totalWidth;
+        final preferredWidth = _preferredMasterWidth(totalWidth);
+        final masterWidth = _clampMasterWidth(preferredWidth, totalWidth);
+        final mWidth = showBothPanes ? masterWidth : totalWidth;
 
         final row = Row(
           children: [
@@ -117,7 +137,10 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
             if (showBothPanes) ...[
               const VerticalDivider(width: 1, thickness: 1),
               Expanded(
-                child: widget.detail ?? widget.emptyDetail ?? _buildEmptyState(context),
+                child:
+                    widget.detail ??
+                    widget.emptyDetail ??
+                    _buildEmptyState(context),
               ),
             ],
           ],
@@ -134,13 +157,15 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
               bottom: 0,
               width: 16,
               child: DraggableDivider(
-                onResizeStart: () => _dragStartWidth = _currentMasterWidth,
+                onResizeStart: () => _dragStartWidth = masterWidth,
                 onResizeUpdate: (globalX, startX) {
                   setState(() {
                     final desired = _dragStartWidth! + (globalX - startX);
-                    final maxW = (totalWidth - MasterDetailLayout.defaultMinDetailWidth)
-                        .clamp(MasterDetailLayout.minMasterWidth, MasterDetailLayout.maxMasterWidth);
-                    _currentMasterWidth = desired.clamp(MasterDetailLayout.minMasterWidth, maxW);
+                    _currentMasterWidth = _clampMasterWidth(
+                      desired,
+                      totalWidth,
+                    );
+                    _hasUserResized = true;
                   });
                 },
               ),

--- a/test/widgets/layout/adaptive_navigation_test.dart
+++ b/test/widgets/layout/adaptive_navigation_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/widgets/layout/adaptive_navigation.dart';
+
+void main() {
+  testWidgets(
+    'topDestinationCount keeps only the top group above category shortcuts',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(220, 800);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SizedBox(
+                height: 700,
+                child: AdaptiveNavigationRail(
+                  selectedIndex: -1,
+                  onDestinationSelected: (_) {},
+                  extended: true,
+                  topDestinationCount: 1,
+                  categoryShortcuts: const SizedBox(
+                    key: ValueKey('shortcuts'),
+                    height: 80,
+                  ),
+                  destinations: const [
+                    AdaptiveDestination(
+                      id: 'home',
+                      icon: Icon(Icons.home_outlined),
+                      selectedIcon: Icon(Icons.home),
+                      label: 'Home',
+                    ),
+                    AdaptiveDestination(
+                      id: 'profile',
+                      icon: Icon(Icons.person_outline),
+                      selectedIcon: Icon(Icons.person),
+                      label: 'Profile',
+                    ),
+                    AdaptiveDestination(
+                      id: 'bookmarks',
+                      icon: Icon(Icons.bookmark_outline),
+                      selectedIcon: Icon(Icons.bookmark),
+                      label: 'Bookmarks',
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final homeTop = tester.getTopLeft(find.text('Home')).dy;
+      final shortcutsTop = tester
+          .getTopLeft(find.byKey(const ValueKey('shortcuts')))
+          .dy;
+      final profileTop = tester.getTopLeft(find.text('Profile')).dy;
+      final bookmarksBottom = tester.getBottomRight(find.text('Bookmarks')).dy;
+      final railBottom = tester
+          .getBottomRight(find.byType(AdaptiveNavigationRail))
+          .dy;
+
+      expect(homeTop, lessThan(shortcutsTop));
+      expect(shortcutsTop, lessThan(profileTop));
+      expect(railBottom - bookmarksBottom, lessThanOrEqualTo(32));
+    },
+  );
+}

--- a/test/widgets/layout/master_detail_layout_test.dart
+++ b/test/widgets/layout/master_detail_layout_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/widgets/layout/master_detail_layout.dart';
+
+void main() {
+  Future<void> pumpLayout(WidgetTester tester, {required double width}) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = Size(width, 800);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: MasterDetailLayout(
+            master: ColoredBox(
+              key: ValueKey('master-content'),
+              color: Colors.blue,
+            ),
+            detail: ColoredBox(
+              key: ValueKey('detail-content'),
+              color: Colors.green,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('desktop layout widens the master pane on wide windows', (
+    tester,
+  ) async {
+    await pumpLayout(tester, width: 1600);
+
+    final masterSize = tester.getSize(
+      find.byKey(const ValueKey('master-pane')),
+    );
+    final detailSize = tester.getSize(
+      find.byKey(const ValueKey('detail-content')),
+    );
+
+    expect(masterSize.width, closeTo(448, 0.1));
+    expect(detailSize.width, greaterThanOrEqualTo(400));
+  });
+
+  testWidgets(
+    'desktop layout keeps the existing compact width near tablet size',
+    (tester) async {
+      await pumpLayout(tester, width: 1000);
+
+      final masterSize = tester.getSize(
+        find.byKey(const ValueKey('master-pane')),
+      );
+      final detailSize = tester.getSize(
+        find.byKey(const ValueKey('detail-content')),
+      );
+
+      expect(masterSize.width, closeTo(380, 0.1));
+      expect(detailSize.width, greaterThanOrEqualTo(400));
+    },
+  );
+
+  testWidgets('narrow windows stay single pane', (tester) async {
+    await pumpLayout(tester, width: 760);
+
+    final masterSize = tester.getSize(
+      find.byKey(const ValueKey('master-pane')),
+    );
+    expect(masterSize.width, closeTo(760, 0.1));
+    expect(find.byKey(const ValueKey('detail-content')), findsNothing);
+  });
+}

--- a/test/widgets/layout/master_detail_layout_test.dart
+++ b/test/widgets/layout/master_detail_layout_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/widgets/layout/draggable_divider.dart';
 import 'package:fluxdo/widgets/layout/master_detail_layout.dart';
 
 void main() {
@@ -68,5 +69,35 @@ void main() {
     );
     expect(masterSize.width, closeTo(760, 0.1));
     expect(find.byKey(const ValueKey('detail-content')), findsNothing);
+  });
+
+  testWidgets('user resize sticks across window width changes', (
+    tester,
+  ) async {
+    await pumpLayout(tester, width: 1600);
+
+    // 初始：1600 * 0.28 = 448
+    var masterSize = tester.getSize(
+      find.byKey(const ValueKey('master-pane')),
+    );
+    expect(masterSize.width, closeTo(448, 0.1));
+
+    // 用户向右拖动 52 像素，master 调整到约 500
+    await tester.timedDrag(
+      find.byType(DraggableDivider),
+      const Offset(52, 0),
+      const Duration(milliseconds: 300),
+    );
+    await tester.pump();
+
+    masterSize = tester.getSize(find.byKey(const ValueKey('master-pane')));
+    expect(masterSize.width, closeTo(500, 1));
+
+    // 缩小窗口到 1200，用户设定的 500 仍在合法范围内，应当保持
+    tester.view.physicalSize = const Size(1200, 800);
+    await tester.pump();
+
+    masterSize = tester.getSize(find.byKey(const ValueKey('master-pane')));
+    expect(masterSize.width, closeTo(500, 1));
   });
 }


### PR DESCRIPTION
## Summary / 概要

This PR refines the desktop navigation layout in two focused areas:

- widen the master pane on large desktop windows while preserving the existing compact behavior near tablet widths
- move desktop rail entries derived from bottom navigation settings to the bottom area, keeping Home at the top and category shortcuts in the middle

这个 PR 主要收敛两个桌面端布局问题：

- 在大屏桌面窗口下适度放宽主列表面板，同时保持接近平板宽度时的现有紧凑行为
- 将由底栏设置映射到桌面侧边栏的导航入口整体下沉到底部，保留首页在顶部、分类快捷入口在中间

## Changes / 改动

- add proportional master pane sizing in `MasterDetailLayout`, with clamping that still guarantees minimum detail width
- preserve manual divider resizing behavior and make the drag start width match the currently rendered master width
- add `topDestinationCount` to `AdaptiveNavigationRail` so desktop rail items can be split into top and bottom groups explicitly
- update `AdaptiveScaffold` to keep only the first navigation item at the top and place the remaining configured entries at the bottom on rail layouts
- add focused widget tests for desktop master-detail sizing and rail grouping behavior

- 在 `MasterDetailLayout` 中加入按窗口宽度自适应的主面板宽度，并继续保证详情区最小宽度
- 保留手动拖拽分隔线行为，并让拖拽起点与当前实际渲染宽度一致
- 为 `AdaptiveNavigationRail` 增加 `topDestinationCount`，显式支持桌面侧边栏的顶部/底部分组
- 更新 `AdaptiveScaffold` 的桌面 rail 传参，只保留首个导航项在顶部，其余配置项贴底
- 补充两个针对桌面布局行为的 widget test

## Verification / 验证

- `flutter test --no-pub test/widgets/layout/adaptive_navigation_test.dart test/widgets/layout/master_detail_layout_test.dart`
- `dart analyze lib/widgets/layout/adaptive_navigation.dart lib/widgets/layout/adaptive_scaffold.dart lib/widgets/layout/master_detail_layout.dart test/widgets/layout/adaptive_navigation_test.dart test/widgets/layout/master_detail_layout_test.dart`

## Screenshots / 截图

### Before / 修改前
<img width="713" height="1026" alt="17fef1c7af9194c717ff5bca0b7eb3f0" src="https://github.com/user-attachments/assets/eb7c6a32-1392-41b2-a1df-19aeee1120e2" />

### After / 修改后
<img width="726" height="999" alt="56e5bb95855dee2a649eb931563f9f88" src="https://github.com/user-attachments/assets/0b1ac9ed-dac4-4f52-bdcb-25988a55cb5a" />
