### PR TITLE
Fix post-login loading handoff

### DIFF
--- a/lib/pages/webview_login_page.dart
+++ b/lib/pages/webview_login_page.dart
@@ -23,6 +23,7 @@ import '../services/hcaptcha_accessibility_service.dart';
 import '../services/webview_settings.dart';
 import '../services/windows_webview_environment_service.dart';
 import '../services/log/log_writer.dart';
+import '../services/login_ready_coordinator.dart';
 import '../widgets/common/dismissible_popup_menu.dart';
 import '../l10n/s.dart';
 import '../utils/dialog_utils.dart';
@@ -172,13 +173,13 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
                 Offstage(
                   offstage: _webViewSnapshot != null,
                   child: WebViewSettings.wrapWithScrollFix(
-                  InAppWebView(
-                    webViewEnvironment: windowsWebViewEnvironment,
-                    initialSettings: WebViewSettings.visible,
-                    initialUserScripts: UnmodifiableListView([
-                      ...WebViewSettings.ios15PolyfillScripts,
-                      UserScript(
-                        source: '''
+                    InAppWebView(
+                      webViewEnvironment: windowsWebViewEnvironment,
+                      initialSettings: WebViewSettings.visible,
+                      initialUserScripts: UnmodifiableListView([
+                        ...WebViewSettings.ios15PolyfillScripts,
+                        UserScript(
+                          source: '''
                           new MutationObserver(function(_, obs) {
                             var el = document.querySelector('[data-preloaded]');
                             if (!el) return;
@@ -192,104 +193,107 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
                             window.__rawPreloaded = parts.join('\\n');
                           }).observe(document.documentElement, {childList: true, subtree: true});
                         ''',
-                        injectionTime:
-                            UserScriptInjectionTime.AT_DOCUMENT_START,
-                      ),
-                    ]),
-                    onReceivedServerTrustAuthRequest: (_, challenge) =>
-                        WebViewSettings.handleServerTrustAuthRequest(challenge),
-                    onWebViewCreated: (controller) async {
-                      _controller = controller;
-                      // 注册 JS Handler，用于在登录按钮点击时接收凭证
-                      controller.addJavaScriptHandler(
-                        handlerName: 'onLoginCredentials',
-                        callback: (args) {
-                          if (args.isNotEmpty &&
-                              ref.read(preferencesProvider).autoFillLogin) {
-                            try {
-                              final data = args[0] as Map<String, dynamic>;
-                              final username = data['username'] as String?;
-                              final password = data['password'] as String?;
-                              if (username != null &&
-                                  username.isNotEmpty &&
-                                  password != null &&
-                                  password.isNotEmpty) {
-                                _credentialStore.save(username, password);
-                                if (mounted) {
-                                  setState(() => _savedUsername = username);
-                                }
-                              }
-                            } catch (_) {}
-                          }
-                        },
-                      );
-                      controller.addJavaScriptHandler(
-                        handlerName: 'onFingerprintDone',
-                        callback: (_) {
-                          _fingerprintDone = true;
-                          final c = _fingerprintCompleter;
-                          if (c != null && !c.isCompleted) c.complete();
-                          return null;
-                        },
-                      );
-                      // 等待 cookie flush 完成再加载 URL，
-                      // 确保 WebView 引擎初始化后 cookie 已就位
-                      await _awaitInitialCookieFlush();
-                      await controller.loadUrl(
-                        urlRequest: URLRequest(
-                          url: WebUri(
-                            widget.initialUrl ??
-                                '${AppConstants.baseUrl}/login',
-                          ),
+                          injectionTime:
+                              UserScriptInjectionTime.AT_DOCUMENT_START,
                         ),
-                      );
-                      // Android: 启用 WebAuthn/PassKey 支持
-                      if (Platform.isAndroid) {
-                        WidgetsBinding.instance.addPostFrameCallback((_) {
-                          const MethodChannel('com.fluxdo/webauthn')
-                              .invokeMethod('enableWebAuthentication');
-                        });
-                      }
-                    },
-                    onLoadStart: (controller, url) => setState(() {
-                      _isLoading = true;
-                      _url = url?.toString() ?? '';
-                      _lastHomeResponseUrl = null;
-                    }),
-                    onProgressChanged: (controller, progress) =>
-                        setState(() => _progress = progress / 100),
-                    onLoadResource: (controller, resource) {
-                      _handleLoadedResource(controller, resource);
-                    },
-                    onLoadStop: (controller, url) async {
-                      setState(() {
-                        _isLoading = false;
+                      ]),
+                      onReceivedServerTrustAuthRequest: (_, challenge) =>
+                          WebViewSettings.handleServerTrustAuthRequest(
+                            challenge,
+                          ),
+                      onWebViewCreated: (controller) async {
+                        _controller = controller;
+                        // 注册 JS Handler，用于在登录按钮点击时接收凭证
+                        controller.addJavaScriptHandler(
+                          handlerName: 'onLoginCredentials',
+                          callback: (args) {
+                            if (args.isNotEmpty &&
+                                ref.read(preferencesProvider).autoFillLogin) {
+                              try {
+                                final data = args[0] as Map<String, dynamic>;
+                                final username = data['username'] as String?;
+                                final password = data['password'] as String?;
+                                if (username != null &&
+                                    username.isNotEmpty &&
+                                    password != null &&
+                                    password.isNotEmpty) {
+                                  _credentialStore.save(username, password);
+                                  if (mounted) {
+                                    setState(() => _savedUsername = username);
+                                  }
+                                }
+                              } catch (_) {}
+                            }
+                          },
+                        );
+                        controller.addJavaScriptHandler(
+                          handlerName: 'onFingerprintDone',
+                          callback: (_) {
+                            _fingerprintDone = true;
+                            final c = _fingerprintCompleter;
+                            if (c != null && !c.isCompleted) c.complete();
+                            return null;
+                          },
+                        );
+                        // 等待 cookie flush 完成再加载 URL，
+                        // 确保 WebView 引擎初始化后 cookie 已就位
+                        await _awaitInitialCookieFlush();
+                        await controller.loadUrl(
+                          urlRequest: URLRequest(
+                            url: WebUri(
+                              widget.initialUrl ??
+                                  '${AppConstants.baseUrl}/login',
+                            ),
+                          ),
+                        );
+                        // Android: 启用 WebAuthn/PassKey 支持
+                        if (Platform.isAndroid) {
+                          WidgetsBinding.instance.addPostFrameCallback((_) {
+                            const MethodChannel(
+                              'com.fluxdo/webauthn',
+                            ).invokeMethod('enableWebAuthentication');
+                          });
+                        }
+                      },
+                      onLoadStart: (controller, url) => setState(() {
+                        _isLoading = true;
                         _url = url?.toString() ?? '';
-                      });
-                      _recheckCount = 0;
-                      await WebViewSettings.injectScrollFix(controller);
-                      _injectFingerprintHook(controller);
-                      // 自动填充登录表单
-                      await _autoFillLoginForm(controller, url);
-                      // 自动检测登录状态
-                      await _checkLoginStatus(
-                        controller,
-                        currentUrl: url?.toString(),
-                      );
-                    },
-                    onUpdateVisitedHistory: (controller, url, isReload) {
-                      if (!_loginHandled && isReload != true) {
-                        // SPA 路由变化时也尝试检测登录状态
+                        _lastHomeResponseUrl = null;
+                      }),
+                      onProgressChanged: (controller, progress) =>
+                          setState(() => _progress = progress / 100),
+                      onLoadResource: (controller, resource) {
+                        _handleLoadedResource(controller, resource);
+                      },
+                      onLoadStop: (controller, url) async {
+                        setState(() {
+                          _isLoading = false;
+                          _url = url?.toString() ?? '';
+                        });
                         _recheckCount = 0;
-                        _checkLoginStatus(
+                        await WebViewSettings.injectScrollFix(controller);
+                        _injectFingerprintHook(controller);
+                        // 自动填充登录表单
+                        await _autoFillLoginForm(controller, url);
+                        // 自动检测登录状态
+                        await _checkLoginStatus(
                           controller,
                           currentUrl: url?.toString(),
                         );
-                      }
-                    },
+                      },
+                      onUpdateVisitedHistory: (controller, url, isReload) {
+                        if (!_loginHandled && isReload != true) {
+                          // SPA 路由变化时也尝试检测登录状态
+                          _recheckCount = 0;
+                          _checkLoginStatus(
+                            controller,
+                            currentUrl: url?.toString(),
+                          );
+                        }
+                      },
+                    ),
+                    getController: () => _controller,
                   ),
-                  getController: () => _controller,
-                ),
                 ),
                 if (_webViewSnapshot != null)
                   Positioned.fill(
@@ -514,34 +518,32 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
       }
 
       _loginHandled = true;
-      final fingerprintFuture = _waitForFingerprintPost();
+      unawaited(_waitForFingerprintPost());
       final finalToken = await _finalizeLoginBeforeExit(
         controller,
         username: username,
         currentUrl: currentUrl,
         webViewToken: tToken,
       );
-      await fingerprintFuture;
-
       String? pageHtml;
       try {
-        pageHtml = await controller.evaluateJavascript(
-          source: 'window.__rawPreloaded || null',
-        ) as String?;
+        pageHtml =
+            await controller.evaluateJavascript(
+                  source: 'window.__rawPreloaded || null',
+                )
+                as String?;
       } catch (_) {}
+
+      await _finalizeLoginBootstrap(
+        currentUrl: currentUrl,
+        token: finalToken,
+        pageHtml: pageHtml,
+      );
 
       if (mounted) {
         ToastService.showSuccess(S.current.webviewLogin_loginSuccess);
         Navigator.of(context).pop(true);
       }
-
-      unawaited(
-        _finalizeLoginAfterExit(
-          currentUrl: currentUrl,
-          token: finalToken,
-          pageHtml: pageHtml,
-        ),
-      );
     } finally {
       _loginInProgress = false;
     }
@@ -571,9 +573,10 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
         ? jarToken
         : webViewToken;
     final tokenMatch = jarToken == webViewToken;
-    final jarSessionCookies = await _cookieJar.getSessionCookieDiagnosticsForRequest(
-      uri: Uri.parse(AppConstants.baseUrl),
-    );
+    final jarSessionCookies = await _cookieJar
+        .getSessionCookieDiagnosticsForRequest(
+          uri: Uri.parse(AppConstants.baseUrl),
+        );
     LogWriter.instance.write({
       'timestamp': DateTime.now().toIso8601String(),
       'level': tokenMatch ? 'info' : 'warning',
@@ -596,31 +599,34 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
     }
 
     _service.setToken(finalToken);
-    _service.onLoginSuccess(finalToken);
     return finalToken;
   }
 
-  Future<void> _finalizeLoginAfterExit({
+  Future<void> _finalizeLoginBootstrap({
     required String? currentUrl,
     required String token,
     String? pageHtml,
   }) async {
+    var loginReadyNotified = false;
     try {
-      var reusedPreloaded = false;
-      if (pageHtml != null && pageHtml.isNotEmpty) {
-        reusedPreloaded =
-            await PreloadedDataService().hydrateFromHtml(pageHtml);
-      }
-      if (!reusedPreloaded) {
-        debugPrint('[Login] 当前页面无可复用首页数据，回退到 HTTP refresh');
-        await PreloadedDataService().refresh();
-      }
+      final reusedPreloaded = await LoginReadyCoordinator(
+        hydrateFromHtml: PreloadedDataService().hydrateFromHtml,
+        refreshPreloadedData: () async {
+          debugPrint('[Login] 当前页面无可复用首页数据，回退到 HTTP refresh');
+          await PreloadedDataService().refresh();
+        },
+        notifyLoginReady: (finalToken) {
+          loginReadyNotified = true;
+          _service.onLoginSuccess(finalToken);
+        },
+      ).finalize(token: token, pageHtml: pageHtml);
 
       final jarToken = await _cookieJar.getTToken();
       final tokenMatch = jarToken == token;
-      final jarSessionCookies = await _cookieJar.getSessionCookieDiagnosticsForRequest(
-        uri: Uri.parse(AppConstants.baseUrl),
-      );
+      final jarSessionCookies = await _cookieJar
+          .getSessionCookieDiagnosticsForRequest(
+            uri: Uri.parse(AppConstants.baseUrl),
+          );
       LogWriter.instance.write({
         'timestamp': DateTime.now().toIso8601String(),
         'level': 'info',
@@ -631,11 +637,14 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
         'webViewTokenLen': token.length,
         'tokenMatch': tokenMatch,
         'currentUrl': currentUrl,
+        'reusedPreloaded': reusedPreloaded,
         'jarSessionCookies': jarSessionCookies,
       });
-
     } catch (e) {
-      debugPrint('[Login] 登录态后台收尾失败: $e');
+      debugPrint('[Login] 登录态收尾失败: $e');
+      if (!loginReadyNotified) {
+        _service.onLoginSuccess(token);
+      }
     }
   }
 
@@ -691,7 +700,8 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
   }
 
   void _injectFingerprintHook(InAppWebViewController controller) {
-    controller.evaluateJavascript(source: '''
+    controller.evaluateJavascript(
+      source: '''
       (function() {
         if (window.__fpHooked) return;
         window.__fpHooked = true;
@@ -716,7 +726,8 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
           return _s.apply(this, arguments);
         };
       })();
-    ''');
+    ''',
+    );
   }
 
   Future<void> _waitForFingerprintPost() async {

--- a/lib/pages/webview_login_page.dart
+++ b/lib/pages/webview_login_page.dart
@@ -518,6 +518,10 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
       }
 
       _loginHandled = true;
+      // 指纹 POST 改为 fire-and-forget：后续 _finalizeLoginBeforeExit +
+      // evaluateJavascript + _finalizeLoginBootstrap 链路本身就会 await 一段时间，
+      // 足以让 WebView 内的 visitor_id POST 自然完成；
+      // 不再为指纹单独等待最多 15 秒，避免阻塞登录交接。
       unawaited(_waitForFingerprintPost());
       final finalToken = await _finalizeLoginBeforeExit(
         controller,
@@ -607,19 +611,25 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
     required String token,
     String? pageHtml,
   }) async {
+    // PreloadedDataService.refresh 底层 Dio 请求没有显式超时，极端网络下
+    // 可能挂住很久；这里整段限时 8 秒，超时也要兜底广播登录成功，
+    // 避免用户被永久卡在「正在同步登录状态…」界面。
+    const finalizeTimeout = Duration(seconds: 8);
+
     var loginReadyNotified = false;
     try {
-      final reusedPreloaded = await LoginReadyCoordinator(
-        hydrateFromHtml: PreloadedDataService().hydrateFromHtml,
-        refreshPreloadedData: () async {
-          debugPrint('[Login] 当前页面无可复用首页数据，回退到 HTTP refresh');
-          await PreloadedDataService().refresh();
-        },
-        notifyLoginReady: (finalToken) {
-          loginReadyNotified = true;
-          _service.onLoginSuccess(finalToken);
-        },
-      ).finalize(token: token, pageHtml: pageHtml);
+      final reusedPreloaded =
+          await LoginReadyCoordinator(
+            hydrateFromHtml: PreloadedDataService().hydrateFromHtml,
+            refreshPreloadedData: () async {
+              debugPrint('[Login] 当前页面无可复用首页数据，回退到 HTTP refresh');
+              await PreloadedDataService().refresh();
+            },
+            notifyLoginReady: (finalToken) {
+              loginReadyNotified = true;
+              _service.onLoginSuccess(finalToken);
+            },
+          ).finalize(token: token, pageHtml: pageHtml).timeout(finalizeTimeout);
 
       final jarToken = await _cookieJar.getTToken();
       final tokenMatch = jarToken == token;
@@ -640,8 +650,20 @@ class _WebViewLoginPageState extends ConsumerState<WebViewLoginPage> {
         'reusedPreloaded': reusedPreloaded,
         'jarSessionCookies': jarSessionCookies,
       });
+    } on TimeoutException {
+      debugPrint('[Login] 登录态收尾超时（${finalizeTimeout.inSeconds}s），走兜底广播');
+      LogWriter.instance.write({
+        'timestamp': DateTime.now().toIso8601String(),
+        'level': 'warning',
+        'type': 'auth',
+        'event': 'login_bootstrap_timeout',
+        'message': '登录态收尾超时，已兜底广播登录成功',
+        'currentUrl': currentUrl,
+        'timeoutSeconds': finalizeTimeout.inSeconds,
+      });
     } catch (e) {
       debugPrint('[Login] 登录态收尾失败: $e');
+    } finally {
       if (!loginReadyNotified) {
         _service.onLoginSuccess(token);
       }

--- a/lib/services/login_ready_coordinator.dart
+++ b/lib/services/login_ready_coordinator.dart
@@ -1,0 +1,35 @@
+typedef LoginPreloadedHydrator = Future<bool> Function(String html);
+typedef LoginPreloadedRefresher = Future<void> Function();
+typedef LoginReadyNotifier = void Function(String token);
+
+/// 统一收口登录成功后的预加载数据准备时序。
+///
+/// 约束：
+/// 1. 优先复用登录页已经拿到的首页 HTML 预加载数据；
+/// 2. HTML 无法复用时再回退到 HTTP refresh；
+/// 3. 只有预加载数据准备完成后，才广播登录成功。
+class LoginReadyCoordinator {
+  LoginReadyCoordinator({
+    required LoginPreloadedHydrator hydrateFromHtml,
+    required LoginPreloadedRefresher refreshPreloadedData,
+    required LoginReadyNotifier notifyLoginReady,
+  }) : _hydrateFromHtml = hydrateFromHtml,
+       _refreshPreloadedData = refreshPreloadedData,
+       _notifyLoginReady = notifyLoginReady;
+
+  final LoginPreloadedHydrator _hydrateFromHtml;
+  final LoginPreloadedRefresher _refreshPreloadedData;
+  final LoginReadyNotifier _notifyLoginReady;
+
+  Future<bool> finalize({required String token, String? pageHtml}) async {
+    var reusedPreloaded = false;
+    if (pageHtml != null && pageHtml.isNotEmpty) {
+      reusedPreloaded = await _hydrateFromHtml(pageHtml);
+    }
+    if (!reusedPreloaded) {
+      await _refreshPreloadedData();
+    }
+    _notifyLoginReady(token);
+    return reusedPreloaded;
+  }
+}

--- a/test/services/login_ready_coordinator_test.dart
+++ b/test/services/login_ready_coordinator_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/login_ready_coordinator.dart';
+
+void main() {
+  group('LoginReadyCoordinator', () {
+    test('HTML 预加载可复用时，先复用再广播登录成功', () async {
+      final events = <String>[];
+      final coordinator = LoginReadyCoordinator(
+        hydrateFromHtml: (html) async {
+          events.add('hydrate:$html');
+          return true;
+        },
+        refreshPreloadedData: () async {
+          events.add('refresh');
+        },
+        notifyLoginReady: (token) {
+          events.add('notify:$token');
+        },
+      );
+
+      final reused = await coordinator.finalize(
+        token: 'token-1',
+        pageHtml: '<html />',
+      );
+
+      expect(reused, isTrue);
+      expect(events, ['hydrate:<html />', 'notify:token-1']);
+    });
+
+    test('HTML 不可复用时，refresh 完成后再广播登录成功', () async {
+      final events = <String>[];
+      final coordinator = LoginReadyCoordinator(
+        hydrateFromHtml: (html) async {
+          events.add('hydrate:$html');
+          return false;
+        },
+        refreshPreloadedData: () async {
+          events.add('refresh');
+        },
+        notifyLoginReady: (token) {
+          events.add('notify:$token');
+        },
+      );
+
+      final reused = await coordinator.finalize(
+        token: 'token-2',
+        pageHtml: '<html />',
+      );
+
+      expect(reused, isFalse);
+      expect(events, ['hydrate:<html />', 'refresh', 'notify:token-2']);
+    });
+
+    test('缺少 HTML 时，直接 refresh 后广播登录成功', () async {
+      final events = <String>[];
+      final coordinator = LoginReadyCoordinator(
+        hydrateFromHtml: (_) async {
+          events.add('hydrate');
+          return true;
+        },
+        refreshPreloadedData: () async {
+          events.add('refresh');
+        },
+        notifyLoginReady: (token) {
+          events.add('notify:$token');
+        },
+      );
+
+      final reused = await coordinator.finalize(token: 'token-3');
+
+      expect(reused, isFalse);
+      expect(events, ['refresh', 'notify:token-3']);
+    });
+  });
+}


### PR DESCRIPTION
解决了登录成功后一直卡在 "加载数据" 中的问题

## Summary
- delay login-ready broadcast until preloaded home data has been hydrated or refreshed
- keep the login handoff logic in a dedicated coordinator with regression coverage
- avoid the old post-login loading deadlock path by finishing the auth handoff before the page pops

## Test Plan
- [x] flutter test --no-pub test/services/login_ready_coordinator_test.dart
- [x] flutter analyze --no-pub lib/pages/webview_login_page.dart lib/services/login_ready_coordinator.dart test/services/login_ready_coordinator_test.dart
- [x] flutter build windows --debug --no-pub