### PR TITLE
Fix notification unread count sync

### DIFF
--- a/lib/providers/message_bus/notification_providers.dart
+++ b/lib/providers/message_bus/notification_providers.dart
@@ -51,6 +51,19 @@ class NotificationCountNotifier extends Notifier<NotificationCountState> {
     _hasLiveUpdate = true;
     _lastState = state;
   }
+
+  /// 标记单条通知已读后递减本地计数
+  void markRead({required bool highPriority}) {
+    state = state.copyWith(
+      allUnread: state.allUnread > 0 ? state.allUnread - 1 : 0,
+      unread: state.unread > 0 ? state.unread - 1 : 0,
+      highPriority: highPriority && state.highPriority > 0
+          ? state.highPriority - 1
+          : state.highPriority,
+    );
+    _hasLiveUpdate = true;
+    _lastState = state;
+  }
 }
 
 final notificationCountStateProvider =

--- a/lib/utils/notification_navigation.dart
+++ b/lib/utils/notification_navigation.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/notification.dart';
 import '../providers/discourse_providers.dart';
+import '../providers/message_bus/notification_providers.dart';
 import '../pages/topic_detail_page/topic_detail_page.dart';
 import '../pages/user_profile_page.dart';
 import '../pages/badge_page.dart';
@@ -11,6 +12,49 @@ import '../widgets/notification/notification_quick_panel.dart';
 NavigatorState? _rootNavigator(BuildContext context) {
   return navigatorKey.currentState ??
       Navigator.of(context, rootNavigator: true);
+}
+
+/// 同步本地通知状态，避免角标和不同列表之间状态不一致
+void syncNotificationReadLocallyWithNotifiers({
+  required DiscourseNotification notification,
+  required NotificationCountNotifier countNotifier,
+  RecentNotificationsNotifier? recentNotifier,
+  NotificationListNotifier? listNotifier,
+}) {
+  if (notification.read) return;
+
+  recentNotifier?.markAsRead(notification.id);
+  listNotifier?.markAsRead(notification.id);
+  countNotifier.markRead(highPriority: notification.highPriority);
+}
+
+void syncNotificationReadLocally(WidgetRef ref, DiscourseNotification notification) {
+  syncNotificationReadLocallyWithNotifiers(
+    notification: notification,
+    countNotifier: ref.read(notificationCountStateProvider.notifier),
+    recentNotifier: ref.exists(recentNotificationsProvider)
+        ? ref.read(recentNotificationsProvider.notifier)
+        : null,
+    listNotifier: ref.exists(notificationListProvider)
+        ? ref.read(notificationListProvider.notifier)
+        : null,
+  );
+}
+
+void syncNotificationReadLocallyWithRef(
+  Ref ref,
+  DiscourseNotification notification,
+) {
+  syncNotificationReadLocallyWithNotifiers(
+    notification: notification,
+    countNotifier: ref.read(notificationCountStateProvider.notifier),
+    recentNotifier: ref.exists(recentNotificationsProvider)
+        ? ref.read(recentNotificationsProvider.notifier)
+        : null,
+    listNotifier: ref.exists(notificationListProvider)
+        ? ref.read(notificationListProvider.notifier)
+        : null,
+  );
 }
 
 void _pushOnRootNavigator(BuildContext context, Widget page) {
@@ -27,8 +71,7 @@ void handleNotificationTap(
 ) {
   // 如果通知未读，先标记为已读
   if (!notification.read) {
-    // 更新快捷面板本地状态
-    ref.read(recentNotificationsProvider.notifier).markAsRead(notification.id);
+    syncNotificationReadLocally(ref, notification);
 
     // 异步发送标记已读请求
     ref

--- a/test/utils/notification_navigation_test.dart
+++ b/test/utils/notification_navigation_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/notification.dart';
+import 'package:fluxdo/models/user.dart';
+import 'package:fluxdo/providers/core_providers.dart';
+import 'package:fluxdo/providers/message_bus/notification_providers.dart';
+import 'package:fluxdo/providers/notification_list_provider.dart';
+import 'package:fluxdo/providers/recent_notifications_provider.dart';
+import 'package:fluxdo/utils/notification_navigation.dart';
+
+final _unreadNotification = DiscourseNotification(
+  id: 1001,
+  userId: 42,
+  notificationType: NotificationType.privateMessage,
+  read: false,
+  highPriority: true,
+  createdAt: DateTime.utc(2026, 5, 12, 1, 2, 3),
+  data: NotificationData(
+    topicTitle: '有一条新私信',
+    username: 'tester',
+  ),
+);
+
+void main() {
+  test('本地标记单条通知已读时同步刷新列表与角标计数', () async {
+    final container = ProviderContainer(
+      overrides: [
+        currentUserProvider.overrideWith(_FakeCurrentUserNotifier.new),
+        recentNotificationsProvider.overrideWith(
+          _FakeRecentNotificationsNotifier.new,
+        ),
+        notificationListProvider.overrideWith(
+          _FakeNotificationListNotifier.new,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(currentUserProvider.future);
+    await container.read(recentNotificationsProvider.future);
+    await container.read(notificationListProvider.future);
+
+    expect(container.read(notificationCountStateProvider).allUnread, 1);
+    expect(container.read(notificationCountStateProvider).highPriority, 1);
+    expect(
+      container.read(recentNotificationsProvider).requireValue.single.read,
+      isFalse,
+    );
+    expect(
+      container.read(notificationListProvider).requireValue.single.read,
+      isFalse,
+    );
+
+    syncNotificationReadLocallyWithNotifiers(
+      notification: _unreadNotification,
+      countNotifier: container.read(notificationCountStateProvider.notifier),
+      recentNotifier: container.read(recentNotificationsProvider.notifier),
+      listNotifier: container.read(notificationListProvider.notifier),
+    );
+
+    expect(container.read(notificationCountStateProvider).allUnread, 0);
+    expect(container.read(notificationCountStateProvider).unread, 0);
+    expect(container.read(notificationCountStateProvider).highPriority, 0);
+    expect(
+      container.read(recentNotificationsProvider).requireValue.single.read,
+      isTrue,
+    );
+    expect(
+      container.read(notificationListProvider).requireValue.single.read,
+      isTrue,
+    );
+  });
+}
+
+class _FakeCurrentUserNotifier extends CurrentUserNotifier {
+  @override
+  FutureOr<User?> build() {
+    return User(
+      id: 42,
+      username: 'tester',
+      trustLevel: 2,
+      unreadNotifications: 1,
+      unreadHighPriorityNotifications: 1,
+      allUnreadNotificationsCount: 1,
+      seenNotificationId: 1000,
+      notificationChannelPosition: 1,
+    );
+  }
+}
+
+class _FakeRecentNotificationsNotifier
+    extends RecentNotificationsNotifier {
+  @override
+  Future<List<DiscourseNotification>> build() async => [_unreadNotification];
+}
+
+class _FakeNotificationListNotifier
+    extends NotificationListNotifier {
+  @override
+  Future<List<DiscourseNotification>> build() async => [_unreadNotification];
+}


### PR DESCRIPTION
## Summary
- 同步单条通知已读时的本地角标计数，避免点击消息后未读数不变化
- 统一快捷面板与通知历史页的本地已读状态更新路径
- 新增回归测试覆盖单条通知已读后的列表与角标同步行为

## Test Plan
- E:\flutter\bin\cache\dart-sdk\bin\dart.exe analyze test\\utils\\notification_navigation_test.dart lib\\utils\\notification_navigation.dart lib\\providers\\message_bus\\notification_providers.dart
- flutter test --no-pub test/utils/notification_navigation_test.dart