### PR TITLE
🐛 修复 rhttp 引擎开关退出重进自动关闭问题

### DIFF
--- a/lib/l10n/modules/network/network_en.arb
+++ b/lib/l10n/modules/network/network_en.arb
@@ -65,6 +65,7 @@
   "rhttpEngine_proxyDohOnly": "Proxy/DOH Only",
   "rhttpEngine_title": "rhttp Engine",
   "rhttpEngine_useMode": "Usage Mode",
+  "rhttpEngine_initFailedHint": "rhttp engine initialization failed, fallback adapter in use, will retry on next launch",
   "webviewAdapter_disabledDesc": "Use browser engine for requests, may improve login stability",
   "webviewAdapter_enabledDesc": "Main site API requests sent via browser engine",
   "webviewAdapter_hint": "Only main site API requests go through WebView; images and push notifications are not affected",

--- a/lib/l10n/modules/network/network_zh.arb
+++ b/lib/l10n/modules/network/network_zh.arb
@@ -86,6 +86,7 @@
   "rhttpEngine_proxyDohOnly": "仅代理/DOH",
   "rhttpEngine_title": "rhttp 引擎",
   "rhttpEngine_useMode": "使用模式",
+  "rhttpEngine_initFailedHint": "rhttp 引擎初始化失败，已回退至备用网络适配器，下次启动将自动重试",
   "webviewAdapter_disabledDesc": "使用浏览器内核发送请求，可改善登录稳定性",
   "webviewAdapter_enabledDesc": "主站 API 请求通过浏览器内核发送",
   "webviewAdapter_hint": "仅主站 API 请求通过 WebView 发送，图片加载和消息推送不受影响",

--- a/lib/l10n/modules/network/network_zh_HK.arb
+++ b/lib/l10n/modules/network/network_zh_HK.arb
@@ -85,5 +85,6 @@
   "rhttpEngine_enabledDesc": "HTTP/2 多路複用 · Rust reqwest",
   "rhttpEngine_proxyDohOnly": "僅代理/DOH",
   "rhttpEngine_title": "rhttp 引擎",
-  "rhttpEngine_useMode": "使用模式"
+  "rhttpEngine_useMode": "使用模式",
+  "rhttpEngine_initFailedHint": "rhttp 引擎初始化失敗，已退回至備用網絡適配器，下次啓動將自動重試"
 }

--- a/lib/l10n/modules/network/network_zh_TW.arb
+++ b/lib/l10n/modules/network/network_zh_TW.arb
@@ -85,5 +85,6 @@
   "rhttpEngine_enabledDesc": "HTTP/2 多路複用 · Rust reqwest",
   "rhttpEngine_proxyDohOnly": "僅代理/DOH",
   "rhttpEngine_title": "rhttp 引擎",
-  "rhttpEngine_useMode": "使用模式"
+  "rhttpEngine_useMode": "使用模式",
+  "rhttpEngine_initFailedHint": "rhttp 引擎初始化失敗，已退回至備用網路介面卡，下次啟動將自動重試"
 }

--- a/lib/pages/network_settings_page/widgets/rhttp_engine_card.dart
+++ b/lib/pages/network_settings_page/widgets/rhttp_engine_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../l10n/s.dart';
+import '../../../services/network/adapters/cronet_fallback_service.dart';
 import '../../../services/network/adapters/platform_adapter.dart';
 import '../../../services/network/doh/network_settings_service.dart';
 import '../../../services/network/proxy/proxy_settings_service.dart';
