### PR TITLE
支持 Boost 举报功能

### DIFF
--- a/lib/l10n/modules/post/post_en.arb
+++ b/lib/l10n/modules/post/post_en.arb
@@ -5,6 +5,7 @@
   "boost_deleteFailed": "Failed to delete boost",
   "boost_deleted": "Boost deleted",
   "boost_failed": "Failed to send boost",
+  "boost_flagAlreadyReported": "You have already reported this boost",
   "boost_flagSubmitted": "Flag submitted",
   "boost_flagTitle": "Flag Boost",
   "boost_limitReached": "Boost limit reached for this post",

--- a/lib/l10n/modules/post/post_zh.arb
+++ b/lib/l10n/modules/post/post_zh.arb
@@ -5,6 +5,7 @@
   "boost_deleteFailed": "Boost 删除失败",
   "boost_deleted": "Boost 已删除",
   "boost_failed": "Boost 发送失败",
+  "boost_flagAlreadyReported": "你已经举报过这条 Boost",
   "boost_flagSubmitted": "举报已提交",
   "boost_flagTitle": "举报 Boost",
   "boost_limitReached": "此帖子的 Boost 数量已达上限",

--- a/lib/l10n/modules/post/post_zh_HK.arb
+++ b/lib/l10n/modules/post/post_zh_HK.arb
@@ -40,6 +40,7 @@
   },
   "post_flagDescriptionHint": "請描述具體問題...",
   "post_flagFailed": "舉報失敗，請稍後重試",
