### PR TITLE
✨ 添加话题关键词过滤功能，允许用户根据标题关键词筛选话题

### DIFF
--- a/lib/l10n/modules/settings/settings_en.arb
+++ b/lib/l10n/modules/settings/settings_en.arb
@@ -46,7 +46,9 @@
     }
   },
   "preferences_topicFilterKeywordsHint": "Enter one keyword per line",
-  "preferences_topicFilterKeywordsHelper": "Only topic titles are matched, case-insensitively",
+  "preferences_topicFilterKeywordsHelper": "Only topic titles are matched as substrings, case-insensitively",
+  "preferences_topicFilterWholeWord": "Whole-word match",
+  "preferences_topicFilterWholeWordDesc": "When enabled, English keywords no longer match as substrings (e.g. \"ai\" will not hit \"Main thread\"). CJK keywords are unaffected.",
   "preferences_autoPanguSpacing": "Auto CJK spacing",
   "preferences_autoPanguSpacingDesc": "Auto-insert spaces between CJK and Latin text",
   "preferences_aiPostReview": "AI review before posting",

--- a/lib/l10n/modules/settings/settings_en.arb
+++ b/lib/l10n/modules/settings/settings_en.arb
@@ -36,6 +36,17 @@
   "preferences_clipboardTopicLinkDetectionDesc": "Check for Linux.do topic links in the clipboard when returning to the app and ask before opening",
   "preferences_clipboardTopicLink_detected": "Topic link found in clipboard",
   "preferences_clipboardTopicLink_open": "Open",
+  "preferences_topicFilterKeywords": "Title keyword filter",
+  "preferences_topicFilterKeywordsDesc": "Filter topics whose title contains the configured keywords, one per line",
+  "preferences_topicFilterKeywordsEmpty": "No keywords set",
+  "preferences_topicFilterKeywordsCount": "{count} keywords set",
+  "@preferences_topicFilterKeywordsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_topicFilterKeywordsHint": "Enter one keyword per line",
+  "preferences_topicFilterKeywordsHelper": "Only topic titles are matched, case-insensitively",
   "preferences_autoPanguSpacing": "Auto CJK spacing",
   "preferences_autoPanguSpacingDesc": "Auto-insert spaces between CJK and Latin text",
   "preferences_aiPostReview": "AI review before posting",

--- a/lib/l10n/modules/settings/settings_zh.arb
+++ b/lib/l10n/modules/settings/settings_zh.arb
@@ -63,7 +63,9 @@
     }
   },
   "preferences_topicFilterKeywordsHint": "每行输入一个关键词",
-  "preferences_topicFilterKeywordsHelper": "仅匹配话题标题，不区分大小写",
+  "preferences_topicFilterKeywordsHelper": "仅匹配话题标题，子串匹配，不区分大小写",
+  "preferences_topicFilterWholeWord": "完整词匹配",
+  "preferences_topicFilterWholeWordDesc": "开启后英文关键词不再匹配子串，如 ai 不会命中 Main thread；中文关键词无影响",
   "preferences_autoPanguSpacing": "自动混排优化",
   "preferences_autoPanguSpacingDesc": "输入时自动插入中英文混排空格",
   "preferences_aiPostReview": "发帖前 AI 审核",

--- a/lib/l10n/modules/settings/settings_zh.arb
+++ b/lib/l10n/modules/settings/settings_zh.arb
@@ -53,6 +53,17 @@
   "preferences_clipboardTopicLinkDetectionDesc": "回到应用时检测剪贴板中的 Linux.do 话题链接，并在底部询问是否打开",
   "preferences_clipboardTopicLink_detected": "检测到剪贴板中的话题链接",
   "preferences_clipboardTopicLink_open": "打开",
+  "preferences_topicFilterKeywords": "标题关键词过滤",
+  "preferences_topicFilterKeywordsDesc": "过滤标题包含指定关键词的话题，每行一个关键词",
+  "preferences_topicFilterKeywordsEmpty": "未设置关键词",
+  "preferences_topicFilterKeywordsCount": "已设置 {count} 个关键词",
+  "@preferences_topicFilterKeywordsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_topicFilterKeywordsHint": "每行输入一个关键词",
+  "preferences_topicFilterKeywordsHelper": "仅匹配话题标题，不区分大小写",
   "preferences_autoPanguSpacing": "自动混排优化",
   "preferences_autoPanguSpacingDesc": "输入时自动插入中英文混排空格",
   "preferences_aiPostReview": "发帖前 AI 审核",

--- a/lib/l10n/modules/settings/settings_zh_HK.arb
+++ b/lib/l10n/modules/settings/settings_zh_HK.arb
@@ -46,7 +46,9 @@
     }
   },
   "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵詞",
-  "preferences_topicFilterKeywordsHelper": "只匹配話題標題，不區分大小寫",
+  "preferences_topicFilterKeywordsHelper": "只匹配話題標題，子串匹配，不區分大小寫",
+  "preferences_topicFilterWholeWord": "完整詞匹配",
+  "preferences_topicFilterWholeWordDesc": "開啟後英文關鍵詞不再匹配子串，如 ai 不會命中 Main thread；中文關鍵詞無影響",
   "preferences_autoPanguSpacing": "自動混排優化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發帖前 AI 審核",

--- a/lib/l10n/modules/settings/settings_zh_HK.arb
+++ b/lib/l10n/modules/settings/settings_zh_HK.arb
@@ -36,6 +36,17 @@
   "preferences_clipboardTopicLinkDetectionDesc": "回到應用時檢測剪貼板中的 Linux.do 話題鏈接，並在底部詢問是否打開",
   "preferences_clipboardTopicLink_detected": "檢測到剪貼板中的話題鏈接",
   "preferences_clipboardTopicLink_open": "打開",
+  "preferences_topicFilterKeywords": "標題關鍵詞過濾",
+  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵詞的話題，每行一個關鍵詞",
+  "preferences_topicFilterKeywordsEmpty": "未設定關鍵詞",
+  "preferences_topicFilterKeywordsCount": "已設定 {count} 個關鍵詞",
+  "@preferences_topicFilterKeywordsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵詞",
+  "preferences_topicFilterKeywordsHelper": "只匹配話題標題，不區分大小寫",
   "preferences_autoPanguSpacing": "自動混排優化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發帖前 AI 審核",

--- a/lib/l10n/modules/settings/settings_zh_TW.arb
+++ b/lib/l10n/modules/settings/settings_zh_TW.arb
@@ -36,6 +36,17 @@
   "preferences_clipboardTopicLinkDetectionDesc": "回到應用時偵測剪貼簿中的 Linux.do 話題連結，並在底部詢問是否開啟",
   "preferences_clipboardTopicLink_detected": "偵測到剪貼簿中的話題連結",
   "preferences_clipboardTopicLink_open": "開啟",
+  "preferences_topicFilterKeywords": "標題關鍵字過濾",
+  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵字的話題，每行一個關鍵字",
+  "preferences_topicFilterKeywordsEmpty": "未設定關鍵字",
+  "preferences_topicFilterKeywordsCount": "已設定 {count} 個關鍵字",
+  "@preferences_topicFilterKeywordsCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵字",
+  "preferences_topicFilterKeywordsHelper": "只比對話題標題，不區分大小寫",
   "preferences_autoPanguSpacing": "自動混排最佳化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發文前 AI 審核",

