### PR TITLE
修复 LDC 绑定授权流程

### DIFF
--- a/lib/pages/ldc_oauth_webview_page.dart
+++ b/lib/pages/ldc_oauth_webview_page.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+import 'dart:io' as io;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../l10n/s.dart';
+import '../services/network/cookie/boundary_sync_service.dart';
+import '../services/network/cookie/raw_set_cookie_queue.dart';
+import '../services/webview_settings.dart';
+import '../services/windows_webview_environment_service.dart';
+
+class LdcOAuthWebViewPage extends StatefulWidget {
+  final String authUrl;
+  final Future<bool> Function() checkAuthorized;
+
+  const LdcOAuthWebViewPage({
+    super.key,
+    required this.authUrl,
+    required this.checkAuthorized,
+  });
+
+  static Future<bool?> open(
+    BuildContext context, {
+    required String authUrl,
+    required Future<bool> Function() checkAuthorized,
+  }) {
+    return Navigator.push<bool>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LdcOAuthWebViewPage(
+          authUrl: authUrl,
+          checkAuthorized: checkAuthorized,
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<LdcOAuthWebViewPage> createState() => _LdcOAuthWebViewPageState();
+}
+
+class _LdcOAuthWebViewPageState extends State<LdcOAuthWebViewPage> {
+  InAppWebViewController? _controller;
+  bool _isLoading = true;
+  bool _isChecking = false;
+  bool _authHandled = false;
+  String _currentUrl = '';
+  double _progress = 0;
+  String? _pendingAuthorizationUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentUrl = widget.authUrl;
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final windowsWebViewEnvironment =
+        WindowsWebViewEnvironmentService.instance.environment;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(context.l10n.metaverse_ldcService)),
+      body: Column(
+        children: [
+          if (_isLoading)
+            LinearProgressIndicator(value: _progress == 0 ? null : _progress),
+          Expanded(
+            child: WebViewSettings.wrapWithScrollFix(
+              InAppWebView(
+                webViewEnvironment: windowsWebViewEnvironment,
+                initialSettings: WebViewSettings.visible
+                  ..useShouldOverrideUrlLoading = true,
+                initialUserScripts: WebViewSettings.ios15PolyfillScripts,
+                shouldOverrideUrlLoading: _shouldOverrideUrlLoading,
+                onReceivedServerTrustAuthRequest: (_, challenge) =>
+                    WebViewSettings.handleServerTrustAuthRequest(challenge),
+                onWebViewCreated: (controller) async {
+                  _controller = controller;
+                  await RawSetCookieQueue.instance.flushToWebView();
+                  await controller.loadUrl(
+                    urlRequest: URLRequest(url: WebUri(widget.authUrl)),
+                  );
+                  if (io.Platform.isAndroid) {
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      const MethodChannel(
+                        'com.fluxdo/webauthn',
+                      ).invokeMethod('enableWebAuthentication');
+                    });
+                  }
+                },
+                onLoadStart: (controller, url) {
+                  setState(() {
+                    _isLoading = true;
+                    _currentUrl = url?.toString() ?? '';
+                  });
+                },
+                onProgressChanged: (controller, progress) {
+                  setState(() => _progress = progress / 100);
+                },
+                onLoadStop: (controller, url) async {
+                  setState(() {
+                    _isLoading = false;
+                    _currentUrl = url?.toString() ?? _currentUrl;
+                  });
+                  await WebViewSettings.injectScrollFix(controller);
+                  await _checkAuthorization(controller, _currentUrl);
+                },
+                onUpdateVisitedHistory: (controller, url, isReload) async {
+                  final currentUrl = url?.toString() ?? '';
+                  setState(() => _currentUrl = currentUrl);
+                  await _checkAuthorization(controller, currentUrl);
+                },
+              ),
+              getController: () => _controller,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<NavigationActionPolicy> _shouldOverrideUrlLoading(
+    InAppWebViewController controller,
+    NavigationAction navigationAction,
+  ) async {
+    final url = navigationAction.request.url;
+    if (url == null) return NavigationActionPolicy.CANCEL;
+
+    final scheme = url.scheme.toLowerCase();
+    if (scheme == 'http' ||
+        scheme == 'https' ||
+        scheme == 'about' ||
+        scheme == 'data' ||
+        scheme == 'blob') {
+      return NavigationActionPolicy.ALLOW;
+    }
+    return NavigationActionPolicy.CANCEL;
+  }
+
+  Future<void> _checkAuthorization(
+    InAppWebViewController controller,
+    String currentUrl,
+  ) async {
+    if (_authHandled || currentUrl.isEmpty) return;
+
+    if (_isChecking) {
+      _pendingAuthorizationUrl = currentUrl;
+      return;
+    }
+
+    final uri = Uri.tryParse(currentUrl);
+    if (uri == null || uri.host != 'credit.linux.do') {
+      return;
+    }
+
+    _isChecking = true;
+    try {
+      await BoundarySyncService.instance.syncFromWebView(
+        currentUrl: currentUrl,
+        controller: controller,
+        allowLowConfidenceSessionCookies: true,
+      );
+
+      final authorized = await widget.checkAuthorized();
+      if (!mounted || !authorized) return;
+
+      _authHandled = true;
+      Navigator.of(context).pop(true);
+    } finally {
+      _isChecking = false;
+      final pendingAuthorizationUrl = _pendingAuthorizationUrl;
+      _pendingAuthorizationUrl = null;
+      if (!_authHandled &&
+          mounted &&
+          pendingAuthorizationUrl != null &&
+          pendingAuthorizationUrl.isNotEmpty) {
+        unawaited(_checkAuthorization(controller, pendingAuthorizationUrl));
+      }
+    }
+  }
+}

--- a/lib/services/ldc_oauth_service.dart
+++ b/lib/services/ldc_oauth_service.dart
@@ -1,15 +1,15 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:html/parser.dart' as html_parser;
+
+import '../models/ldc_user_info.dart';
+import '../pages/ldc_oauth_webview_page.dart';
+import '../l10n/s.dart';
 import 'network/discourse_dio.dart';
 import 'network/exceptions/oauth_exception.dart';
-import '../l10n/s.dart';
-import '../utils/dialog_utils.dart';
-import 'toast_service.dart';
-import '../models/ldc_user_info.dart';
 
 class LdcOAuthService {
   static const String baseUrl = 'https://credit.linux.do';
+
   late final Dio _dio;
 
   LdcOAuthService() {
@@ -22,14 +22,6 @@ class LdcOAuthService {
       options: Options(extra: {'skipCsrf': true}),
     );
     return response.data['data'] as String;
-  }
-
-  Future<void> callback(String code, String state) async {
-    await _dio.post(
-      '$baseUrl/api/v1/oauth/callback',
-      data: {'code': code, 'state': state},
-      options: Options(extra: {'skipCsrf': true}),
-    );
   }
 
   Future<void> logout() async {
@@ -85,117 +77,26 @@ class LdcOAuthService {
       throw Exception(S.current.oauth_getAuthUrlFailed);
     }
 
-    final Response response;
-    try {
-      response = await _dio.get(
-        authUrl,
-        options: Options(
-          followRedirects: false,
-          validateStatus: (status) => status != null && status < 500,
-          extra: {'skipCsrf': true, 'allowRedirectSetCookie': true},
-        ),
-      );
-    } on DioException {
-      throw Exception(S.current.oauth_networkError);
-    }
-
-    final document = html_parser.parse(response.data);
-    final approveLink = document.querySelector('a[href*="/oauth2/approve/"]')?.attributes['href'];
-
     if (!context.mounted) return false;
-    if (approveLink == null) {
-      throw Exception(S.current.oauth_approvePageParseFailed);
-    }
 
-    final confirmed = await showAppDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (context) => _AuthDialog(
-        onApprove: () async {
-          final approveResponse = await _dio.get(
-            'https://connect.linux.do$approveLink',
-            options: Options(
-              followRedirects: false,
-              validateStatus: (status) => status != null && status < 500,
-              extra: {
-                'skipCsrf': true,
-                'skipRedirect': true,
-                'allowRedirectSetCookie': true,
-              },
-            ),
-          );
-
-          final location = approveResponse.headers.value('location');
-          if (location == null) {
-            throw Exception(S.current.oauth_noRedirectResponse);
-          }
-
-          final uri = Uri.parse(location);
-          final code = uri.queryParameters['code'];
-          final state = uri.queryParameters['state'];
-
-          if (code == null || state == null) {
-            throw Exception(S.current.oauth_missingParams);
-          }
-
-          await callback(code, state);
-          return true;
-        },
-      ),
-    );
-
-    return confirmed ?? false;
+    return await LdcOAuthWebViewPage.open(
+          context,
+          authUrl: authUrl,
+          checkAuthorized: hasAuthorizedSession,
+        ) ??
+        false;
   }
-}
 
-class _AuthDialog extends StatefulWidget {
-  final Future<bool> Function() onApprove;
-
-  const _AuthDialog({required this.onApprove});
-
-  @override
-  State<_AuthDialog> createState() => _AuthDialogState();
-}
-
-class _AuthDialogState extends State<_AuthDialog> {
-  bool _isLoading = false;
-
-  Future<void> _handleApprove() async {
-    setState(() => _isLoading = true);
+  Future<bool> hasAuthorizedSession() async {
     try {
-      final result = await widget.onApprove();
-      if (mounted) {
-        Navigator.pop(context, result);
-      }
-    } catch (e) {
-      if (mounted) {
-        setState(() => _isLoading = false);
-        ToastService.showError('${S.current.reward_authFailed}: $e');
-      }
+      final response = await _dio.get(
+        '$baseUrl/api/v1/oauth/user-info',
+        options: Options(extra: {'skipCsrf': true, 'showErrorToast': false}),
+      );
+      return response.statusCode == 200;
+    } on DioException catch (e) {
+      debugPrint('[LDC OAuth] 检查授权状态失败: $e');
+      return false;
     }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(context.l10n.auth_ldcConfirmTitle),
-      content: Text(context.l10n.auth_ldcConfirmMessage),
-      actions: [
-        TextButton(
-          onPressed: _isLoading ? null : () => Navigator.pop(context, false),
-          child: Text(context.l10n.common_deny),
-        ),
-        FilledButton(
-          onPressed: _isLoading ? null : _handleApprove,
-          child: _isLoading
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
-              : Text(context.l10n.common_allow),
-        ),
-      ],
-    );
   }
 }


### PR DESCRIPTION
## 变更摘要

修复 FluxDO 中 LDC 绑定失败的问题。

此前 LDC 绑定使用的是客户端手工拼装的 OAuth 流程：先解析授权页，再手动请求 approve/callback。近期这条链路在 `credit.linux.do` 上会出现授权收口失败，表现为：

- `connect.linux.do/oauth2/approve/...` 返回 302
- 之后 `credit.linux.do` 未建立授权态
- `GET /api/v1/oauth/user-info` 返回 401
- `POST /api/v1/oauth/callback` 返回 403

本次改动将 LDC 绑定切换为真实 WebView OAuth 流，避免继续手工模拟回调。

## 具体改动

- 新增 `LdcOAuthWebViewPage`
  - 直接加载 `credit.linux.do/api/v1/oauth/login` 返回的授权地址
  - 让 `connect.linux.do -> credit.linux.do` 的完整 OAuth 跳转在 WebView 内真实完成
  - 在进入 `credit.linux.do` 页面后同步 WebView Cookie 到 CookieJar
  - 通过 `GET /api/v1/oauth/user-info` 校验授权是否真正成功
  - 授权成功后自动返回上层页面

- 简化 `LdcOAuthService.authorize()`
  - 不再手工解析 approveLink
  - 不再手工调用 `oauth/callback`
  - 改为统一走真实 WebView 授权页

## 风险控制

- 本次 PR 不包含本地 Android 共存调试配置
- 本次 PR 不包含构建生成物或其他本地副作用文件
- 仅保留 LDC 授权流程本体修复

## 实际测试

- [x] Android 真机手动测试通过
- 测试内容：
  - 安装调试包
  - 登录 Linux.do
  - 进入元宇宙页面
  - 触发 LDC 绑定
  - 点击授权确认
  - 验证绑定成功

## 影响范围

- LDC 绑定授权流程
- 不影响 LDC 打赏商户凭证配置逻辑
- 不影响 CDK 授权流程