@@ -22,6 +23,7 @@ class RhttpEngineCard extends StatelessWidget {
         rhttpService.notifier,
         networkService.notifier,
         proxyService.notifier,
+        CronetFallbackService.instance,
       ]),
       builder: (context, _) {
         final settings = rhttpService.current;
@@ -33,11 +35,15 @@ class RhttpEngineCard extends StatelessWidget {
         final wouldUseRhttp = rhttpService.shouldUseRhttp(ns, ps);
         final echFallback = enabled && ns.dohEnabled && ns.echServerUrl != null;
 
-        // 推算当前实际适配器类型
+        // 推算当前实际适配器类型（对齐 _resolveAdapterType() 完整链路）
         final AdapterType effectiveType;
         if (wouldUseRhttp) {
           effectiveType = AdapterType.rhttp;
-        } else if (networkService.shouldRunLocalProxy) {
+        } else if (networkService.isGatewayMode &&
+            !CronetFallbackService.instance.hasFallenBack) {
+          effectiveType = AdapterType.native;
+        } else if (networkService.shouldRunLocalProxy ||
+            CronetFallbackService.instance.hasFallenBack) {
           effectiveType = AdapterType.network;
         } else {
           effectiveType = AdapterType.native;
@@ -51,7 +57,9 @@ class RhttpEngineCard extends StatelessWidget {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
             side: enabled
-                ? BorderSide(color: theme.colorScheme.primary.withValues(alpha: 0.3))
+                ? BorderSide(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.3),
+                  )
                 : BorderSide.none,
           ),
           child: Column(
@@ -74,12 +82,17 @@ class RhttpEngineCard extends StatelessWidget {
               if (enabled) ...[
                 Divider(
                   height: 1,
-                  color: theme.colorScheme.outlineVariant.withValues(alpha: 0.2),
+                  color: theme.colorScheme.outlineVariant.withValues(
+                    alpha: 0.2,
+                  ),
                 ),
 
                 // 模式选择
                 Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
@@ -100,7 +113,9 @@ class RhttpEngineCard extends StatelessWidget {
                             ),
                             ButtonSegment(
                               value: RhttpMode.proxyOnly,
-                              label: Text(context.l10n.rhttpEngine_proxyDohOnly),
+                              label: Text(
+                                context.l10n.rhttpEngine_proxyDohOnly,
+                              ),
                             ),
                           ],
                           selected: {settings.mode},
@@ -116,10 +131,15 @@ class RhttpEngineCard extends StatelessWidget {
                 // 当前适配器状态
                 Divider(
                   height: 1,
-                  color: theme.colorScheme.outlineVariant.withValues(alpha: 0.2),
+                  color: theme.colorScheme.outlineVariant.withValues(
+                    alpha: 0.2,
+                  ),
                 ),
                 Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
                   child: Row(
                     children: [
                       Icon(
@@ -131,7 +151,9 @@ class RhttpEngineCard extends StatelessWidget {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        context.l10n.rhttpEngine_currentAdapter(getAdapterDisplayName(effectiveType)),
+                        context.l10n.rhttpEngine_currentAdapter(
+                          getAdapterDisplayName(effectiveType),
+                        ),
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
@@ -157,6 +179,31 @@ class RhttpEngineCard extends StatelessWidget {
                             context.l10n.rhttpEngine_echFallbackHint,
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: theme.colorScheme.tertiary,
+                              fontSize: 11,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                // rhttp 初始化失败警告
+                if (settings.forceDisabled)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                    child: Row(
+                      children: [
+                        Icon(
+                          Icons.warning_amber,
+                          size: 14,
+                          color: theme.colorScheme.error,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            context.l10n.rhttpEngine_initFailedHint,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.error,
                               fontSize: 11,
                             ),
                           ),

--- a/lib/services/network/rhttp/rhttp_settings_service.dart
+++ b/lib/services/network/rhttp/rhttp_settings_service.dart
@@ -18,18 +18,26 @@ class RhttpSettings {
   const RhttpSettings({
     this.enabled = false,
     this.mode = RhttpMode.always,
+    this.forceDisabled = false,
   });
 
   final bool enabled;
   final RhttpMode mode;
 
+  /// 运行时强制禁用标志（不持久化，仅当前进程有效）
+  /// 当 rhttp Rust 引擎初始化失败时由 forceDisable() 置为 true，
+  /// 下次启动自动恢复为 false 并重新尝试初始化
+  final bool forceDisabled;
+
   RhttpSettings copyWith({
     bool? enabled,
     RhttpMode? mode,
+    bool? forceDisabled,
   }) {
     return RhttpSettings(
       enabled: enabled ?? this.enabled,
       mode: mode ?? this.mode,
+      forceDisabled: forceDisabled ?? this.forceDisabled,
     );
   }
 }
@@ -81,20 +89,33 @@ class RhttpSettingsService {
   }
 
   /// 强制禁用（Rhttp.init() 失败时调用）
+  ///
+  /// 仅修改运行时内存状态，不持久化到 SharedPreferences，
+  /// 确保下次启动仍会重新尝试初始化 rhttp 引擎。
   Future<void> forceDisable() async {
-    await setEnabled(false);
+    if (_prefs == null) return;
+    notifier.value = notifier.value.copyWith(forceDisabled: true);
+    _touch();
     debugPrint('[rhttp] 已强制禁用（初始化失败）');
   }
 
   /// 综合判断当前是否应该使用 rhttp
   bool shouldUseRhttp(NetworkSettings ns, ProxySettings ps) {
     if (!current.enabled) return false;
+    if (current.forceDisabled) return false;
     // rhttp fork 已支持 ECH（通过 TlsSettings.echConfigList），不再排除
     // proxyOnly 模式：仅代理/DOH 启用时使用
     if (current.mode == RhttpMode.proxyOnly) {
       return ns.dohEnabled || ps.isValid;
     }
     return true; // always 模式
+  }
+
+  /// 重置单例内部状态，仅用于测试，使 initialize() 可重新执行。
+  @visibleForTesting
+  void resetForTest() {
+    _prefs = null;
+    _version = 0;
   }
 
   void _touch() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -819,13 +819,13 @@ packages:
     source: hosted
     version: "3.3.1"
   flutter_rust_bridge:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: flutter_rust_bridge
-      sha256: e87d6b9ee934dcd24a128ccb2bd91905d2d5fe5c06245d6a8f5477d4907a437a
+      sha256: "37ef40bc6f863652e865f0b2563ea07f0d3c58d8efad803cc01933a4b2ee067e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,6 +113,9 @@ dependency_overrides:
   device_info_plus: 12.3.0
   flutter_inappwebview_linux:
     path: packages/flutter_inappwebview_linux
+  # 锁定 flutter_rust_bridge 版本，与 rhttp 插件的 codegen 版本保持一致
+  # rhttp 预编译原生库基于 2.11.1，升级会导致 rhttp.Rhttp.init() 失败
+  flutter_rust_bridge: 2.11.1
 
 dev_dependencies:
   flutter_test:

--- a/test/services/network/rhttp/rhttp_settings_service_test.dart
+++ b/test/services/network/rhttp/rhttp_settings_service_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fluxdo/services/network/rhttp/rhttp_settings_service.dart';
+import 'package:fluxdo/services/network/doh/network_settings_service.dart';
+import 'package:fluxdo/services/network/proxy/proxy_settings_service.dart';
+
+/// RhttpSettingsService 单例的单元测试
+///
+/// 注意：RhttpSettingsService 是单例，initialize() 首次后因 _prefs != null
+/// 守卫不再更新。每条测试都需要 resetForTest()，避免吃到上一条测试留下的内存状态。
+void main() {
+  group('RhttpSettingsService forceDisable', () {
+    late SharedPreferences prefs;
+    late RhttpSettingsService rhttp;
+
+    setUp(() async {
+      rhttp = RhttpSettingsService.instance;
+      rhttp.resetForTest();
+
+      // 使用固定初始值确保每条测试都有独立的 SharedPreferences mock。
+      SharedPreferences.setMockInitialValues({
+        'rhttp_enabled': true,
+        'rhttp_mode': 0,
+      });
+      prefs = await SharedPreferences.getInstance();
+    });
+
+    test('forceDisable 不修改 SharedPreferences', () async {
+      await rhttp.initialize(prefs);
+      expect(prefs.getBool('rhttp_enabled'), true);
+
+      await rhttp.forceDisable();
+
+      expect(
+        prefs.getBool('rhttp_enabled'),
+        true,
+        reason: 'forceDisable 不应覆盖用户的偏好设置',
+      );
+    });
+
+    test('forceDisable 后 enabled 保持 true', () async {
+      await rhttp.initialize(prefs);
+      await rhttp.forceDisable();
+
+      expect(rhttp.current.enabled, true, reason: '用户偏好不受 forceDisable 影响');
+    });
+
+    test('forceDisable 后 forceDisabled 为 true', () async {
+      await rhttp.initialize(prefs);
+      await rhttp.forceDisable();
+
+      expect(rhttp.current.forceDisabled, true);
+    });
+
+    test('forceDisable 后 shouldUseRhttp 返回 false', () async {
+      await rhttp.initialize(prefs);
+      await rhttp.forceDisable();
+
+      expect(
+        rhttp.shouldUseRhttp(_networkSettings(), const ProxySettings()),
+        false,
+        reason: 'forceDisable 后应阻止使用 rhttp',
+      );
+    });
+
+    test('setEnabled 不改变 forceDisabled', () async {
+      await rhttp.initialize(prefs);
+      await rhttp.forceDisable();
+      expect(rhttp.current.forceDisabled, true);
+
+      await rhttp.setEnabled(false);
+      expect(rhttp.current.forceDisabled, true);
+
+      await rhttp.setEnabled(true);
+      expect(rhttp.current.forceDisabled, true);
+    });
+
+    test('setMode 不改变 forceDisabled', () async {
+      await rhttp.initialize(prefs);
+      await rhttp.forceDisable();
+      expect(rhttp.current.forceDisabled, true);
+
+      await rhttp.setMode(RhttpMode.proxyOnly);
+      expect(rhttp.current.forceDisabled, true);
+    });
+
+    test(
+      'resetForTest 后重新 initialize 恢复 forceDisabled 为 false（模拟重启）',
+      () async {
+        // 首次初始化并 forceDisable
+        await rhttp.initialize(prefs);
+        await rhttp.forceDisable();
+        expect(rhttp.current.forceDisabled, true);
+
+        // 模拟重启：重置单例 + 新建 SharedPreferences
+        rhttp.resetForTest();
+        SharedPreferences.setMockInitialValues({
+          'rhttp_enabled': true,
+          'rhttp_mode': 0,
+        });
+        final freshPrefs = await SharedPreferences.getInstance();
+
+        // 重新 initialize → 走完整路径，forceDisabled 应为默认值 false
+        await rhttp.initialize(freshPrefs);
+
+        expect(rhttp.current.enabled, true, reason: '重启后用户偏好 enabled 应保留');
+        expect(
+          rhttp.current.forceDisabled,
+          false,
+          reason: '重启后 forceDisabled 恢复为 false，允许重新尝试 rhttp',
+        );
+      },
+    );
+  });
+}
+
+NetworkSettings _networkSettings({bool dohEnabled = false}) {
+  return NetworkSettings(
+    dohEnabled: dohEnabled,
+    selectedServerUrl: 'https://dns.google/dns-query',
+    customServers: const [],
+    proxyPort: null,
+  );
+}


### PR DESCRIPTION
issue:https://github.com/Lingyan000/fluxdo/issues/247
## 问题

用户在「网络设置」中开启 rhttp 引擎后，退出 App 重新进入，开关自动变为关闭状态。

## 修复

将"用户偏好（enabled，持久化）"与"运行时可用性（forceDisabled，仅内存）"分离：

- **`forceDisabled`** 新增运行时标志，默认 `false`，`forceDisable()` 仅修改此标志，不写 SharedPreferences
- **`shouldUseRhttp()`** 同时检查 `enabled` 和 `forceDisabled`
- **`setEnabled()` / `setMode()`** 通过 `copyWith` 保留 `forceDisabled` 值
- **下次启动**：`initialize()` 构建新 `RhttpSettings` 时 `forceDisabled` 默认为 `false`，自动重试
- **UI**：`forceDisabled` 时卡片底部显示警告提示

## 额外修复

- `rhttp_engine_card` 适配器推算对齐 `_resolveAdapterType()` 完整链路
- `AnimatedBuilder` 补监听 `CronetFallbackService`，降级触发时自动刷新
- 锁定 `flutter_rust_bridge` 至 2.11.1，修复原生引擎初始化失败

## 测试

- 新增 7 个回归测试覆盖持久化和状态迁移 ✅
- `flutter analyze` 无新增问题 ✅
- `flutter test` 全部通过 ✅