--- a/lib/l10n/modules/settings/settings_zh_TW.arb
+++ b/lib/l10n/modules/settings/settings_zh_TW.arb
@@ -46,7 +46,9 @@
     }
   },
   "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵字",
-  "preferences_topicFilterKeywordsHelper": "只比對話題標題，不區分大小寫",
+  "preferences_topicFilterKeywordsHelper": "只比對話題標題，子字串比對，不區分大小寫",
+  "preferences_topicFilterWholeWord": "完整詞比對",
+  "preferences_topicFilterWholeWordDesc": "開啟後英文關鍵字不再比對子字串，如 ai 不會命中 Main thread；中文關鍵字無影響",
   "preferences_autoPanguSpacing": "自動混排最佳化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發文前 AI 審核",

--- a/lib/l10n/modules/topic/topic_en.arb
+++ b/lib/l10n/modules/topic/topic_en.arb
@@ -102,5 +102,7 @@
   "topics_topicId": "Topic ID",
   "topics_topicIdHint": "e.g., 1095754",
   "topics_unreadTopics": "Unread topics",
-  "topics_viewNewTopics": "View {count} new or updated topics"
+  "topics_viewNewTopics": "View {count} new or updated topics",
+  "topic_keywordFilter_hiddenCount": "{count} topics hidden",
+  "topic_keywordFilter_manage": "Manage"
 }

--- a/lib/l10n/modules/topic/topic_zh.arb
+++ b/lib/l10n/modules/topic/topic_zh.arb
@@ -203,5 +203,14 @@
         "type": "int"
       }
     }
-  }
+  },
+  "topic_keywordFilter_hiddenCount": "已隐藏 {count} 条话题",
+  "@topic_keywordFilter_hiddenCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "topic_keywordFilter_manage": "管理"
 }

--- a/lib/l10n/modules/topic/topic_zh_HK.arb
+++ b/lib/l10n/modules/topic/topic_zh_HK.arb
@@ -202,5 +202,14 @@
         "type": "int"
       }
     }
-  }
+  },
+  "topic_keywordFilter_hiddenCount": "已隱藏 {count} 條話題",
+  "@topic_keywordFilter_hiddenCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "topic_keywordFilter_manage": "管理"
 }

--- a/lib/l10n/modules/topic/topic_zh_TW.arb
+++ b/lib/l10n/modules/topic/topic_zh_TW.arb
@@ -202,5 +202,14 @@
         "type": "int"
       }
     }
-  }
+  },
+  "topic_keywordFilter_hiddenCount": "已隱藏 {count} 則話題",
+  "@topic_keywordFilter_hiddenCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "topic_keywordFilter_manage": "管理"
 }

--- a/lib/pages/category_topics_page.dart
+++ b/lib/pages/category_topics_page.dart
@@ -6,7 +6,9 @@ import '../providers/discourse_providers.dart';
 import '../providers/selected_topic_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../utils/pagination_helper.dart';
+import '../utils/topic_keyword_filter.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
+import '../widgets/topic/keyword_filter_hint_bar.dart';
 import '../widgets/topic/sort_and_tags_bar.dart';
 import '../widgets/topic/topic_item_builder.dart';
 import '../widgets/topic/topic_notification_button.dart';
@@ -81,10 +83,51 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     }
   }
 
+  /// 关键词过滤场景下，loadMore 自动续加载的并发标志
+  bool _isAutoContinueLoading = false;
+
   void _onScroll() {
     if (_scrollController.position.pixels >=
         _scrollController.position.maxScrollExtent - 200) {
-      _loadMore();
+      _loadMoreWithAutoContinue();
+    }
+  }
+
+  /// 触发 loadMore；若关键词命中率高、可见增量不足，自动续加载至多 3 次。
+  Future<void> _loadMoreWithAutoContinue() async {
+    if (_isAutoContinueLoading) return;
+    _isAutoContinueLoading = true;
+    try {
+      final prefs = ref.read(preferencesProvider);
+      final keywords = prefs.normalizedFilterKeywords;
+      final wholeWord = prefs.topicFilterWholeWord;
+
+      var attempts = 0;
+      while (true) {
+        final (visBefore, _) = TopicKeywordFilter.apply(
+          _topics,
+          normalizedKeywords: keywords,
+          wholeWord: wholeWord,
+        );
+        await _loadMore();
+        if (!mounted) return;
+        final (visAfter, _) = TopicKeywordFilter.apply(
+          _topics,
+          normalizedKeywords: keywords,
+          wholeWord: wholeWord,
+        );
+        if (!TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: visBefore.length,
+          visibleAfter: visAfter.length,
+          hasMore: _hasMore,
+          attempts: attempts,
+        )) {
+          break;
+        }
+        attempts++;
+      }
+    } finally {
+      _isAutoContinueLoading = false;
     }
   }
 
@@ -467,15 +510,32 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
       );
     }
 