+  "boost_flagAlreadyReported": "你已經舉報過這條 Boost",
   "post_flagMessageUser": "向 @{username} 發送消息",
   "@post_flagMessageUser": {
     "placeholders": {

--- a/lib/l10n/modules/post/post_zh_TW.arb
+++ b/lib/l10n/modules/post/post_zh_TW.arb
@@ -40,6 +40,7 @@
   },
   "post_flagDescriptionHint": "請描述具體問題...",
   "post_flagFailed": "舉報失敗，請稍後重試",
+  "boost_flagAlreadyReported": "你已經舉報過這條 Boost",
   "post_flagMessageUser": "向 @{username} 傳送訊息",
   "@post_flagMessageUser": {
     "placeholders": {

--- a/lib/services/discourse/_posts.dart
+++ b/lib/services/discourse/_posts.dart
@@ -437,16 +437,20 @@ mixin _PostsMixin on _DiscourseServiceBase {
 
   /// 举报 Boost
   Future<void> flagBoost(int boostId, {required int flagTypeId, String? message}) async {
-    final data = <String, dynamic>{
-      'flag_type_id': flagTypeId,
-    };
-    if (message != null && message.isNotEmpty) {
-      data['message'] = message;
+    try {
+      final data = <String, dynamic>{
+        'flag_type_id': flagTypeId,
+      };
+      if (message != null && message.isNotEmpty) {
+        data['message'] = message;
+      }
+      await _dio.post(
+        '/discourse-boosts/boosts/$boostId/flags',
+        data: data,
+        options: Options(contentType: Headers.formUrlEncodedContentType),
+      );
+    } on DioException catch (e) {
+      _throwApiError(e);
     }
-    await _dio.post(
-      '/discourse-boosts/boosts/$boostId/flags',
-      data: data,
-      options: Options(contentType: Headers.formUrlEncodedContentType),
-    );
   }
 }

--- a/lib/widgets/post/post_item/widgets/boost_flag_sheet.dart
+++ b/lib/widgets/post/post_item/widgets/boost_flag_sheet.dart
@@ -1,0 +1,430 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+
+import '../../../../l10n/s.dart';
+import '../../../../models/topic.dart';
+import '../../../../services/preloaded_data_service.dart';
+import '../../../../services/toast_service.dart';
+import '../../../../utils/url_helper.dart';
+
+typedef BoostFlagTypesLoader = Future<List<FlagType>> Function();
+typedef BoostFlagSubmitter =
+    Future<void> Function(int flagTypeId, String? message);
+
+bool boostAlreadyReportedByCurrentUser({
+  required Boost boost,
+  required String? currentUsername,
+}) {
+  if (currentUsername == null || currentUsername.isEmpty) {
+    return false;
+  }
+  if (currentUsername == boost.user.username) {
+    return false;
+  }
+  return (boost.userFlagStatus ?? 0) > 0;
+}
+
+bool canDeleteBoostAction({
+  required Boost boost,
+  required String? currentUsername,
+}) {
+  if (currentUsername == null || currentUsername.isEmpty) {
+    return false;
+  }
+  final isOwn = currentUsername == boost.user.username;
+  return isOwn || boost.canDelete;
+}
+
+bool canFlagBoostAction({
+  required Boost boost,
+  required String? currentUsername,
+}) {
+  if (currentUsername == null || currentUsername.isEmpty) {
+    return false;
+  }
+  if (boostAlreadyReportedByCurrentUser(
+    boost: boost,
+    currentUsername: currentUsername,
+  )) {
+    return false;
+  }
+  final isOwn = currentUsername == boost.user.username;
+  return !isOwn && boost.canFlag;
+}
+
+bool canOpenBoostActionMenu({
+  required Boost boost,
+  required String? currentUsername,
+}) {
+  return canDeleteBoostAction(
+        boost: boost,
+        currentUsername: currentUsername,
+      ) ||
+      canFlagBoostAction(boost: boost, currentUsername: currentUsername);
+}
+
+List<FlagType> filterBoostFlagTypes({
+  required List<FlagType> allFlagTypes,
+  List<String>? availableFlags,
+}) {
+  final enabledTypes = allFlagTypes.where((f) => f.isFlag && f.enabled).toList();
+  if (availableFlags == null || availableFlags.isEmpty) {
+    return const [];
+  }
+  final allowedKeys = availableFlags
+      ?.map((flag) => flag.trim())
+      .where((flag) => flag.isNotEmpty)
+      .toSet();
+
+  List<FlagType> sortTypes(List<FlagType> types) {
+    final sorted = [...types];
+    sorted.sort((a, b) => a.position.compareTo(b.position));
+    return sorted;
+  }
+
+  if (allowedKeys == null || allowedKeys.isEmpty) {
+    return const [];
+  }
+
+  final baseTypes = enabledTypes.isNotEmpty ? enabledTypes : FlagType.defaultTypes;
+  final matchedTypes = baseTypes
+      .where((type) => allowedKeys.contains(type.nameKey))
+      .toList();
+  if (matchedTypes.isNotEmpty) {
+    return sortTypes(matchedTypes);
+  }
+
+  return sortTypes(
+    FlagType.defaultTypes
+        .where((type) => allowedKeys.contains(type.nameKey))
+        .toList(),
+  );
+}
+
+/// 举报 Boost 底部弹窗
+class BoostFlagSheet extends StatefulWidget {
+  final Boost boost;
+  final BoostFlagTypesLoader? loadFlagTypes;
+  final BoostFlagSubmitter? submitFlag;
+  final VoidCallback? onSuccess;
+
+  const BoostFlagSheet({
+    super.key,
+    required this.boost,
+    this.loadFlagTypes,
+    this.submitFlag,
+    this.onSuccess,
+  });
+
+  @override
+  State<BoostFlagSheet> createState() => _BoostFlagSheetState();
+}
+
+class _BoostFlagSheetState extends State<BoostFlagSheet> {
+  FlagType? _selectedType;
+  final _messageController = TextEditingController();
+  bool _isSubmitting = false;
+  List<FlagType> _flagTypes = [];
+  bool _isLoading = true;
+
+  List<FlagType> get _notifyUserTypes =>
+      _flagTypes.where((f) => f.nameKey == 'notify_user').toList();
+  List<FlagType> get _moderatorTypes =>
+      _flagTypes.where((f) => f.nameKey != 'notify_user').toList();
+
+  String _replaceDescription(String description) {
+    return description
+        .replaceAll('%{username}', widget.boost.user.username)
+        .replaceAll('@%{username}', '@${widget.boost.user.username}');
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFlagTypes();
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadFlagTypes() async {
+    try {
+      final types = widget.loadFlagTypes != null
+          ? await widget.loadFlagTypes!()
+          : await _loadDefaultFlagTypes();
+      if (!mounted) return;
+      setState(() {
+        _flagTypes = filterBoostFlagTypes(
+          allFlagTypes: types,
+          availableFlags: widget.boost.availableFlags,
+        );
+        _isLoading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _flagTypes = filterBoostFlagTypes(
+          allFlagTypes: const [],
+          availableFlags: widget.boost.availableFlags,
+        );
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<List<FlagType>> _loadDefaultFlagTypes() async {
+    final types = await PreloadedDataService().getPostActionTypes();
+    if (types == null || types.isEmpty) {
+      return FlagType.defaultTypes;
+    }
+    return types
+        .map((t) => FlagType.fromJson(t))
+        .where((f) => f.isFlag && f.enabled)
+        .toList();
+  }
+
+  Future<void> _submitFlag() async {
+    if (_selectedType == null || _isSubmitting) return;
+    final submitter = widget.submitFlag;
+    if (submitter == null) return;
+    final message = _messageController.text.trim();
+    if (_selectedType!.requireMessage && message.isEmpty) {
+      return;
+    }
+
+    setState(() => _isSubmitting = true);
+    try {
+      await submitter(
+        _selectedType!.id,
+        message.isNotEmpty ? message : null,
+      );
+      if (!mounted) return;
+      Navigator.pop(context);
+      widget.onSuccess?.call();
+    } catch (e) {
+      if (!mounted) return;
+      final message = e is Exception
+          ? e.toString().replaceFirst('Exception: ', '')
+          : S.current.post_flagFailed;
+      ToastService.showError(message);
+    } finally {
+      if (mounted) {
+        setState(() => _isSubmitting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      margin: const EdgeInsets.all(16),
+      constraints: BoxConstraints(
+        maxHeight: MediaQuery.of(context).size.height * 0.7,
+      ),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 8, 0),
+              child: Row(
+                children: [
+                  Icon(Icons.flag_outlined, color: theme.colorScheme.error),
+                  const SizedBox(width: 8),
+                  Text(
+                    context.l10n.boost_flagTitle,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const Spacer(),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    onPressed: () => Navigator.pop(context),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                ],
+              ),
+            ),
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (_isLoading)
+                      const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(20),
+                          child: CircularProgressIndicator(),
+                        ),
+                      )
+                    else if (_flagTypes.isEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 20),
+                        child: Center(
+                          child: Text(
+                            context.l10n.common_noData,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                      )
+                    else ...[
+                      if (_notifyUserTypes.isNotEmpty) ...[
+                        _buildSectionHeader(
+                          context.l10n.post_flagMessageUser(
+                            widget.boost.user.username,
+                          ),
+                          theme,
+                        ),
+                        ..._notifyUserTypes.map(
+                          (type) => _buildFlagOption(type, theme),
+                        ),
+                        const SizedBox(height: 16),
+                        Divider(color: theme.colorScheme.outlineVariant),
+                        const SizedBox(height: 16),
+                      ],
+                      if (_moderatorTypes.isNotEmpty) ...[
+                        _buildSectionHeader(
+                          context.l10n.post_flagNotifyModerators,
+                          theme,
+                        ),
+                        ..._moderatorTypes.map(
+                          (type) => _buildFlagOption(type, theme),
+                        ),
+                      ],
+                    ],
+                    if (_selectedType?.requireMessage == true) ...[
+                      const SizedBox(height: 16),
+                      TextField(
+                        controller: _messageController,
+                        maxLines: 3,
+                        onChanged: (_) => setState(() {}),
+                        decoration: InputDecoration(
+                          hintText: context.l10n.post_flagDescriptionHint,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          contentPadding: const EdgeInsets.all(12),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed:
+                      _selectedType == null ||
+                          _isSubmitting ||
+                          _isLoading ||
+                          (_selectedType?.requireMessage == true &&
+                              _messageController.text.trim().isEmpty) ||
+                          widget.submitFlag == null
+                      ? null
+                      : _submitFlag,
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(context.l10n.post_submitFlag),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title, ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Text(
+        title,
+        style: theme.textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFlagOption(FlagType type, ThemeData theme) {
+    final isSelected = _selectedType?.id == type.id;
+    final description = _replaceDescription(type.description);
+    return InkWell(
+      onTap: () => setState(() => _selectedType = type),
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        margin: const EdgeInsets.only(bottom: 8),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? theme.colorScheme.primaryContainer.withValues(alpha: 0.3)
+              : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isSelected
+                ? theme.colorScheme.primary
+                : Colors.transparent,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              isSelected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_off,
+              size: 20,
+              color: isSelected
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _buildDescriptionText(description, theme),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDescriptionText(String description, ThemeData theme) {
+    return HtmlWidget(
+      description,
+      textStyle: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+      customStylesBuilder: (element) {
+        if (element.localName == 'a') {
+          return {'text-decoration': 'none'};
+        }
+        return null;
+      },
+      onTapUrl: (url) {
+        final fullUrl = UrlHelper.resolveUrl(url);
+        debugPrint('Open URL: $fullUrl');
+        return true;
+      },
+    );
+  }
+}

--- a/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
+++ b/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
@@ -17,6 +17,7 @@ import '../post_action_bar.dart';
 import '../../../../bookmark/bookmark_edit_sheet.dart';
 import '../../../../post/post_boost/boost_list.dart';
 import '../../../../post/post_boost/boost_input.dart';
+import '../boost_flag_sheet.dart';
 import '../post_flag_sheet.dart';
 import '../post_reaction_picker.dart';
 import '../post_reaction_users_sheet.dart';
@@ -169,6 +170,20 @@ class _PostFooterSectionState extends ConsumerState<PostFooterSection> {
     );
   }
 
+  void _handleBoostChanged(Boost boost) {
+    if (!mounted) return;
+    final index = _boosts.indexWhere((b) => b.id == boost.id);
+    if (index == -1) return;
+    setState(() {
+      final updated = [..._boosts];
+      updated[index] = boost;
+      _boosts = updated;
+    });
+    widget.onBoostUpdated?.call(
+      widget.post.copyWith(boosts: List.from(_boosts), canBoost: _canBoost),
+    );
+  }
+
   List<Boost> _dedupeBoostsById(List<Boost> boosts) {
     final byId = <int, Boost>{};
     for (final boost in boosts) {
@@ -210,12 +225,115 @@ class _PostFooterSectionState extends ConsumerState<PostFooterSection> {
     }
   }
 
-  void _showBoostActions(Boost boost) {
-    final currentUser = ref.read(currentUserProvider).value;
-    final isOwn =
-        currentUser != null && boost.user.username == currentUser.username;
+  bool _shouldFetchBoostActionState({
+    required Boost boost,
+    required String currentUsername,
+  }) {
+    final isOwnBoost = currentUsername == boost.user.username;
+    if (isOwnBoost) {
+      return false;
+    }
+    if (boost.canFlag && boost.availableFlags == null) {
+      return true;
+    }
+    return !boost.canDelete &&
+        !boost.canFlag &&
+        boost.availableFlags == null &&
+        boost.userFlagStatus == null;
+  }
 
-    if (!isOwn && !boost.canDelete) return;
+  Future<Boost> _resolveBoostActionState({
+    required Boost boost,
+    required String currentUsername,
+  }) async {
+    if (!_shouldFetchBoostActionState(
+      boost: boost,
+      currentUsername: currentUsername,
+    )) {
+      return boost;
+    }
+    final detailedBoost = await _service.getBoost(boost.id);
+    if (mounted) {
+      _handleBoostChanged(detailedBoost);
+    }
+    return detailedBoost;
+  }
+
+  Future<void> _refreshBoostAfterFlag(Boost boost) async {
+    try {
+      final updatedBoost = await _service.getBoost(boost.id);
+      if (!mounted) return;
+      _handleBoostChanged(updatedBoost);
+    } catch (_) {
+      if (!mounted) return;
+      _handleBoostChanged(
+        boost.copyWith(
+          canFlag: false,
+          userFlagStatus: boost.userFlagStatus ?? 1,
+        ),
+      );
+    }
+  }
+
+  void _showBoostFlagSheet(Boost boost) {
+    showAppBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => BoostFlagSheet(
+        boost: boost,
+        submitFlag: (flagTypeId, message) async {
+          await _service.flagBoost(
+            boost.id,
+            flagTypeId: flagTypeId,
+            message: message,
+          );
+          await _refreshBoostAfterFlag(boost);
+        },
+        onSuccess: () => ToastService.showSuccess(S.current.boost_flagSubmitted),
+      ),
+    );
+  }
+
+  Future<void> _showBoostActions(Boost boost) async {
+    final currentUsername = ref.read(currentUserProvider).value?.username;
+    if (currentUsername == null || currentUsername.isEmpty) {
+      return;
+    }
+    Boost resolvedBoost;
+    try {
+      resolvedBoost = await _resolveBoostActionState(
+        boost: boost,
+        currentUsername: currentUsername,
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ToastService.showError(S.current.common_loadFailed);
+      return;
+    }
+    if (!mounted) return;
+    final canDelete = canDeleteBoostAction(
+      boost: resolvedBoost,
+      currentUsername: currentUsername,
+    );
+    if (boostAlreadyReportedByCurrentUser(
+          boost: resolvedBoost,
+          currentUsername: currentUsername,
+        ) &&
+        !canDelete) {
+      ToastService.showInfo(S.current.boost_flagAlreadyReported);
+      return;
+    }
+    final canFlag = canFlagBoostAction(
+      boost: resolvedBoost,
+      currentUsername: currentUsername,
+    );
+    if (!canOpenBoostActionMenu(
+      boost: resolvedBoost,
+      currentUsername: currentUsername,
+    )) {
+      return;
+    }
 
     showModalBottomSheet(
       context: context,
@@ -224,14 +342,27 @@ class _PostFooterSectionState extends ConsumerState<PostFooterSection> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              ListTile(
-                leading: const Icon(Icons.delete_outline, color: Colors.red),
-                title: Text(S.current.common_delete),
-                onTap: () {
-                  Navigator.pop(ctx);
-                  _deleteBoost(boost);
-                },
-              ),
+              if (canFlag)
+                ListTile(
+                  leading: const Icon(Icons.flag_outlined, color: Colors.red),
+                  title: Text(
+                    S.current.common_report,
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _showBoostFlagSheet(resolvedBoost);
+                  },
+                ),
+              if (canDelete)
+                ListTile(
+                  leading: const Icon(Icons.delete_outline, color: Colors.red),
+                  title: Text(S.current.common_delete),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    _deleteBoost(resolvedBoost);
+                  },
+                ),
               ListTile(
                 leading: const Icon(Icons.close),
                 title: Text(S.current.common_cancel),
@@ -329,7 +460,9 @@ class _PostFooterSectionState extends ConsumerState<PostFooterSection> {
               boosts: _boosts,
               canBoost: _canBoost,
               onAddBoost: _openBoostInput,
-              onBoostTap: _showBoostActions,
+              onBoostTap: (boost) {
+                _showBoostActions(boost);
+              },
               highlightUsername: widget.highlightBoostUsername,
             ),
           ValueListenableBuilder<bool>(

--- a/test/widgets/post/post_boost/boost_flag_sheet_test.dart
+++ b/test/widgets/post/post_boost/boost_flag_sheet_test.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/l10n/app_localizations.dart';
+import 'package:fluxdo/models/topic.dart';
+import 'package:fluxdo/widgets/post/post_item/widgets/boost_flag_sheet.dart';
+
+void main() {
+  group('Boost 操作权限', () {
+    const selfBoost = Boost(
+      id: 1,
+      cooked: 'self',
+      user: BoostUser(id: 1, username: 'alice', avatarTemplate: ''),
+    );
+    const otherBoost = Boost(
+      id: 2,
+      cooked: 'other',
+      user: BoostUser(id: 2, username: 'bob', avatarTemplate: ''),
+      canFlag: true,
+    );
+
+    test('本人 Boost 可删除但不可举报', () {
+      expect(
+        canDeleteBoostAction(boost: selfBoost, currentUsername: 'alice'),
+        isTrue,
+      );
+      expect(
+        canFlagBoostAction(boost: selfBoost, currentUsername: 'alice'),
+        isFalse,
+      );
+      expect(
+        canOpenBoostActionMenu(boost: selfBoost, currentUsername: 'alice'),
+        isTrue,
+      );
+    });
+
+    test('他人 Boost 在 canFlag 为真时可举报', () {
+      expect(
+        canDeleteBoostAction(boost: otherBoost, currentUsername: 'alice'),
+        isFalse,
+      );
+      expect(
+        canFlagBoostAction(boost: otherBoost, currentUsername: 'alice'),
+        isTrue,
+      );
+      expect(
+        canOpenBoostActionMenu(boost: otherBoost, currentUsername: 'alice'),
+        isTrue,
+      );
+    });
+
+    test('游客不能打开 Boost 操作菜单', () {
+      expect(
+        canDeleteBoostAction(boost: otherBoost, currentUsername: null),
+        isFalse,
+      );
+      expect(
+        canFlagBoostAction(boost: otherBoost, currentUsername: null),
+        isFalse,
+      );
+      expect(
+        canOpenBoostActionMenu(boost: otherBoost, currentUsername: null),
+        isFalse,
+      );
+    });
+
+    test('已举报的他人 Boost 不再视为可举报', () {
+      const flaggedBoost = Boost(
+        id: 3,
+        cooked: 'flagged',
+        user: BoostUser(id: 3, username: 'carol', avatarTemplate: ''),
+        canFlag: true,
+        userFlagStatus: 1,
+      );
+
+      expect(
+        boostAlreadyReportedByCurrentUser(
+          boost: flaggedBoost,
+          currentUsername: 'alice',
+        ),
+        isTrue,
+      );
+      expect(
+        canFlagBoostAction(boost: flaggedBoost, currentUsername: 'alice'),
+        isFalse,
+      );
+    });
+  });
+
+  group('Boost 举报类型过滤', () {
+    const types = [
+      FlagType(
+        id: 7,
+        nameKey: 'notify_moderators',
+        name: 'Other',
+        description: '需要版主处理',
+        isFlag: true,
+        requireMessage: true,
+        position: 2,
+      ),
+      FlagType(
+        id: 2,
+        nameKey: 'notify_user',
+        name: 'Message user',
+        description: '提醒 %{username}',
+        isFlag: true,
+        position: 1,
+      ),
+      FlagType(
+        id: 8,
+        nameKey: 'spam',
+        name: 'Spam',
+        description: '垃圾内容',
+        isFlag: true,
+        enabled: false,
+        position: 3,
+      ),
+    ];
+
+    test('按 availableFlags 过滤并按 position 排序', () {
+      final result = filterBoostFlagTypes(
+        allFlagTypes: types,
+        availableFlags: const ['notify_moderators', 'notify_user'],
+      );
+
+      expect(result.map((type) => type.nameKey).toList(), [
+        'notify_user',
+        'notify_moderators',
+      ]);
+    });
+
+    test('availableFlags 为空列表时不返回任何类型', () {
+      final result = filterBoostFlagTypes(
+        allFlagTypes: types,
+        availableFlags: const [],
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('availableFlags 缺失时不返回任何类型', () {
+      final result = filterBoostFlagTypes(allFlagTypes: types);
+
+      expect(result, isEmpty);
+    });
+  });
+
+  group('Boost 举报弹层', () {
+    testWidgets('选择需要补充说明的类型后可提交举报', (tester) async {
+      int? submittedFlagTypeId;
+      String? submittedMessage;
+      var successCalled = false;
+
+      final boost = const Boost(
+        id: 10,
+        cooked: 'hello',
+        user: BoostUser(id: 2, username: 'bob', avatarTemplate: ''),
+        canFlag: true,
+        availableFlags: ['notify_moderators', 'notify_user'],
+      );
+
+      await tester.pumpWidget(
+        _buildTestApp(
+          child: _BoostFlagSheetHost(
+            boost: boost,
+            loadFlagTypes: () async => const [
+              FlagType(
+                id: 2,
+                nameKey: 'notify_user',
+                name: 'Message user',
+                description: '提醒 %{username}',
+                isFlag: true,
+                position: 1,
+              ),
+              FlagType(
+                id: 7,
+                nameKey: 'notify_moderators',
+                name: 'Other',
+                description: '需要版主处理',
+                isFlag: true,
+                requireMessage: true,
+                position: 2,
+              ),
+            ],
+            submitFlag: (flagTypeId, message) async {
+              submittedFlagTypeId = flagTypeId;
+              submittedMessage = message;
+            },
+            onSuccess: () {
+              successCalled = true;
+            },
+          ),
+        ),
+      );
+
+      final hostState = tester.state<_BoostFlagSheetHostState>(
+        find.byType(_BoostFlagSheetHost),
+      );
+      hostState.openSheet();
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('举报 Boost'), findsOneWidget);
+      expect(find.textContaining('@bob'), findsOneWidget);
+      expect(find.byType(TextField), findsNothing);
+
+      await tester.tap(find.byIcon(Icons.radio_button_off).last);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(
+        tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+        isNull,
+      );
+      await tester.enterText(find.byType(TextField), '请版主看一下');
+      await tester.pumpAndSettle();
+      expect(
+        tester.widget<FilledButton>(find.byType(FilledButton)).onPressed,
+        isNotNull,
+      );
+      await tester.tap(find.text('提交举报'));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(submittedFlagTypeId, 7);
+      expect(submittedMessage, '请版主看一下');
+      expect(successCalled, isTrue);
+    });
+  });
+}
+
+Widget _buildTestApp({required Widget child}) {
+  return TranslationProvider(
+    child: MaterialApp(
+      locale: const Locale('zh'),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocaleUtils.supportedLocales,
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+class _BoostFlagSheetHost extends StatefulWidget {
+  final Boost boost;
+  final BoostFlagTypesLoader loadFlagTypes;
+  final BoostFlagSubmitter submitFlag;
+  final VoidCallback onSuccess;
+
+  const _BoostFlagSheetHost({
+    required this.boost,
+    required this.loadFlagTypes,
+    required this.submitFlag,
+    required this.onSuccess,
+  });
+
+  @override
+  State<_BoostFlagSheetHost> createState() => _BoostFlagSheetHostState();
+}
+
+class _BoostFlagSheetHostState extends State<_BoostFlagSheetHost> {
+  Future<void> openSheet() {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => BoostFlagSheet(
+        boost: widget.boost,
+        loadFlagTypes: widget.loadFlagTypes,
+        submitFlag: widget.submitFlag,
+        onSuccess: widget.onSuccess,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.expand();
+  }
+}


### PR DESCRIPTION
## 变更说明

为 Boost 增加举报能力，并补齐重复举报时的错误提示。

本 PR 包含：

- 在 Boost 操作菜单中增加举报入口
- 新增 `BoostFlagSheet`，按 `availableFlags` 过滤可选举报类型
- 对齐 Boost 举报与帖子举报的错误处理，优先展示服务端返回的具体错误原因
- 在本地状态已知“当前用户已举报过该 Boost”时，直接给出明确提示，避免泛化报错
- 补充 Boost 举报相关测试

## 具体改动

- `lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart`
  - 增加 Boost 举报入口
  - 增加 Boost 权限补全与重复举报提示逻辑

- `lib/widgets/post/post_item/widgets/boost_flag_sheet.dart`
  - 新增 Boost 举报弹层
  - 增加举报类型过滤与提交逻辑

- `lib/services/discourse/_posts.dart`
  - `flagBoost()` 改为对齐帖子举报的错误提取方式

- `lib/l10n/modules/post/*.arb`
  - 新增 Boost 重复举报提示文案

- `test/widgets/post/post_boost/boost_flag_sheet_test.dart`
  - 新增 Boost 举报相关测试

## 验证

已执行：

- `dart run tool/flutterw.dart test test/widgets/post/post_boost`

本地 Android 手测确认：

- 首次举报 Boost 可正常提交
- 重复举报时会给出明确提示，不再只显示泛化错误

## 说明

- 本 PR 不包含 Android 共存调试包相关改动
- 本地用于测试的 `FluxDO Dev` 包名/应用名调整已从 PR 分支剥离