+    final keywords = ref.watch(
+      preferencesProvider.select((p) => p.normalizedFilterKeywords),
+    );
+    final wholeWord = ref.watch(
+      preferencesProvider.select((p) => p.topicFilterWholeWord),
+    );
+    final (visible, hidden) = TopicKeywordFilter.apply(
+      _topics,
+      normalizedKeywords: keywords,
+      wholeWord: wholeWord,
+    );
+    final hintOffset = hidden > 0 ? 1 : 0;
+
     return DesktopRefreshIndicator(
       onRefresh: _loadTopics,
       child: ListView.builder(
         controller: _scrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(12),
-        itemCount: _topics.length + 1,
+        itemCount: visible.length + hintOffset + 1,
         itemBuilder: (context, index) {
-          if (index >= _topics.length) {
+          if (hintOffset > 0 && index == 0) {
+            return KeywordFilterHintBar(hiddenCount: hidden);
+          }
+          final topicIndex = index - hintOffset;
+          if (topicIndex >= visible.length) {
             if (!_hasMore) {
               return Padding(
                 padding: const EdgeInsets.all(16.0),
@@ -524,7 +584,7 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
             );
           }
 
-          final topic = _topics[index];
+          final topic = visible[topicIndex];
           final enableLongPress = ref
               .watch(preferencesProvider)
               .longPressPreview;

--- a/lib/pages/tag_topics_page.dart
+++ b/lib/pages/tag_topics_page.dart
@@ -5,6 +5,8 @@ import '../providers/discourse_providers.dart';
 import '../providers/selected_topic_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../utils/pagination_helper.dart';
+import '../utils/topic_keyword_filter.dart';
+import '../widgets/topic/keyword_filter_hint_bar.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
 import '../widgets/topic/sort_and_tags_bar.dart';
 import '../widgets/topic/topic_item_builder.dart';
@@ -56,7 +58,6 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     _ascending = ref.read(topicSortAscendingProvider);
     _scrollController.addListener(_onScroll);
     _loadTopics();
-
   }
 
   @override
@@ -65,9 +66,51 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     super.dispose();
   }
 
+  /// 关键词过滤场景下，loadMore 自动续加载的并发标志
+  bool _isAutoContinueLoading = false;
+
   void _onScroll() {
-    if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 200) {
-      _loadMore();
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      _loadMoreWithAutoContinue();
+    }
+  }
+
+  /// 触发 loadMore；若关键词命中率高、可见增量不足，自动续加载至多 3 次。
+  Future<void> _loadMoreWithAutoContinue() async {
+    if (_isAutoContinueLoading) return;
+    _isAutoContinueLoading = true;
+    try {
+      final prefs = ref.read(preferencesProvider);
+      final keywords = prefs.normalizedFilterKeywords;
+      final wholeWord = prefs.topicFilterWholeWord;
+
+      var attempts = 0;
+      while (true) {
+        final (visBefore, _) = TopicKeywordFilter.apply(
+          _topics,
+          normalizedKeywords: keywords,
+          wholeWord: wholeWord,
+        );
+        await _loadMore();
+        if (!mounted) return;
+        final (visAfter, _) = TopicKeywordFilter.apply(
+          _topics,
+          normalizedKeywords: keywords,
+          wholeWord: wholeWord,
+        );
+        if (!TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: visBefore.length,
+          visibleAfter: visAfter.length,
+          hasMore: _hasMore,
+          attempts: attempts,
+        )) {
+          break;
+        }
+        attempts++;
+      }
+    } finally {
+      _isAutoContinueLoading = false;
     }
   }
 
@@ -85,14 +128,19 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
         period: _currentFilter.period,
         page: 0,
         order: _currentOrder.apiValue,
-        ascending: _currentOrder != TopicSortOrder.defaultOrder ? _ascending : null,
+        ascending: _currentOrder != TopicSortOrder.defaultOrder
+            ? _ascending
+            : null,
         subset: _currentFilter == TopicListFilter.newTopics
             ? _currentSubset.apiValue
             : null,
       );
 
       final result = _paginationHelper.processRefresh(
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
 
       if (mounted) {
@@ -123,14 +171,19 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
         period: _currentFilter.period,
         page: 0,
         order: _currentOrder.apiValue,
-        ascending: _currentOrder != TopicSortOrder.defaultOrder ? _ascending : null,
+        ascending: _currentOrder != TopicSortOrder.defaultOrder
+            ? _ascending
+            : null,
         subset: _currentFilter == TopicListFilter.newTopics
             ? _currentSubset.apiValue
             : null,
       );
 
       final result = _paginationHelper.processRefresh(
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
 
       if (mounted) {
@@ -162,7 +215,9 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
         period: _currentFilter.period,
         page: nextPage,
         order: _currentOrder.apiValue,
-        ascending: _currentOrder != TopicSortOrder.defaultOrder ? _ascending : null,
+        ascending: _currentOrder != TopicSortOrder.defaultOrder
+            ? _ascending
+            : null,
         subset: _currentFilter == TopicListFilter.newTopics
             ? _currentSubset.apiValue
             : null,
@@ -171,7 +226,10 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
       final currentState = PaginationState(items: _topics);
       final result = _paginationHelper.processLoadMore(
         currentState,
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
 
       if (mounted) {
@@ -252,11 +310,11 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
             icon: const Icon(Icons.search),
             onPressed: () => Navigator.push(
               context,
-              MaterialPageRoute(builder: (_) => SearchPage(
-                initialFilter: SearchFilter(
-                  tags: [widget.tagName],
+              MaterialPageRoute(
+                builder: (_) => SearchPage(
+                  initialFilter: SearchFilter(tags: [widget.tagName]),
                 ),
-              )),
+              ),
             ),
             tooltip: context.l10n.common_search,
           ),
@@ -287,16 +345,11 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
 
   Widget _buildBody(int? selectedTopicId) {
     if (_isLoading) {
-      return const TopicListSkeleton(
-        padding: EdgeInsets.all(12),
-      );
+      return const TopicListSkeleton(padding: EdgeInsets.all(12));
     }
 
     if (_error != null) {
-      return ErrorView(
-        error: _error!,
-        onRetry: _loadTopics,
-      );
+      return ErrorView(error: _error!, onRetry: _loadTopics);
     }
 
     if (_topics.isEmpty) {
@@ -304,7 +357,11 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.inbox_outlined, size: 48, color: Theme.of(context).colorScheme.outline),
+            Icon(
+              Icons.inbox_outlined,
+              size: 48,
+              color: Theme.of(context).colorScheme.outline,
+            ),
             const SizedBox(height: 12),
             Text(context.l10n.tagTopics_empty),
           ],
@@ -312,20 +369,40 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
       );
     }
 
+    final keywords = ref.watch(
+      preferencesProvider.select((p) => p.normalizedFilterKeywords),
+    );
+    final wholeWord = ref.watch(
+      preferencesProvider.select((p) => p.topicFilterWholeWord),
+    );
+    final (visible, hidden) = TopicKeywordFilter.apply(
+      _topics,
+      normalizedKeywords: keywords,
+      wholeWord: wholeWord,
+    );
+    final hintOffset = hidden > 0 ? 1 : 0;
+
     return DesktopRefreshIndicator(
       onRefresh: _loadTopics,
       child: ListView.builder(
         controller: _scrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(12),
-        itemCount: _topics.length + 1,
+        itemCount: visible.length + hintOffset + 1,
         itemBuilder: (context, index) {
-          if (index >= _topics.length) {
+          if (hintOffset > 0 && index == 0) {
+            return KeywordFilterHintBar(hiddenCount: hidden);
+          }
+          final topicIndex = index - hintOffset;
+          if (topicIndex >= visible.length) {
             if (!_hasMore) {
               return Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: Center(
-                  child: Text(context.l10n.common_noMore, style: const TextStyle(color: Colors.grey)),
+                  child: Text(
+                    context.l10n.common_noMore,
+                    style: const TextStyle(color: Colors.grey),
+                  ),
                 ),
               );
             }
@@ -341,11 +418,18 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Icon(Icons.refresh, size: 16, color: Theme.of(context).colorScheme.primary),
+                        Icon(
+                          Icons.refresh,
+                          size: 16,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
                         const SizedBox(width: 6),
                         Text(
                           context.l10n.common_loadFailedTapRetry,
-                          style: TextStyle(fontSize: 14, color: Theme.of(context).colorScheme.primary),
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
                         ),
                       ],
                     ),
@@ -359,8 +443,10 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
             );
           }
 
-          final topic = _topics[index];
-          final enableLongPress = ref.watch(preferencesProvider).longPressPreview;
+          final topic = visible[topicIndex];
+          final enableLongPress = ref
+              .watch(preferencesProvider)
+              .longPressPreview;
 
           return buildTopicItem(
             context: context,

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -21,6 +21,7 @@ import 'search_page.dart';
 import '../models/search_filter.dart';
 import '../widgets/common/notification_icon_button.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
+import '../widgets/topic/keyword_filter_hint_bar.dart';
 import '../widgets/topic/sort_and_tags_bar.dart';
 import '../widgets/topic/filter_dropdown.dart';
 import '../widgets/topic/topic_item_builder.dart';
@@ -30,6 +31,7 @@ import '../widgets/common/tag_selection_sheet.dart';
 import '../navigation/nav_action_bus.dart';
 import '../providers/app_state_refresher.dart';
 import '../providers/preferences_provider.dart';
+import '../utils/topic_keyword_filter.dart';
 import '../utils/responsive.dart';
 import '../widgets/layout/master_detail_layout.dart';
 import '../widgets/common/error_view.dart';
@@ -1184,6 +1186,9 @@ class _TopicListState extends ConsumerState<_TopicList>
   /// J/K 防抖：上次触发时间
   DateTime _lastKeyNavTime = DateTime(0);
 
+  /// 关键词过滤场景下，loadMore 自动续加载的并发标志
+  bool _isAutoContinueLoading = false;
+
   @override
   bool get wantKeepAlive => true;
 
@@ -1296,20 +1301,53 @@ class _TopicListState extends ConsumerState<_TopicList>
     setState(() => _keyboardFocusIndex = index);
   }
 
-  List<Topic> _filterTopicsByKeywords(
-    List<Topic> topics,
-    List<String> keywords,
-  ) {
-    final normalized = keywords
-        .map((keyword) => keyword.trim().toLowerCase())
-        .where((keyword) => keyword.isNotEmpty)
-        .toList();
-    if (normalized.isEmpty) return topics;
+  /// 触发 loadMore，并在关键词命中率高、可见增量不足时自动续加载，
+  /// 避免用户在话题列表里看到「滑到底但只多了 1-2 条」。
+  Future<void> _triggerLoadMore(int? providerKey) async {
+    if (_isAutoContinueLoading) return;
+    final notifier = ref.read(topicListProvider(providerKey).notifier);
+    if (!notifier.hasMore) {
+      // 单次仍然交给 notifier，让其内部状态/错误处理生效
+      await notifier.loadMore();
+      return;
+    }
 
-    return topics.where((topic) {
-      final title = topic.title.toLowerCase();
-      return !normalized.any(title.contains);
-    }).toList();
+    _isAutoContinueLoading = true;
+    try {
+      final prefs = ref.read(preferencesProvider);
+      final keywords = prefs.normalizedFilterKeywords;
+      final wholeWord = prefs.topicFilterWholeWord;
+
+      int countVisible() {
+        final async = ref.read(topicListProvider(providerKey));
+        final raw = async.value ?? const <Topic>[];
+        final (vis, _) = TopicKeywordFilter.apply(
+          raw,
+          normalizedKeywords: keywords,
+          wholeWord: wholeWord,
+        );
+        return vis.length;
+      }
+
+      var attempts = 0;
+      while (true) {
+        final before = countVisible();
+        await notifier.loadMore();
+        if (!mounted) return;
+        final after = countVisible();
+        if (!TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: before,
+          visibleAfter: after,
+          hasMore: notifier.hasMore,
+          attempts: attempts,
+        )) {
+          break;
+        }
+        attempts++;
+      }
+    } finally {
+      _isAutoContinueLoading = false;
+    }
   }
 
   void _openTopic(Topic topic) {
@@ -1383,11 +1421,21 @@ class _TopicListState extends ConsumerState<_TopicList>
     }
 
     final keywords = ref.watch(
-      preferencesProvider.select((p) => p.topicFilterKeywords),
+      preferencesProvider.select((p) => p.normalizedFilterKeywords),
     );
-    final visibleTopicsAsync = topicsAsync.whenData(
-      (topics) => _filterTopicsByKeywords(topics, keywords),
+    final wholeWord = ref.watch(
+      preferencesProvider.select((p) => p.topicFilterWholeWord),
     );
+    var hiddenCount = 0;
+    final visibleTopicsAsync = topicsAsync.whenData((topics) {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: keywords,
+        wholeWord: wholeWord,
+      );
+      hiddenCount = hidden;
+      return visible;
+    });
     final selectedTopicId = ref.watch(selectedTopicProvider).topicId;
 
     // 桌面端：注册 J/K/Enter 导航到主面板快捷键
@@ -1441,7 +1489,9 @@ class _TopicListState extends ConsumerState<_TopicList>
         final newTopicCount = incomingState.incomingCountForCategory(
           widget.categoryId,
         );
+        final hintOffset = hiddenCount > 0 ? 1 : 0;
         final newTopicOffset = hasNewTopics ? 1 : 0;
+        final headerOffset = hintOffset + newTopicOffset;
 
         return DesktopRefreshIndicator(
           refreshIndicatorKey: _refreshIndicatorKey,
@@ -1466,16 +1516,19 @@ class _TopicListState extends ConsumerState<_TopicList>
                 if (notification.depth == 0 &&
                     notification.metrics.pixels >=
                         notification.metrics.maxScrollExtent - 200) {
-                  ref.read(topicListProvider(providerKey).notifier).loadMore();
+                  _triggerLoadMore(providerKey);
                 }
                 return false;
               },
               child: ListView.builder(
                 physics: const AlwaysScrollableScrollPhysics(),
                 padding: const EdgeInsets.only(top: 8, bottom: 12),
-                itemCount: topics.length + newTopicOffset + 1,
+                itemCount: topics.length + headerOffset + 1,
                 itemBuilder: (context, index) {
-                  if (hasNewTopics && index == 0) {
+                  if (hintOffset > 0 && index == 0) {
+                    return KeywordFilterHintBar(hiddenCount: hiddenCount);
+                  }
+                  if (hasNewTopics && index == hintOffset) {
                     return _buildNewTopicIndicator(
                       context,
                       newTopicCount,
@@ -1483,7 +1536,7 @@ class _TopicListState extends ConsumerState<_TopicList>
                     );
                   }
 
-                  final topicIndex = index - newTopicOffset;
+                  final topicIndex = index - headerOffset;
                   if (topicIndex >= topics.length) {
                     final notifier = ref.watch(
                       topicListProvider(providerKey).notifier,

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -1296,6 +1296,22 @@ class _TopicListState extends ConsumerState<_TopicList>
     setState(() => _keyboardFocusIndex = index);
   }
 
+  List<Topic> _filterTopicsByKeywords(
+    List<Topic> topics,
+    List<String> keywords,
+  ) {
+    final normalized = keywords
+        .map((keyword) => keyword.trim().toLowerCase())
+        .where((keyword) => keyword.isNotEmpty)
+        .toList();
+    if (normalized.isEmpty) return topics;
+
+    return topics.where((topic) {
+      final title = topic.title.toLowerCase();
+      return !normalized.any(title.contains);
+    }).toList();
+  }
+
   void _openTopic(Topic topic) {
     final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
 
@@ -1366,6 +1382,12 @@ class _TopicListState extends ConsumerState<_TopicList>
           : (_cachedTopicsAsync ?? const AsyncValue.loading());
     }
 
+    final keywords = ref.watch(
+      preferencesProvider.select((p) => p.topicFilterKeywords),
+    );
+    final visibleTopicsAsync = topicsAsync.whenData(
+      (topics) => _filterTopicsByKeywords(topics, keywords),
+    );
     final selectedTopicId = ref.watch(selectedTopicProvider).topicId;
 
     // 桌面端：注册 J/K/Enter 导航到主面板快捷键
@@ -1373,10 +1395,11 @@ class _TopicListState extends ConsumerState<_TopicList>
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         _listShortcutBinding.register(context, {
-          ShortcutAction.nextItem: () => _moveKeyboardFocus(1, topicsAsync),
+          ShortcutAction.nextItem: () =>
+              _moveKeyboardFocus(1, visibleTopicsAsync),
           ShortcutAction.previousItem: () =>
-              _moveKeyboardFocus(-1, topicsAsync),
-          ShortcutAction.openItem: () => _openFocusedTopic(topicsAsync),
+              _moveKeyboardFocus(-1, visibleTopicsAsync),
+          ShortcutAction.openItem: () => _openFocusedTopic(visibleTopicsAsync),
         });
       });
     } else if (PlatformUtils.isDesktop) {
@@ -1386,7 +1409,7 @@ class _TopicListState extends ConsumerState<_TopicList>
       });
     }
 
-    return topicsAsync.when(
+    return visibleTopicsAsync.when(
       data: (topics) {
         if (topics.isEmpty) {
           return RefreshIndicator(

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -1525,15 +1525,15 @@ class _TopicListState extends ConsumerState<_TopicList>
                 padding: const EdgeInsets.only(top: 8, bottom: 12),
                 itemCount: topics.length + headerOffset + 1,
                 itemBuilder: (context, index) {
-                  if (hintOffset > 0 && index == 0) {
-                    return KeywordFilterHintBar(hiddenCount: hiddenCount);
-                  }
-                  if (hasNewTopics && index == hintOffset) {
+                  if (hasNewTopics && index == 0) {
                     return _buildNewTopicIndicator(
                       context,
                       newTopicCount,
                       providerKey,
                     );
+                  }
+                  if (hintOffset > 0 && index == newTopicOffset) {
+                    return KeywordFilterHintBar(hiddenCount: hiddenCount);
                   }
 
                   final topicIndex = index - headerOffset;

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
@@ -59,8 +60,18 @@ class AppPreferences {
   /// 自动识别剪贴板中的 Linux.do 话题链接
   final bool clipboardTopicLinkDetection;
 
-  /// 话题关键词过滤列表
+  /// 话题关键词过滤列表（原样存储，仅 trim 去重去空，保留用户输入大小写以便回显）
   final List<String> topicFilterKeywords;
+
+  /// 话题关键词过滤：是否启用完整词匹配（仅影响英文/数字等 word-char 关键词）
+  final bool topicFilterWholeWord;
+
+  /// 话题关键词过滤的归一化形式（lowercase），匹配时使用
+  late final List<String> normalizedFilterKeywords = List.unmodifiable(
+    topicFilterKeywords
+        .map((keyword) => keyword.trim().toLowerCase())
+        .where((keyword) => keyword.isNotEmpty),
+  );
 
   /// 崩溃日志上报（仅 Android）
   final bool crashlytics;
@@ -125,7 +136,7 @@ class AppPreferences {
   /// 底栏入口 id 列表（顺序即显示顺序）
   final List<String> bottomNavIds;
 
-  const AppPreferences({
+  AppPreferences({
     required this.autoPanguSpacing,
     required this.displayPanguSpacing,
     required this.anonymousShare,
@@ -136,6 +147,7 @@ class AppPreferences {
     required this.autoFillLogin,
     required this.clipboardTopicLinkDetection,
     required this.topicFilterKeywords,
+    this.topicFilterWholeWord = false,
     required this.crashlytics,
     required this.androidNativeCdp,
     required this.portraitLock,
@@ -170,6 +182,7 @@ class AppPreferences {
     bool? autoFillLogin,
     bool? clipboardTopicLinkDetection,
     List<String>? topicFilterKeywords,
+    bool? topicFilterWholeWord,
     bool? crashlytics,
     bool? androidNativeCdp,
     bool? portraitLock,
@@ -205,6 +218,7 @@ class AppPreferences {
       clipboardTopicLinkDetection:
           clipboardTopicLinkDetection ?? this.clipboardTopicLinkDetection,
       topicFilterKeywords: topicFilterKeywords ?? this.topicFilterKeywords,
+      topicFilterWholeWord: topicFilterWholeWord ?? this.topicFilterWholeWord,
       crashlytics: crashlytics ?? this.crashlytics,
       androidNativeCdp: androidNativeCdp ?? this.androidNativeCdp,
       portraitLock: portraitLock ?? this.portraitLock,
@@ -247,6 +261,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _clipboardTopicLinkDetectionKey =
       'pref_clipboard_topic_link_detection';
   static const String _topicFilterKeywordsKey = 'pref_topic_filter_keywords';
+  static const String _topicFilterWholeWordKey = 'pref_topic_filter_whole_word';
   static const String _crashlyticsKey = 'pref_crashlytics';
   static const String _androidNativeCdpKey = AndroidCdpFeature.prefKey;
   static const String _portraitLockKey = 'pref_portrait_lock';
@@ -292,6 +307,8 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
               _prefs.getBool(_clipboardTopicLinkDetectionKey) ?? false,
           topicFilterKeywords:
               _prefs.getStringList(_topicFilterKeywordsKey) ?? const [],
+          topicFilterWholeWord:
+              _prefs.getBool(_topicFilterWholeWordKey) ?? false,
           crashlytics: _prefs.getBool(_crashlyticsKey) ?? true,
           androidNativeCdp: _prefs.getBool(_androidNativeCdpKey) ?? false,
           portraitLock: _prefs.getBool(_portraitLockKey) ?? false,
@@ -381,13 +398,24 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   }
 
   Future<void> setTopicFilterKeywords(List<String> keywords) async {
-    final normalized = keywords
+    final deduped = keywords
         .map((keyword) => keyword.trim())
         .where((keyword) => keyword.isNotEmpty)
         .toSet()
         .toList();
-    state = state.copyWith(topicFilterKeywords: normalized);
-    await _prefs.setStringList(_topicFilterKeywordsKey, normalized);
+    final current = state.topicFilterKeywords;
+    if (deduped.length == current.length &&
+        const ListEquality<String>().equals(deduped, current)) {
+      return;
+    }
+    state = state.copyWith(topicFilterKeywords: deduped);
+    await _prefs.setStringList(_topicFilterKeywordsKey, deduped);
+  }
+
+  Future<void> setTopicFilterWholeWord(bool enabled) async {
+    if (state.topicFilterWholeWord == enabled) return;
+    state = state.copyWith(topicFilterWholeWord: enabled);
+    await _prefs.setBool(_topicFilterWholeWordKey, enabled);
   }
 
   Future<void> setCrashlytics(bool enabled) async {

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -59,6 +59,9 @@ class AppPreferences {
   /// 自动识别剪贴板中的 Linux.do 话题链接
   final bool clipboardTopicLinkDetection;
 
+  /// 话题关键词过滤列表
+  final List<String> topicFilterKeywords;
+
   /// 崩溃日志上报（仅 Android）
   final bool crashlytics;
 
@@ -132,6 +135,7 @@ class AppPreferences {
     required this.shareImageThemeIndex,
     required this.autoFillLogin,
     required this.clipboardTopicLinkDetection,
+    required this.topicFilterKeywords,
     required this.crashlytics,
     required this.androidNativeCdp,
     required this.portraitLock,
@@ -165,6 +169,7 @@ class AppPreferences {
     int? shareImageThemeIndex,
     bool? autoFillLogin,
     bool? clipboardTopicLinkDetection,
+    List<String>? topicFilterKeywords,
     bool? crashlytics,
     bool? androidNativeCdp,
     bool? portraitLock,
@@ -199,6 +204,7 @@ class AppPreferences {
       autoFillLogin: autoFillLogin ?? this.autoFillLogin,
       clipboardTopicLinkDetection:
           clipboardTopicLinkDetection ?? this.clipboardTopicLinkDetection,
+      topicFilterKeywords: topicFilterKeywords ?? this.topicFilterKeywords,
       crashlytics: crashlytics ?? this.crashlytics,
       androidNativeCdp: androidNativeCdp ?? this.androidNativeCdp,
       portraitLock: portraitLock ?? this.portraitLock,
@@ -240,6 +246,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _autoFillLoginKey = 'pref_auto_fill_login';
   static const String _clipboardTopicLinkDetectionKey =
       'pref_clipboard_topic_link_detection';
+  static const String _topicFilterKeywordsKey = 'pref_topic_filter_keywords';
   static const String _crashlyticsKey = 'pref_crashlytics';
   static const String _androidNativeCdpKey = AndroidCdpFeature.prefKey;
   static const String _portraitLockKey = 'pref_portrait_lock';
@@ -283,6 +290,8 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           autoFillLogin: _prefs.getBool(_autoFillLoginKey) ?? true,
           clipboardTopicLinkDetection:
               _prefs.getBool(_clipboardTopicLinkDetectionKey) ?? false,
+          topicFilterKeywords:
+              _prefs.getStringList(_topicFilterKeywordsKey) ?? const [],
           crashlytics: _prefs.getBool(_crashlyticsKey) ?? true,
           androidNativeCdp: _prefs.getBool(_androidNativeCdpKey) ?? false,
           portraitLock: _prefs.getBool(_portraitLockKey) ?? false,
@@ -369,6 +378,16 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   Future<void> setClipboardTopicLinkDetection(bool enabled) async {
     state = state.copyWith(clipboardTopicLinkDetection: enabled);
     await _prefs.setBool(_clipboardTopicLinkDetectionKey, enabled);
+  }
+
+  Future<void> setTopicFilterKeywords(List<String> keywords) async {
+    final normalized = keywords
+        .map((keyword) => keyword.trim())
+        .where((keyword) => keyword.isNotEmpty)
+        .toSet()
+        .toList();
+    state = state.copyWith(topicFilterKeywords: normalized);
+    await _prefs.setStringList(_topicFilterKeywordsKey, normalized);
   }
 
   Future<void> setCrashlytics(bool enabled) async {

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -51,6 +51,21 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
               .read(preferencesProvider.notifier)
               .setClipboardTopicLinkDetection(v),
         ),
+        ActionModel(
+          id: 'topicFilterKeywords',
+          title: l10n.preferences_topicFilterKeywords,
+          subtitle: l10n.preferences_topicFilterKeywordsDesc,
+          icon: Icons.filter_alt_off_rounded,
+          getDynamicSubtitle: (ref) {
+            final count = ref
+                .watch(preferencesProvider)
+                .topicFilterKeywords
+                .length;
+            if (count == 0) return l10n.preferences_topicFilterKeywordsEmpty;
+            return l10n.preferences_topicFilterKeywordsCount(count);
+          },
+          onTap: (context, ref) => _showTopicFilterKeywordsDialog(context, ref),
+        ),
         SwitchModel(
           id: 'cfClearanceRefresh',
           title: l10n.preferences_cfClearanceRefresh,
@@ -179,6 +194,94 @@ Future<void> _showAiPostReviewModelSheet(
       .setAiPostReviewModelKey(
         buildAiModelKey(selected.provider.id, selected.model.id),
       );
+}
+
+Future<void> _showTopicFilterKeywordsDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final keywords = ref.read(preferencesProvider).topicFilterKeywords;
+  final result = await showAppDialog<List<String>>(
+    context: context,
+    builder: (dialogContext) =>
+        _TopicFilterKeywordsDialog(initialKeywords: keywords),
+  );
+  if (result == null || !context.mounted) return;
+  await ref.read(preferencesProvider.notifier).setTopicFilterKeywords(result);
+}
+
+class _TopicFilterKeywordsDialog extends StatefulWidget {
+  final List<String> initialKeywords;
+
+  const _TopicFilterKeywordsDialog({required this.initialKeywords});
+
+  @override
+  State<_TopicFilterKeywordsDialog> createState() =>
+      _TopicFilterKeywordsDialogState();
+}
+
+class _TopicFilterKeywordsDialogState
+    extends State<_TopicFilterKeywordsDialog> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(
+      text: widget.initialKeywords.join('\n'),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
+    return AlertDialog(
+      title: Text(l10n.preferences_topicFilterKeywords),
+      content: SizedBox(
+        width: 420,
+        child: TextField(
+          controller: _controller,
+          decoration: InputDecoration(
+            hintText: l10n.preferences_topicFilterKeywordsHint,
+            helperText: l10n.preferences_topicFilterKeywordsHelper,
+            border: const OutlineInputBorder(),
+          ),
+          keyboardType: TextInputType.multiline,
+          minLines: 5,
+          maxLines: 10,
+          autofocus: true,
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.common_cancel),
+        ),
+        TextButton(
+          onPressed: () => _controller.clear(),
+          child: Text(l10n.common_clear),
+        ),
+        FilledButton(
+          onPressed: () {
+            final keywords = _controller.text
+                .split('\n')
+                .map((keyword) => keyword.trim())
+                .where((keyword) => keyword.isNotEmpty)
+                .toList();
+            Navigator.pop(context, keywords);
+          },
+          child: Text(l10n.common_confirm),
+        ),
+      ],
+    );
+  }
 }
 
 void _showStickerBaseUrlDialog(BuildContext context, WidgetRef ref) {

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -61,10 +61,10 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
                 .watch(preferencesProvider)
                 .topicFilterKeywords
                 .length;
-            if (count == 0) return l10n.preferences_topicFilterKeywordsEmpty;
+            if (count == 0) return null;
             return l10n.preferences_topicFilterKeywordsCount(count);
           },
-          onTap: (context, ref) => _showTopicFilterKeywordsDialog(context, ref),
+          onTap: (context, ref) => showTopicFilterKeywordsDialog(context, ref),
         ),
         SwitchModel(
           id: 'cfClearanceRefresh',
@@ -196,24 +196,35 @@ Future<void> _showAiPostReviewModelSheet(
       );
 }
 
-Future<void> _showTopicFilterKeywordsDialog(
+typedef _TopicFilterDialogResult = ({List<String> keywords, bool wholeWord});
+
+/// 打开「标题关键词过滤」编辑弹窗（公共入口，hint bar 与设置项均复用）。
+Future<void> showTopicFilterKeywordsDialog(
   BuildContext context,
   WidgetRef ref,
 ) async {
-  final keywords = ref.read(preferencesProvider).topicFilterKeywords;
-  final result = await showAppDialog<List<String>>(
+  final prefs = ref.read(preferencesProvider);
+  final result = await showAppDialog<_TopicFilterDialogResult>(
     context: context,
-    builder: (dialogContext) =>
-        _TopicFilterKeywordsDialog(initialKeywords: keywords),
+    builder: (dialogContext) => _TopicFilterKeywordsDialog(
+      initialKeywords: prefs.topicFilterKeywords,
+      initialWholeWord: prefs.topicFilterWholeWord,
+    ),
   );
   if (result == null || !context.mounted) return;
-  await ref.read(preferencesProvider.notifier).setTopicFilterKeywords(result);
+  final notifier = ref.read(preferencesProvider.notifier);
+  await notifier.setTopicFilterKeywords(result.keywords);
+  await notifier.setTopicFilterWholeWord(result.wholeWord);
 }
 
 class _TopicFilterKeywordsDialog extends StatefulWidget {
   final List<String> initialKeywords;
+  final bool initialWholeWord;
 
-  const _TopicFilterKeywordsDialog({required this.initialKeywords});
+  const _TopicFilterKeywordsDialog({
+    required this.initialKeywords,
+    required this.initialWholeWord,
+  });
 
   @override
   State<_TopicFilterKeywordsDialog> createState() =>
@@ -223,6 +234,7 @@ class _TopicFilterKeywordsDialog extends StatefulWidget {
 class _TopicFilterKeywordsDialogState
     extends State<_TopicFilterKeywordsDialog> {
   late final TextEditingController _controller;
+  late bool _wholeWord;
 
   @override
   void initState() {
@@ -230,6 +242,7 @@ class _TopicFilterKeywordsDialogState
     _controller = TextEditingController(
       text: widget.initialKeywords.join('\n'),
     );
+    _wholeWord = widget.initialWholeWord;
   }
 
   @override
@@ -246,27 +259,47 @@ class _TopicFilterKeywordsDialogState
       title: Text(l10n.preferences_topicFilterKeywords),
       content: SizedBox(
         width: 420,
-        child: TextField(
-          controller: _controller,
-          decoration: InputDecoration(
-            hintText: l10n.preferences_topicFilterKeywordsHint,
-            helperText: l10n.preferences_topicFilterKeywordsHelper,
-            border: const OutlineInputBorder(),
-          ),
-          keyboardType: TextInputType.multiline,
-          minLines: 5,
-          maxLines: 10,
-          autofocus: true,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                icon: const Icon(Icons.clear_all_rounded, size: 18),
+                label: Text(l10n.common_clear),
+                onPressed: () => _controller.clear(),
+              ),
+            ),
+            TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: l10n.preferences_topicFilterKeywordsHint,
+                helperText: l10n.preferences_topicFilterKeywordsHelper,
+                helperMaxLines: 2,
+                border: const OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.multiline,
+              minLines: 5,
+              maxLines: 10,
+              autofocus: true,
+            ),
+            const SizedBox(height: 8),
+            SwitchListTile.adaptive(
+              contentPadding: EdgeInsets.zero,
+              dense: true,
+              title: Text(l10n.preferences_topicFilterWholeWord),
+              subtitle: Text(l10n.preferences_topicFilterWholeWordDesc),
+              value: _wholeWord,
+              onChanged: (v) => setState(() => _wholeWord = v),
+            ),
+          ],
         ),
       ),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: Text(l10n.common_cancel),
-        ),
-        TextButton(
-          onPressed: () => _controller.clear(),
-          child: Text(l10n.common_clear),
         ),
         FilledButton(
           onPressed: () {
@@ -275,7 +308,7 @@ class _TopicFilterKeywordsDialogState
                 .map((keyword) => keyword.trim())
                 .where((keyword) => keyword.isNotEmpty)
                 .toList();
-            Navigator.pop(context, keywords);
+            Navigator.pop(context, (keywords: keywords, wholeWord: _wholeWord));
           },
           child: Text(l10n.common_confirm),
         ),

--- a/lib/utils/topic_keyword_filter.dart
+++ b/lib/utils/topic_keyword_filter.dart
@@ -1,0 +1,100 @@
+import '../models/topic.dart';
+
+/// 标题关键词过滤工具。
+///
+/// 关键词在 [PreferencesNotifier] 保存时已 trim + 去重；调用方需传入
+/// `normalizedFilterKeywords`（已 lowercase）以避免重复归一化开销。
+class TopicKeywordFilter {
+  TopicKeywordFilter._();
+
+  /// 应用关键词过滤，返回 `(可见列表, 隐藏数量)`。
+  ///
+  /// - [normalizedKeywords] 必须是已 trim + lowercase + 去空的列表。
+  /// - [wholeWord] 为 true 时：对纯 ASCII word-char 关键词（如 `ai`、`db_2`）
+  ///   使用单词边界（`\b`）匹配；对含非 word-char（如中文）的关键词依然走子串
+  ///   匹配——Dart 的 `\b` 不在两个非 word-char 之间产生边界，强制套 `\b`
+  ///   会让 `\b中文\b` 几乎不可能命中。
+  static (List<Topic> visible, int hiddenCount) apply(
+    List<Topic> topics, {
+    required List<String> normalizedKeywords,
+    required bool wholeWord,
+  }) {
+    if (normalizedKeywords.isEmpty || topics.isEmpty) {
+      return (topics, 0);
+    }
+
+    final substrings = <String>[];
+    final regexes = <RegExp>[];
+    for (final keyword in normalizedKeywords) {
+      if (wholeWord && _isAsciiWordOnly(keyword)) {
+        regexes.add(
+          RegExp(r'\b' + RegExp.escape(keyword) + r'\b', caseSensitive: false),
+        );
+      } else {
+        substrings.add(keyword);
+      }
+    }
+
+    final visible = <Topic>[];
+    var hidden = 0;
+    for (final topic in topics) {
+      if (_matches(topic.title, substrings, regexes)) {
+        hidden++;
+      } else {
+        visible.add(topic);
+      }
+    }
+    return (visible, hidden);
+  }
+
+  static bool _matches(
+    String title,
+    List<String> substrings,
+    List<RegExp> regexes,
+  ) {
+    if (substrings.isNotEmpty) {
+      final lower = title.toLowerCase();
+      for (final keyword in substrings) {
+        if (lower.contains(keyword)) return true;
+      }
+    }
+    for (final re in regexes) {
+      if (re.hasMatch(title)) return true;
+    }
+    return false;
+  }
+
+  /// 关键词是否全部由 ASCII 字母 / 数字 / 下划线组成（`\w` 等价集）。
+  static bool _isAsciiWordOnly(String s) {
+    if (s.isEmpty) return false;
+    for (final code in s.codeUnits) {
+      final isWord =
+          (code >= 0x30 && code <= 0x39) || // 0-9
+          (code >= 0x41 && code <= 0x5A) || // A-Z
+          (code >= 0x61 && code <= 0x7A) || // a-z
+          code == 0x5F; // _
+      if (!isWord) return false;
+    }
+    return true;
+  }
+
+  /// loadMore 完成后判断是否需要自动再加载一次。
+  ///
+  /// 当关键词命中率高时，单次 loadMore 实际新增可见条目很少，会让用户感到
+  /// "划到底什么也没出来"。本判定在以下都满足时返回 true：
+  /// - 仍有更多页（[hasMore]）
+  /// - 本次 loadMore 的可见增量小于 [threshold]
+  /// - 自动续加载次数未超 [maxAttempts]
+  static bool shouldAutoLoadMore({
+    required int visibleBefore,
+    required int visibleAfter,
+    required bool hasMore,
+    required int attempts,
+    int threshold = 5,
+    int maxAttempts = 3,
+  }) {
+    if (!hasMore) return false;
+    if (attempts >= maxAttempts) return false;
+    return (visibleAfter - visibleBefore) < threshold;
+  }
+}

--- a/lib/widgets/topic/keyword_filter_hint_bar.dart
+++ b/lib/widgets/topic/keyword_filter_hint_bar.dart
@@ -4,9 +4,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/s.dart';
 import '../../settings/definitions/preferences_defs.dart';
 
-/// 话题列表顶部的「关键词过滤」提示条。
+/// 话题列表顶部的「关键词过滤」提示。
 ///
-/// 仅在有话题被隐藏时显示。点击右侧「管理」按钮打开关键词编辑弹窗。
+/// 仅在有话题被隐藏时显示。整行可点击，打开关键词编辑弹窗。
+/// 形态与 `_buildNewTopicIndicator` 保持一致（同样的胶囊容器、margin、圆角），
+/// 但使用 surfaceVariant 系颜色而非 primaryContainer，刻意做成次要状态层级，
+/// 与新话题 CTA 堆叠时形成「主操作 + 次要状态」的视觉层次。
 class KeywordFilterHintBar extends ConsumerWidget {
   final int hiddenCount;
 
@@ -17,42 +20,49 @@ class KeywordFilterHintBar extends ConsumerWidget {
     if (hiddenCount <= 0) return const SizedBox.shrink();
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    final mutedColor = theme.colorScheme.onSurfaceVariant;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
       child: Material(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
           onTap: () => showTopicFilterKeywordsDialog(context, ref),
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(12, 6, 8, 6),
+            padding: const EdgeInsets.symmetric(vertical: 6),
             child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
               children: [
                 Icon(
-                  Icons.filter_alt_off_rounded,
-                  size: 16,
-                  color: theme.colorScheme.onSurfaceVariant,
+                  Icons.visibility_off_outlined,
+                  size: 14,
+                  color: mutedColor,
                 ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    l10n.topic_keywordFilter_hiddenCount(hiddenCount),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
+                const SizedBox(width: 6),
+                Text(
+                  l10n.topic_keywordFilter_hiddenCount(hiddenCount),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: mutedColor,
+                    fontSize: 12,
                   ),
                 ),
-                TextButton(
-                  style: TextButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
-                    minimumSize: const Size(0, 28),
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    visualDensity: VisualDensity.compact,
+                Text(
+                  '  ·  ',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: mutedColor.withValues(alpha: 0.5),
+                    fontSize: 12,
                   ),
-                  onPressed: () => showTopicFilterKeywordsDialog(context, ref),
-                  child: Text(l10n.topic_keywordFilter_manage),
+                ),
+                Text(
+                  l10n.topic_keywordFilter_manage,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                  ),
                 ),
               ],
             ),

--- a/lib/widgets/topic/keyword_filter_hint_bar.dart
+++ b/lib/widgets/topic/keyword_filter_hint_bar.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../l10n/s.dart';
+import '../../settings/definitions/preferences_defs.dart';
+
+/// 话题列表顶部的「关键词过滤」提示条。
+///
+/// 仅在有话题被隐藏时显示。点击右侧「管理」按钮打开关键词编辑弹窗。
+class KeywordFilterHintBar extends ConsumerWidget {
+  final int hiddenCount;
+
+  const KeywordFilterHintBar({super.key, required this.hiddenCount});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (hiddenCount <= 0) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Material(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: () => showTopicFilterKeywordsDialog(context, ref),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(12, 6, 8, 6),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.filter_alt_off_rounded,
+                  size: 16,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    l10n.topic_keywordFilter_hiddenCount(hiddenCount),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  style: TextButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    minimumSize: const Size(0, 28),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  onPressed: () => showTopicFilterKeywordsDialog(context, ref),
+                  child: Text(l10n.topic_keywordFilter_manage),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/utils/topic_keyword_filter_test.dart
+++ b/test/utils/topic_keyword_filter_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/topic.dart';
+import 'package:fluxdo/utils/topic_keyword_filter.dart';
+
+Topic _topic(int id, String title) => Topic(
+  id: id,
+  title: title,
+  slug: 'topic-$id',
+  postsCount: 1,
+  replyCount: 0,
+  views: 0,
+  likeCount: 0,
+  categoryId: '1',
+);
+
+void main() {
+  group('TopicKeywordFilter.apply', () {
+    final topics = [
+      _topic(1, 'Main thread for the AI release'),
+      _topic(2, '今天的水帖合集'),
+      _topic(3, 'Available tools'),
+      _topic(4, 'Hello world'),
+      _topic(5, 'AI 助手测试'),
+    ];
+
+    test('空关键词返回原列表，hidden 为 0', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const [],
+        wholeWord: false,
+      );
+      expect(visible, topics);
+      expect(hidden, 0);
+    });
+
+    test('空话题列表直接返回，hidden 为 0', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        const [],
+        normalizedKeywords: const ['ai'],
+        wholeWord: false,
+      );
+      expect(visible, isEmpty);
+      expect(hidden, 0);
+    });
+
+    test('子串匹配不区分大小写', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const ['ai'],
+        wholeWord: false,
+      );
+      // 子串模式下 "ai" 命中 Main、Available、AI、AI 助手 → 4 条被过滤
+      // 仅 id=2 "今天的水帖合集" 与 id=4 "Hello world" 留下
+      // 等等：Hello world 不含 ai，Main 含 ai (m-a-i-n)，Available 含 ai (av-ai-lable)
+      // AI release 含 ai，AI 助手 含 ai
+      expect(visible.map((t) => t.id), [2, 4]);
+      expect(hidden, 3);
+    });
+
+    test('中文关键词命中', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const ['水帖'],
+        wholeWord: false,
+      );
+      expect(visible.map((t) => t.id), [1, 3, 4, 5]);
+      expect(hidden, 1);
+    });
+
+    test('多关键词任一命中即过滤', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const ['ai', '水帖'],
+        wholeWord: false,
+      );
+      // 命中：1(ai)、2(水帖)、3(ai)、5(ai) → 剩 4
+      expect(visible.map((t) => t.id), [4]);
+      expect(hidden, 4);
+    });
+
+    test('完整词模式下英文不再误匹配子串', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const ['ai'],
+        wholeWord: true,
+      );
+      // 完整词下 "ai" 应命中 "AI release"（独立的 AI 词）和 "AI 助手"
+      // 而不命中 "Main"（mai 是 main 的子串）和 "Available"（ai 是 av-ai-lable 的子串）
+      expect(visible.map((t) => t.id), containsAll([2, 3, 4]));
+      expect(visible.map((t) => t.id), isNot(contains(1)));
+      expect(visible.map((t) => t.id), isNot(contains(5)));
+      expect(hidden, 2);
+    });
+
+    test('完整词模式对中文关键词等价于子串', () {
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        topics,
+        normalizedKeywords: const ['水帖'],
+        wholeWord: true,
+      );
+      expect(visible.map((t) => t.id), [1, 3, 4, 5]);
+      expect(hidden, 1);
+    });
+
+    test('包含特殊正则字符的关键词被转义', () {
+      final special = [
+        _topic(10, 'Use a.b.c notation'),
+        _topic(11, 'No dots here'),
+      ];
+      final (visible, hidden) = TopicKeywordFilter.apply(
+        special,
+        normalizedKeywords: const ['a.b.c'],
+        wholeWord: false,
+      );
+      expect(visible.map((t) => t.id), [11]);
+      expect(hidden, 1);
+    });
+  });
+
+  group('TopicKeywordFilter.shouldAutoLoadMore', () {
+    test('hasMore 为 false 时不续加载', () {
+      expect(
+        TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: 5,
+          visibleAfter: 5,
+          hasMore: false,
+          attempts: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('达到 maxAttempts 时不续加载', () {
+      expect(
+        TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: 0,
+          visibleAfter: 0,
+          hasMore: true,
+          attempts: 3,
+        ),
+        isFalse,
+      );
+    });
+
+    test('可见增量足够时不续加载', () {
+      expect(
+        TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: 10,
+          visibleAfter: 25,
+          hasMore: true,
+          attempts: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('可见增量不足且未达上限且仍有更多时续加载', () {
+      expect(
+        TopicKeywordFilter.shouldAutoLoadMore(
+          visibleBefore: 10,
+          visibleAfter: 12,
+          hasMore: true,
+          attempts: 1,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
  ## 目的

  该功能用于帮助用户隐藏不感兴趣的话题内容，提升话题列表浏览效率和个性化体验。


  ## Summary

  - 添加话题标题关键词过滤功能。
  - 新增对应偏好设置与多语言文案。
  - 将关键词过滤接入话题列表展示逻辑。