### PR TITLE
添加本地实现的用户黑名单功能

### DIFF
--- a/lib/l10n/modules/settings/settings_en.arb
+++ b/lib/l10n/modules/settings/settings_en.arb
@@ -37,7 +37,7 @@
   "preferences_clipboardTopicLink_detected": "Topic link found in clipboard",
   "preferences_clipboardTopicLink_open": "Open",
   "preferences_topicFilterKeywords": "Title keyword filter",
-  "preferences_topicFilterKeywordsDesc": "Filter topics whose title contains the configured keywords, one per line",
+  "preferences_topicFilterKeywordsDesc": "Filter topics whose title contains the configured keywords. Press Enter to add each keyword",
   "preferences_topicFilterKeywordsEmpty": "No keywords set",
   "preferences_topicFilterKeywordsCount": "{count} keywords set",
   "@preferences_topicFilterKeywordsCount": {
@@ -45,10 +45,21 @@
       "count": {"type": "int"}
     }
   },
-  "preferences_topicFilterKeywordsHint": "Enter one keyword per line",
+  "preferences_topicFilterKeywordsHint": "Enter a keyword, then press Enter",
   "preferences_topicFilterKeywordsHelper": "Only topic titles are matched as substrings, case-insensitively",
   "preferences_topicFilterWholeWord": "Whole-word match",
   "preferences_topicFilterWholeWordDesc": "When enabled, English keywords no longer match as substrings (e.g. \"ai\" will not hit \"Main thread\"). CJK keywords are unaffected.",
+  "preferences_blockedUsernames": "Locally blocked users",
+  "preferences_blockedUsernamesDesc": "Hide topics, replies, and Boosts from these users. The list stays only on this device and is never synced to Linux.do",
+  "preferences_blockedUsernamesEmpty": "No users locally blocked",
+  "preferences_blockedUsernamesCount": "{count} users blocked",
+  "@preferences_blockedUsernamesCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_blockedUsernamesHint": "Enter a username, then press Enter",
+  "preferences_blockedUsernamesHelper": "Do not include @. Usernames are matched exactly, case-insensitively. This does not use Discourse ignore.",
   "preferences_autoPanguSpacing": "Auto CJK spacing",
   "preferences_autoPanguSpacingDesc": "Auto-insert spaces between CJK and Latin text",
   "preferences_aiPostReview": "AI review before posting",

--- a/lib/l10n/modules/settings/settings_zh.arb
+++ b/lib/l10n/modules/settings/settings_zh.arb
@@ -54,7 +54,7 @@
   "preferences_clipboardTopicLink_detected": "检测到剪贴板中的话题链接",
   "preferences_clipboardTopicLink_open": "打开",
   "preferences_topicFilterKeywords": "标题关键词过滤",
-  "preferences_topicFilterKeywordsDesc": "过滤标题包含指定关键词的话题，每行一个关键词",
+  "preferences_topicFilterKeywordsDesc": "过滤标题包含指定关键词的话题，输入后按回车添加",
   "preferences_topicFilterKeywordsEmpty": "未设置关键词",
   "preferences_topicFilterKeywordsCount": "已设置 {count} 个关键词",
   "@preferences_topicFilterKeywordsCount": {
@@ -62,10 +62,21 @@
       "count": {"type": "int"}
     }
   },
-  "preferences_topicFilterKeywordsHint": "每行输入一个关键词",
+  "preferences_topicFilterKeywordsHint": "输入关键词后按回车添加",
   "preferences_topicFilterKeywordsHelper": "仅匹配话题标题，子串匹配，不区分大小写",
   "preferences_topicFilterWholeWord": "完整词匹配",
   "preferences_topicFilterWholeWordDesc": "开启后英文关键词不再匹配子串，如 ai 不会命中 Main thread；中文关键词无影响",
+  "preferences_blockedUsernames": "本地拉黑用户",
+  "preferences_blockedUsernamesDesc": "在本机隐藏这些用户发布的话题、回复和 Boost；名单不会同步到 Linux.do",
+  "preferences_blockedUsernamesEmpty": "未拉黑任何用户",
+  "preferences_blockedUsernamesCount": "已拉黑 {count} 个用户",
+  "@preferences_blockedUsernamesCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_blockedUsernamesHint": "输入用户名后按回车添加",
+  "preferences_blockedUsernamesHelper": "无需输入 @；用户名精确匹配，不区分大小写；不会调用 Discourse 的忽略功能",
   "preferences_autoPanguSpacing": "自动混排优化",
   "preferences_autoPanguSpacingDesc": "输入时自动插入中英文混排空格",
   "preferences_aiPostReview": "发帖前 AI 审核",

--- a/lib/l10n/modules/settings/settings_zh_HK.arb
+++ b/lib/l10n/modules/settings/settings_zh_HK.arb
@@ -37,7 +37,7 @@
   "preferences_clipboardTopicLink_detected": "檢測到剪貼板中的話題鏈接",
   "preferences_clipboardTopicLink_open": "打開",
   "preferences_topicFilterKeywords": "標題關鍵詞過濾",
-  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵詞的話題，每行一個關鍵詞",
+  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵詞的話題，輸入後按 Enter 新增",
   "preferences_topicFilterKeywordsEmpty": "未設定關鍵詞",
   "preferences_topicFilterKeywordsCount": "已設定 {count} 個關鍵詞",
   "@preferences_topicFilterKeywordsCount": {
@@ -45,10 +45,21 @@
       "count": {"type": "int"}
     }
   },
-  "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵詞",
+  "preferences_topicFilterKeywordsHint": "輸入關鍵詞後按 Enter 新增",
   "preferences_topicFilterKeywordsHelper": "只匹配話題標題，子串匹配，不區分大小寫",
   "preferences_topicFilterWholeWord": "完整詞匹配",
   "preferences_topicFilterWholeWordDesc": "開啟後英文關鍵詞不再匹配子串，如 ai 不會命中 Main thread；中文關鍵詞無影響",
+  "preferences_blockedUsernames": "本機封鎖用戶",
+  "preferences_blockedUsernamesDesc": "在本機隱藏這些用戶發表的話題、回覆與 Boost；名單不會同步到 Linux.do",
+  "preferences_blockedUsernamesEmpty": "未封鎖任何用戶",
+  "preferences_blockedUsernamesCount": "已封鎖 {count} 位用戶",
+  "@preferences_blockedUsernamesCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_blockedUsernamesHint": "輸入用戶名後按 Enter 新增",
+  "preferences_blockedUsernamesHelper": "無需輸入 @；用戶名精確匹配，不區分大小寫；不會調用 Discourse 的忽略功能",
   "preferences_autoPanguSpacing": "自動混排優化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發帖前 AI 審核",

--- a/lib/l10n/modules/settings/settings_zh_TW.arb
+++ b/lib/l10n/modules/settings/settings_zh_TW.arb
@@ -37,7 +37,7 @@
   "preferences_clipboardTopicLink_detected": "偵測到剪貼簿中的話題連結",
   "preferences_clipboardTopicLink_open": "開啟",
   "preferences_topicFilterKeywords": "標題關鍵字過濾",
-  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵字的話題，每行一個關鍵字",
+  "preferences_topicFilterKeywordsDesc": "過濾標題包含指定關鍵字的話題，輸入後按 Enter 新增",
   "preferences_topicFilterKeywordsEmpty": "未設定關鍵字",
   "preferences_topicFilterKeywordsCount": "已設定 {count} 個關鍵字",
   "@preferences_topicFilterKeywordsCount": {
@@ -45,10 +45,21 @@
       "count": {"type": "int"}
     }
   },
-  "preferences_topicFilterKeywordsHint": "每行輸入一個關鍵字",
+  "preferences_topicFilterKeywordsHint": "輸入關鍵字後按 Enter 新增",
   "preferences_topicFilterKeywordsHelper": "只比對話題標題，子字串比對，不區分大小寫",
   "preferences_topicFilterWholeWord": "完整詞比對",
   "preferences_topicFilterWholeWordDesc": "開啟後英文關鍵字不再比對子字串，如 ai 不會命中 Main thread；中文關鍵字無影響",
+  "preferences_blockedUsernames": "本機封鎖使用者",
+  "preferences_blockedUsernamesDesc": "在本機隱藏這些使用者發表的話題、回覆與 Boost；名單不會同步到 Linux.do",
+  "preferences_blockedUsernamesEmpty": "未封鎖任何使用者",
+  "preferences_blockedUsernamesCount": "已封鎖 {count} 位使用者",
+  "@preferences_blockedUsernamesCount": {
+    "placeholders": {
+      "count": {"type": "int"}
+    }
+  },
+  "preferences_blockedUsernamesHint": "輸入使用者名稱後按 Enter 新增",
+  "preferences_blockedUsernamesHelper": "無需輸入 @；使用者名稱精確比對，不區分大小寫；不會呼叫 Discourse 的忽略功能",
   "preferences_autoPanguSpacing": "自動混排最佳化",
   "preferences_autoPanguSpacingDesc": "輸入時自動插入中英文混排空格",
   "preferences_aiPostReview": "發文前 AI 審核",

--- a/lib/pages/browsing_history_page.dart
+++ b/lib/pages/browsing_history_page.dart
@@ -7,6 +7,7 @@ import '../navigation/nav_action_bus.dart';
 import '../providers/discourse_providers.dart';
 import '../providers/user_content_search_provider.dart';
 import '../utils/load_more_coordinator.dart';
+import '../utils/blocked_user_filter.dart';
 import '../widgets/common/paged_list_footer.dart';
 import '../widgets/search/searchable_app_bar.dart';
 import '../widgets/search/user_content_search_view.dart';
@@ -187,7 +188,14 @@ class _BrowsingHistoryPageState extends ConsumerState<BrowsingHistoryPage> {
       onRefresh: _onRefresh,
       child: historyAsync.when(
         data: (topics) {
-          if (topics.isEmpty) {
+          final blockedUsernames = ref.watch(
+            preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+          );
+          final visibleTopics = BlockedUserFilter.visibleTopics(
+            topics,
+            blockedUsernames,
+          );
+          if (visibleTopics.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -206,9 +214,9 @@ class _BrowsingHistoryPageState extends ConsumerState<BrowsingHistoryPage> {
           return ListView.builder(
             controller: _scrollController,
             padding: const EdgeInsets.all(12),
-            itemCount: topics.length + 1,
+            itemCount: visibleTopics.length + 1,
             itemBuilder: (context, index) {
-              if (index == topics.length) {
+              if (index == visibleTopics.length) {
                 final notifier = ref.watch(browsingHistoryProvider.notifier);
                 return PagedListFooter(
                   hasMore: notifier.hasMore,
@@ -218,7 +226,7 @@ class _BrowsingHistoryPageState extends ConsumerState<BrowsingHistoryPage> {
                 );
               }
 
-              final topic = topics[index];
+              final topic = visibleTopics[index];
               final enableLongPress = ref
                   .watch(preferencesProvider)
                   .longPressPreview;

--- a/lib/pages/browsing_history_page.dart
+++ b/lib/pages/browsing_history_page.dart
@@ -195,7 +195,15 @@ class _BrowsingHistoryPageState extends ConsumerState<BrowsingHistoryPage> {
             topics,
             blockedUsernames,
           );
-          if (visibleTopics.isEmpty) {
+          final notifier = ref.read(browsingHistoryProvider.notifier);
+          // 已加载页全部被本地屏蔽时列表不可滚，滚动触发的翻页永远不会发生；
+          // 主动补载下一页（coordinator 自带冷却，不会打转），footer 显示加载中
+          if (visibleTopics.isEmpty && topics.isNotEmpty && notifier.hasMore) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) _loadMore();
+            });
+          }
+          if (visibleTopics.isEmpty && (topics.isEmpty || !notifier.hasMore)) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/pages/category_topics_page.dart
+++ b/lib/pages/category_topics_page.dart
@@ -58,6 +58,7 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
   bool _ascending = false;
   List<String> _selectedTags = [];
   List<String> _lastAutoLoadKeywords = const [];
+  Set<String> _lastAutoLoadBlockedUsernames = const <String>{};
   bool? _lastAutoLoadWholeWord;
 
   static final _paginationHelper = PaginationHelpers.forTopics<Topic>(
@@ -105,12 +106,14 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     final prefs = ref.read(preferencesProvider);
     final keywords = prefs.normalizedFilterKeywords;
     final wholeWord = prefs.topicFilterWholeWord;
+    final blockedUsernames = prefs.normalizedBlockedUsernames;
 
     int visibleItemCount() {
       final (visible, _) = TopicKeywordFilter.apply(
         _topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
+        blockedUsernames: blockedUsernames,
       );
       return visible.length;
     }
@@ -121,7 +124,7 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
       isActive: () => mounted,
       itemCount: () => _topics.length,
       visibleItemCount: visibleItemCount,
-      hasKeywordFilter: keywords.isNotEmpty,
+      hasKeywordFilter: keywords.isNotEmpty || blockedUsernames.isNotEmpty,
     );
   }
 
@@ -313,13 +316,19 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     _loadTopics();
   }
 
-  void _syncAutoLoadFilter(List<String> keywords, bool wholeWord) {
+  void _syncAutoLoadFilter(
+    List<String> keywords,
+    bool wholeWord,
+    Set<String> blockedUsernames,
+  ) {
     if (listEquals(_lastAutoLoadKeywords, keywords) &&
-        _lastAutoLoadWholeWord == wholeWord) {
+        _lastAutoLoadWholeWord == wholeWord &&
+        setEquals(_lastAutoLoadBlockedUsernames, blockedUsernames)) {
       return;
     }
     _lastAutoLoadKeywords = List.unmodifiable(keywords);
     _lastAutoLoadWholeWord = wholeWord;
+    _lastAutoLoadBlockedUsernames = Set.unmodifiable(blockedUsernames);
     _loadMoreCoordinator.resetCooldown();
   }
 
@@ -530,11 +539,15 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     final wholeWord = ref.watch(
       preferencesProvider.select((p) => p.topicFilterWholeWord),
     );
-    _syncAutoLoadFilter(keywords, wholeWord);
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
     final (visible, hidden) = TopicKeywordFilter.apply(
       _topics,
       normalizedKeywords: keywords,
       wholeWord: wholeWord,
+      blockedUsernames: blockedUsernames,
     );
     final hintOffset = hidden > 0 ? 1 : 0;
 

--- a/lib/pages/category_topics_page.dart
+++ b/lib/pages/category_topics_page.dart
@@ -109,7 +109,7 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     final blockedUsernames = prefs.normalizedBlockedUsernames;
 
     int visibleItemCount() {
-      final (visible, _) = TopicKeywordFilter.apply(
+      final (visible, _, _) = TopicKeywordFilter.apply(
         _topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
@@ -543,7 +543,7 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
       preferencesProvider.select((p) => p.normalizedBlockedUsernames),
     );
     _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
-    final (visible, hidden) = TopicKeywordFilter.apply(
+    final (visible, hidden, hiddenByBlocked) = TopicKeywordFilter.apply(
       _topics,
       normalizedKeywords: keywords,
       wholeWord: wholeWord,
@@ -560,7 +560,10 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
         itemCount: visible.length + hintOffset + 1,
         itemBuilder: (context, index) {
           if (hintOffset > 0 && index == 0) {
-            return KeywordFilterHintBar(hiddenCount: hidden);
+            return KeywordFilterHintBar(
+              hiddenCount: hidden,
+              hiddenByBlocked: hiddenByBlocked,
+            );
           }
           final topicIndex = index - hintOffset;
           if (topicIndex >= visible.length) {

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -99,7 +99,18 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
                   ),
                 )
                 .toList(growable: false);
-            if (visibleNotifications.isEmpty) {
+            final notifier = ref.read(notificationListProvider.notifier);
+            // 已加载页全部被本地屏蔽时列表不可滚，滚动触发的翻页永远不会
+            // 发生；主动补载下一页（coordinator 自带冷却，不会打转）
+            if (visibleNotifications.isEmpty &&
+                notifications.isNotEmpty &&
+                notifier.hasMore) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted) _loadMore();
+              });
+            }
+            if (visibleNotifications.isEmpty &&
+                (notifications.isEmpty || !notifier.hasMore)) {
               return Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/discourse_providers.dart';
+import '../providers/preferences_provider.dart';
 import '../utils/load_more_coordinator.dart';
 import '../widgets/desktop_refresh_indicator.dart';
 import '../utils/notification_navigation.dart';
@@ -10,6 +11,7 @@ import '../widgets/notification/notification_list_skeleton.dart';
 import '../widgets/common/error_view.dart';
 import '../widgets/common/paged_list_footer.dart';
 import '../l10n/s.dart';
+import '../utils/blocked_user_filter.dart';
 
 /// 通知历史列表页面（独立分页，不受 messageBus 干扰）
 class NotificationsPage extends ConsumerStatefulWidget {
@@ -86,7 +88,18 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
         onRefresh: _onRefresh,
         child: notificationsAsync.when(
           data: (notifications) {
-            if (notifications.isEmpty) {
+            final blockedUsernames = ref.watch(
+              preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+            );
+            final visibleNotifications = notifications
+                .where(
+                  (notification) => !BlockedUserFilter.isBlockedNotification(
+                    notification,
+                    blockedUsernames,
+                  ),
+                )
+                .toList(growable: false);
+            if (visibleNotifications.isEmpty) {
               return Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -108,9 +121,9 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
 
             return ListView.builder(
               controller: _scrollController,
-              itemCount: notifications.length + 1,
+              itemCount: visibleNotifications.length + 1,
               itemBuilder: (context, index) {
-                if (index == notifications.length) {
+                if (index == visibleNotifications.length) {
                   final notifier = ref.read(notificationListProvider.notifier);
                   return PagedListFooter(
                     hasMore: notifier.hasMore,
@@ -119,7 +132,7 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
                     onRetry: notifier.retryLoadMore,
                   );
                 }
-                final notification = notifications[index];
+                final notification = visibleNotifications[index];
                 return NotificationItem(
                   notification: notification,
                   systemAvatarTemplate: systemAvatarTemplate,

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -22,6 +22,7 @@ import '../l10n/s.dart';
 import 'user_profile_page.dart';
 import '../utils/dialog_utils.dart';
 import '../utils/load_more_coordinator.dart';
+import '../utils/blocked_user_filter.dart';
 
 /// 搜索页面
 class SearchPage extends ConsumerStatefulWidget {
@@ -753,7 +754,23 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   }
 
   Widget _buildSearchResults(ThemeData theme) {
-    if (_hasError && _allPosts.isEmpty) {
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    final posts = _allPosts
+        .where(
+          (post) =>
+              !BlockedUserFilter.isBlockedUsername(post.username, blockedUsernames),
+        )
+        .toList(growable: false);
+    final users = _allUsers
+        .where(
+          (user) =>
+              !BlockedUserFilter.isBlockedUsername(user.username, blockedUsernames),
+        )
+        .toList(growable: false);
+
+    if (_hasError && posts.isEmpty) {
       return ErrorView(
         error: _searchError ?? Exception(context.l10n.search_error),
         stackTrace: _searchErrorStack,
@@ -761,7 +778,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
       );
     }
 
-    if (_allPosts.isEmpty && _allUsers.isEmpty && !_isLoadingMore) {
+    if (posts.isEmpty && users.isEmpty && !_isLoadingMore) {
       if (_currentPage == 1) {
         return const Center(child: LoadingSpinner());
       }
@@ -771,7 +788,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     return Column(
       children: [
         // 排序选项
-        if (_allPosts.isNotEmpty || _allUsers.isNotEmpty)
+        if (posts.isNotEmpty || users.isNotEmpty)
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Row(
@@ -856,7 +873,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                 ],
                 Text(
                   context.l10n.search_resultCount(
-                    _allPosts.length,
+                    posts.length,
                     _hasMorePosts ? '+' : '',
                   ),
                   style: theme.textTheme.bodySmall?.copyWith(
@@ -871,13 +888,13 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             controller: _scrollController,
             padding: const EdgeInsets.all(16),
             itemCount:
-                _allPosts.length +
-                (_allUsers.isNotEmpty ? _allUsers.length + 1 : 0) +
+                posts.length +
+                (users.isNotEmpty ? users.length + 1 : 0) +
                 1,
             itemBuilder: (context, index) {
               // 帖子结果（标准 + AI 混合）
-              if (index < _allPosts.length) {
-                final searchPost = _allPosts[index];
+              if (index < posts.length) {
+                final searchPost = posts[index];
                 final enableLongPress = ref
                     .watch(preferencesProvider)
                     .longPressPreview;
@@ -921,30 +938,30 @@ class _SearchPageState extends ConsumerState<SearchPage> {
               }
 
               // 用户标题
-              final userStartIndex = _allPosts.length;
-              if (_allUsers.isNotEmpty && index == userStartIndex) {
+              final userStartIndex = posts.length;
+              if (users.isNotEmpty && index == userStartIndex) {
                 return Padding(
                   padding: const EdgeInsets.only(top: 16, bottom: 8),
                   child: _buildSectionHeader(
                     context.l10n.search_users,
-                    _allUsers.length,
+                    users.length,
                     _hasMoreUsers,
                   ),
                 );
               }
 
               // 用户结果
-              if (_allUsers.isNotEmpty && index > userStartIndex) {
+              if (users.isNotEmpty && index > userStartIndex) {
                 final userIndex = index - userStartIndex - 1;
-                if (userIndex < _allUsers.length) {
+                if (userIndex < users.length) {
                   return _SearchUserCard(
-                    user: _allUsers[userIndex],
+                    user: users[userIndex],
                     onTap: () {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
                           builder: (_) => UserProfilePage(
-                            username: _allUsers[userIndex].username,
+                            username: users[userIndex].username,
                           ),
                         ),
                       );

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -779,7 +779,9 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     }
 
     if (posts.isEmpty && users.isEmpty && !_isLoadingMore) {
-      if (_currentPage == 1) {
+      // 只有原始结果也为空才可能是首页请求仍在途；
+      // 原始结果非空但过滤后为空 = 全部被本地屏蔽，必须显示空态而非转圈
+      if (_currentPage == 1 && _allPosts.isEmpty && _allUsers.isEmpty) {
         return const Center(child: LoadingSpinner());
       }
       return _buildNoResults();

--- a/lib/pages/tag_topics_page.dart
+++ b/lib/pages/tag_topics_page.dart
@@ -51,6 +51,7 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
   TopicSortOrder _currentOrder = TopicSortOrder.defaultOrder;
   bool _ascending = false;
   List<String> _lastAutoLoadKeywords = const [];
+  Set<String> _lastAutoLoadBlockedUsernames = const <String>{};
   bool? _lastAutoLoadWholeWord;
 
   static final _paginationHelper = PaginationHelpers.forTopics<Topic>(
@@ -88,12 +89,14 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     final prefs = ref.read(preferencesProvider);
     final keywords = prefs.normalizedFilterKeywords;
     final wholeWord = prefs.topicFilterWholeWord;
+    final blockedUsernames = prefs.normalizedBlockedUsernames;
 
     int visibleItemCount() {
       final (visible, _) = TopicKeywordFilter.apply(
         _topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
+        blockedUsernames: blockedUsernames,
       );
       return visible.length;
     }
@@ -104,7 +107,7 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
       isActive: () => mounted,
       itemCount: () => _topics.length,
       visibleItemCount: visibleItemCount,
-      hasKeywordFilter: keywords.isNotEmpty,
+      hasKeywordFilter: keywords.isNotEmpty || blockedUsernames.isNotEmpty,
     );
   }
 
@@ -279,13 +282,19 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     _loadTopics();
   }
 
-  void _syncAutoLoadFilter(List<String> keywords, bool wholeWord) {
+  void _syncAutoLoadFilter(
+    List<String> keywords,
+    bool wholeWord,
+    Set<String> blockedUsernames,
+  ) {
     if (listEquals(_lastAutoLoadKeywords, keywords) &&
-        _lastAutoLoadWholeWord == wholeWord) {
+        _lastAutoLoadWholeWord == wholeWord &&
+        setEquals(_lastAutoLoadBlockedUsernames, blockedUsernames)) {
       return;
     }
     _lastAutoLoadKeywords = List.unmodifiable(keywords);
     _lastAutoLoadWholeWord = wholeWord;
+    _lastAutoLoadBlockedUsernames = Set.unmodifiable(blockedUsernames);
     _loadMoreCoordinator.resetCooldown();
   }
 
@@ -387,11 +396,15 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     final wholeWord = ref.watch(
       preferencesProvider.select((p) => p.topicFilterWholeWord),
     );
-    _syncAutoLoadFilter(keywords, wholeWord);
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
     final (visible, hidden) = TopicKeywordFilter.apply(
       _topics,
       normalizedKeywords: keywords,
       wholeWord: wholeWord,
+      blockedUsernames: blockedUsernames,
     );
     final hintOffset = hidden > 0 ? 1 : 0;
 

--- a/lib/pages/tag_topics_page.dart
+++ b/lib/pages/tag_topics_page.dart
@@ -92,7 +92,7 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
     final blockedUsernames = prefs.normalizedBlockedUsernames;
 
     int visibleItemCount() {
-      final (visible, _) = TopicKeywordFilter.apply(
+      final (visible, _, _) = TopicKeywordFilter.apply(
         _topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
@@ -400,7 +400,7 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
       preferencesProvider.select((p) => p.normalizedBlockedUsernames),
     );
     _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
-    final (visible, hidden) = TopicKeywordFilter.apply(
+    final (visible, hidden, hiddenByBlocked) = TopicKeywordFilter.apply(
       _topics,
       normalizedKeywords: keywords,
       wholeWord: wholeWord,
@@ -417,7 +417,10 @@ class _TagTopicsPageState extends ConsumerState<TagTopicsPage> {
         itemCount: visible.length + hintOffset + 1,
         itemBuilder: (context, index) {
           if (hintOffset > 0 && index == 0) {
-            return KeywordFilterHintBar(hiddenCount: hidden);
+            return KeywordFilterHintBar(
+              hiddenCount: hidden,
+              hiddenByBlocked: hiddenByBlocked,
+            );
           }
           final topicIndex = index - hintOffset;
           if (topicIndex >= visible.length) {

--- a/lib/pages/topic_detail_page/actions/_scroll_actions.dart
+++ b/lib/pages/topic_detail_page/actions/_scroll_actions.dart
@@ -146,7 +146,9 @@ extension _ScrollActions on _TopicDetailPageState {
 
   Future<void> _scrollToTop() async {
     final params = _params;
-    final detail = ref.read(topicDetailProvider(params)).value;
+    final rawDetail = ref.read(topicDetailProvider(params)).value;
+    // postIndex 数学必须基于与列表渲染一致的过滤后数据
+    final detail = rawDetail == null ? null : _filteredDetail(rawDetail);
 
     if (detail != null &&
         detail.postStream.posts.isNotEmpty &&
@@ -196,8 +198,10 @@ extension _ScrollActions on _TopicDetailPageState {
   Future<void> _navigateByPostOrViewport(int delta) async {
     if (!mounted || delta == 0) return;
 
-    final detail = ref.read(topicDetailProvider(_params)).value;
-    if (detail == null) return;
+    final rawDetail = ref.read(topicDetailProvider(_params)).value;
+    if (rawDetail == null) return;
+    // 用过滤后列表导航，J/K 自然跳过被屏蔽楼层
+    final detail = _filteredDetail(rawDetail);
 
     final posts = detail.postStream.posts;
     if (posts.isEmpty) return;
@@ -410,10 +414,13 @@ extension _ScrollActions on _TopicDetailPageState {
 
   Future<void> _scrollToPost(int postNumber) async {
     final params = _params;
-    final detail = ref.read(topicDetailProvider(params)).value;
-    if (detail == null) return;
+    final rawDetail = ref.read(topicDetailProvider(params)).value;
+    if (rawDetail == null) return;
     _controller.selectKeyboardPostNumber(postNumber);
 
+    // postIndex 供 isPostRendered/scrollToPost 查滚动映射表，映射表由
+    // TopicPostList 基于过滤后列表构建，这里必须用同一份数据
+    final detail = _filteredDetail(rawDetail);
     final posts = detail.postStream.posts;
     final postIndex = posts.indexWhere((p) => p.postNumber == postNumber);
     final notifier = ref.read(topicDetailProvider(params).notifier);
@@ -465,8 +472,10 @@ extension _ScrollActions on _TopicDetailPageState {
 
   Future<void> _scrollToPostById(int postId) async {
     final params = _params;
-    final detail = ref.read(topicDetailProvider(params)).value;
-    if (detail == null) return;
+    final rawDetail = ref.read(topicDetailProvider(params)).value;
+    if (rawDetail == null) return;
+    // 同 _scrollToPost：postIndex 与滚动映射表基于同一份过滤后列表
+    final detail = _filteredDetail(rawDetail);
 
     final posts = detail.postStream.posts;
     final postIndex = posts.indexWhere((p) => p.id == postId);

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'dart:math' as math;
 import '../../models/draft.dart';
 import '../../models/topic.dart';
+import '../../utils/blocked_user_filter.dart';
 import '../../utils/responsive.dart';
 import '../../utils/share_utils.dart';
 import '../../providers/preferences_provider.dart';
@@ -167,6 +168,12 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   bool _hasFirstPost = false;
   bool _isCheckTitleVisibilityScheduled = false;
   bool _isRefreshing = false;
+
+  /// 本地屏蔽名单过滤缓存：provider 状态与名单实例都未变时复用同一份
+  /// 过滤结果，保证同一帧内多处读取拿到 identical 的 posts 列表
+  TopicDetail? _blockedFilterInput;
+  Set<String>? _blockedFilterBlocked;
+  TopicDetail? _blockedFilterOutput;
 
   /// 标题是否显示（用 ValueNotifier 隔离 AppBar 更新）
   final ValueNotifier<bool> _showTitleNotifier = ValueNotifier<bool>(false);
@@ -1584,7 +1591,10 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           });
         }
       }
-      final posts = detail?.postStream.posts;
+      // 与 _buildPostListContent 一致，用过滤后列表判断 1 楼是否存在
+      final posts = detail == null
+          ? null
+          : _filteredDetail(detail).postStream.posts;
       if (posts != null && posts.isNotEmpty) {
         final hasFirstPost = posts.first.postNumber == 1;
         if (_hasFirstPost != hasFirstPost) {
@@ -2003,16 +2013,38 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     );
   }
 
+  /// 对 detail 应用本地屏蔽名单（带身份缓存）。
+  ///
+  /// build 与各 action（跳楼、翻页判断等）都要基于同一份过滤后列表做
+  /// postIndex 数学，riverpod 状态实例与名单实例都未变时直接复用上次
+  /// 结果，避免每次 read 都重新过滤。
+  TopicDetail _filteredDetail(TopicDetail detail) {
+    final blocked = ref.read(preferencesProvider).normalizedBlockedUsernames;
+    if (identical(_blockedFilterInput, detail) &&
+        identical(_blockedFilterBlocked, blocked)) {
+      return _blockedFilterOutput!;
+    }
+    final filtered = BlockedUserFilter.filterTopicDetail(detail, blocked);
+    _blockedFilterInput = detail;
+    _blockedFilterBlocked = blocked;
+    _blockedFilterOutput = filtered;
+    return filtered;
+  }
+
   Widget _buildPostListContent(
     BuildContext context,
     TopicDetail detail,
     TopicDetailNotifier notifier,
     bool isLoggedIn,
   ) {
-    final posts = detail.postStream.posts;
+    // 本地屏蔽过滤统一在此出口完成：页面内所有 postIndex（centerPostIndex/
+    // dividerPostIndex/滚动映射）都基于同一份过滤后列表，语义天然一致。
+    // watch 保证名单变化时整页重建。
     final blockedUsernames = ref.watch(
       preferencesProvider.select((p) => p.normalizedBlockedUsernames),
     );
+    detail = _filteredDetail(detail);
+    final posts = detail.postStream.posts;
     final hasFirstPost = posts.isNotEmpty && posts.first.postNumber == 1;
     // read 而非 watch：sessionState 只用于合成 readPostNumbers 推给 controller,
     // 不驱动任何 UI(未读圆点由 PostItem 内部细粒度 Consumer 自行监听)。
@@ -2125,7 +2157,6 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           builder: (context, highlightPostNumber, _) {
             return TopicPostList(
               detail: detail,
-              blockedUsernames: blockedUsernames,
               scrollController: _controller.scrollController,
               centerKey: _centerKey,
               viewportAnchor: _viewportAnchor,

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -2010,6 +2010,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     bool isLoggedIn,
   ) {
     final posts = detail.postStream.posts;
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
     final hasFirstPost = posts.isNotEmpty && posts.first.postNumber == 1;
     // read 而非 watch：sessionState 只用于合成 readPostNumbers 推给 controller,
     // 不驱动任何 UI(未读圆点由 PostItem 内部细粒度 Consumer 自行监听)。
@@ -2089,6 +2092,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           nestedState: nestedState,
           params: nestedParams,
           detail: detail,
+          blockedUsernames: blockedUsernames,
           topicId: widget.topicId,
           scrollController: _controller.scrollController,
           headerKey: _headerKey,
@@ -2121,6 +2125,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           builder: (context, highlightPostNumber, _) {
             return TopicPostList(
               detail: detail,
+              blockedUsernames: blockedUsernames,
               scrollController: _controller.scrollController,
               centerKey: _centerKey,
               viewportAnchor: _viewportAnchor,

--- a/lib/pages/topic_detail_page/widgets/nested_post_list.dart
+++ b/lib/pages/topic_detail_page/widgets/nested_post_list.dart
@@ -4,6 +4,7 @@ import '../../../l10n/s.dart';
 import '../../../models/nested_topic.dart';
 import '../../../models/topic.dart';
 import '../../../providers/nested_topic_provider.dart';
+import '../../../utils/blocked_user_filter.dart';
 import '../../../utils/responsive.dart';
 import '../../../widgets/nested/nested_post_card.dart';
 import '../../../widgets/post/post_item/post_item.dart';
@@ -15,6 +16,7 @@ class NestedPostList extends ConsumerStatefulWidget {
   final NestedTopicState nestedState;
   final NestedTopicParams params;
   final TopicDetail detail;
+  final Set<String> blockedUsernames;
   final int topicId;
   final ScrollController scrollController;
   final GlobalKey headerKey;
@@ -38,6 +40,7 @@ class NestedPostList extends ConsumerStatefulWidget {
     required this.nestedState,
     required this.params,
     required this.detail,
+    required this.blockedUsernames,
     required this.topicId,
     required this.scrollController,
     required this.headerKey,
@@ -112,7 +115,18 @@ class _NestedPostListState extends ConsumerState<NestedPostList> {
 
     // OP 也算可见
     final ns = widget.nestedState;
-    if (ns.opPost != null) _builtPostNumbers.add(ns.opPost!.postNumber);
+    final opPost = ns.opPost != null &&
+            !BlockedUserFilter.isBlockedUsername(
+              ns.opPost!.username,
+              widget.blockedUsernames,
+            )
+        ? ns.opPost
+        : null;
+    final roots = BlockedUserFilter.visibleNestedNodes(
+      ns.roots,
+      widget.blockedUsernames,
+    );
+    if (opPost != null) _builtPostNumbers.add(opPost.postNumber);
     final p = widget.params;
 
     return NotificationListener<ScrollNotification>(
@@ -133,10 +147,10 @@ class _NestedPostListState extends ConsumerState<NestedPostList> {
             ),
           ),
 
-          if (ns.opPost != null)
+          if (opPost != null)
             SliverToBoxAdapter(
               child: PostItem(
-                post: ns.opPost!,
+                post: opPost,
                 topicId: widget.topicId,
                 isTopicOwner: true,
                 topicHasAcceptedAnswer: widget.detail.hasAcceptedAnswer,
@@ -219,22 +233,23 @@ class _NestedPostListState extends ConsumerState<NestedPostList> {
 
           SliverList.builder(
             itemCount:
-                ns.roots.length + (ns.hasMoreRoots || ns.isLoadingMore ? 1 : 0),
+                roots.length + (ns.hasMoreRoots || ns.isLoadingMore ? 1 : 0),
             itemBuilder: (context, index) {
-              if (index >= ns.roots.length) {
+              if (index >= roots.length) {
                 return _buildLoadMore(context);
               }
               // 收集可见帖子号（含子节点）
-              _collectVisiblePostNumbers(ns.roots[index]);
+              _collectVisiblePostNumbers(roots[index]);
               return NestedPostCard(
-                node: ns.roots[index],
+                node: roots[index],
                 topicId: widget.topicId,
                 detail: widget.detail,
                 params: p,
                 depth: 0,
                 maxDepth: maxDepth,
-                isLastChild: index == ns.roots.length - 1,
+                isLastChild: index == roots.length - 1,
                 isLoggedIn: widget.isLoggedIn,
+                blockedUsernames: widget.blockedUsernames,
                 onReply: widget.onReply,
                 onEdit: widget.onEdit,
                 onRefreshPost: widget.onRefreshPost,

--- a/lib/pages/topic_detail_page/widgets/topic_post_list.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_post_list.dart
@@ -9,6 +9,7 @@ import '../../../l10n/s.dart';
 import '../../../models/topic.dart';
 import '../../../providers/message_bus_providers.dart';
 import '../../../services/toast_service.dart';
+import '../../../utils/blocked_user_filter.dart';
 import '../../../utils/responsive.dart';
 import '../../../utils/time_utils.dart';
 import '../../../widgets/common/loading_spinner.dart';
@@ -29,6 +30,7 @@ import 'typing_indicator.dart';
 /// 保留跨块文本选择能力。
 class TopicPostList extends StatefulWidget {
   final TopicDetail detail;
+  final Set<String> blockedUsernames;
   final AutoScrollController scrollController;
   final GlobalKey centerKey;
   final GlobalKey headerKey;
@@ -94,6 +96,7 @@ class TopicPostList extends StatefulWidget {
   const TopicPostList({
     super.key,
     required this.detail,
+    required this.blockedUsernames,
     required this.scrollController,
     required this.centerKey,
     required this.headerKey,
@@ -145,6 +148,9 @@ class TopicPostList extends StatefulWidget {
 class _TopicPostListState extends State<TopicPostList> {
   int? _lastReportedPostNumber;
   bool _isThrottled = false;
+
+  List<Post> get _visiblePosts =>
+      BlockedUserFilter.visiblePosts(detail.postStream.posts, widget.blockedUsernames);
   List<_PostRenderSegment> _renderSegments = const [];
   Map<int, int> _postIndexToScrollIndex = const {};
   Map<int, int> _scrollIndexToPostNumber = const {};
@@ -219,7 +225,7 @@ class _TopicPostListState extends State<TopicPostList> {
   /// - 滚到最底时，eyeline 在视口底部，确保能显示最后一个帖子
   /// 这使得进度指示器在整个滚动过程中平滑过渡，无需硬编码特殊情况。
   void _updateFirstVisiblePost() {
-    final posts = detail.postStream.posts;
+    final posts = _visiblePosts;
     if (posts.isEmpty) return;
 
     final tagMap = scrollController.tagMap;
@@ -555,10 +561,19 @@ class _TopicPostListState extends State<TopicPostList> {
 
   @override
   Widget build(BuildContext context) {
-    final posts = detail.postStream.posts;
+    final posts = _visiblePosts;
     final hasFirstPost = posts.isNotEmpty && posts.first.postNumber == 1;
     _buildRenderSegments(posts);
-    final centerScrollIndex = _postIndexToScrollIndex[centerPostIndex] ?? 0;
+    final centerPostNumber =
+        widget.centerPostIndex >= 0 &&
+            widget.centerPostIndex < detail.postStream.posts.length
+        ? detail.postStream.posts[widget.centerPostIndex].postNumber
+        : null;
+    final centerVisibleIndex = centerPostNumber == null
+        ? null
+        : _postNumberToIndex[centerPostNumber];
+    final centerScrollIndex =
+        centerVisibleIndex == null ? 0 : (_postIndexToScrollIndex[centerVisibleIndex] ?? 0);
 
     // 不再包系统 SelectionArea:正文选区全部由 FluxdoRender 自研选区承担
     // (含未登录场景 —— toolbar 降级只留「复制」),header/footer 等本就
@@ -748,7 +763,7 @@ class _TopicPostListState extends State<TopicPostList> {
 
   /// 判断是否需要显示日期分割线
   bool _shouldShowDateSeparator(int postIndex) {
-    final posts = detail.postStream.posts;
+    final posts = _visiblePosts;
     if (postIndex <= 0) return false;
 
     final currentDate = posts[postIndex].createdAt;
@@ -776,7 +791,7 @@ class _TopicPostListState extends State<TopicPostList> {
     final dateSeparatorLabel = showTopSeparator
         ? TimeUtils.formatSmartDate(post.createdAt)
         : null;
-    final posts_ = detail.postStream.posts;
+    final posts_ = _visiblePosts;
     final nextPostIndex = postIndex + 1;
     final showBottomSeparator =
         nextPostIndex < posts_.length &&
@@ -790,7 +805,10 @@ class _TopicPostListState extends State<TopicPostList> {
     // 能匹配到具体 boost 时不高亮帖子，匹配不到时回退到高亮帖子
     final canLocateBoost =
         boostUsername != null &&
-        (post.boosts ?? []).any((b) => b.user.username == boostUsername);
+        BlockedUserFilter.visibleBoosts(
+          post.boosts ?? const <Boost>[],
+          widget.blockedUsernames,
+        ).any((b) => b.user.username == boostUsername);
     final highlight = isTargetPost && !canLocateBoost;
     final replyTarget = post.postNumber == 1 ? null : post;
     // OP 帖底部的 "俺也一样" 按钮; 非 OP 或服务端没启用时为 null

--- a/lib/pages/topic_detail_page/widgets/topic_post_list.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_post_list.dart
@@ -9,7 +9,6 @@ import '../../../l10n/s.dart';
 import '../../../models/topic.dart';
 import '../../../providers/message_bus_providers.dart';
 import '../../../services/toast_service.dart';
-import '../../../utils/blocked_user_filter.dart';
 import '../../../utils/responsive.dart';
 import '../../../utils/time_utils.dart';
 import '../../../widgets/common/loading_spinner.dart';
@@ -30,7 +29,6 @@ import 'typing_indicator.dart';
 /// 保留跨块文本选择能力。
 class TopicPostList extends StatefulWidget {
   final TopicDetail detail;
-  final Set<String> blockedUsernames;
   final AutoScrollController scrollController;
   final GlobalKey centerKey;
   final GlobalKey headerKey;
@@ -96,7 +94,6 @@ class TopicPostList extends StatefulWidget {
   const TopicPostList({
     super.key,
     required this.detail,
-    required this.blockedUsernames,
     required this.scrollController,
     required this.centerKey,
     required this.headerKey,
@@ -148,9 +145,6 @@ class TopicPostList extends StatefulWidget {
 class _TopicPostListState extends State<TopicPostList> {
   int? _lastReportedPostNumber;
   bool _isThrottled = false;
-
-  List<Post> get _visiblePosts =>
-      BlockedUserFilter.visiblePosts(detail.postStream.posts, widget.blockedUsernames);
   List<_PostRenderSegment> _renderSegments = const [];
   Map<int, int> _postIndexToScrollIndex = const {};
   Map<int, int> _scrollIndexToPostNumber = const {};
@@ -225,7 +219,7 @@ class _TopicPostListState extends State<TopicPostList> {
   /// - 滚到最底时，eyeline 在视口底部，确保能显示最后一个帖子
   /// 这使得进度指示器在整个滚动过程中平滑过渡，无需硬编码特殊情况。
   void _updateFirstVisiblePost() {
-    final posts = _visiblePosts;
+    final posts = detail.postStream.posts;
     if (posts.isEmpty) return;
 
     final tagMap = scrollController.tagMap;
@@ -561,19 +555,10 @@ class _TopicPostListState extends State<TopicPostList> {
 
   @override
   Widget build(BuildContext context) {
-    final posts = _visiblePosts;
+    final posts = detail.postStream.posts;
     final hasFirstPost = posts.isNotEmpty && posts.first.postNumber == 1;
     _buildRenderSegments(posts);
-    final centerPostNumber =
-        widget.centerPostIndex >= 0 &&
-            widget.centerPostIndex < detail.postStream.posts.length
-        ? detail.postStream.posts[widget.centerPostIndex].postNumber
-        : null;
-    final centerVisibleIndex = centerPostNumber == null
-        ? null
-        : _postNumberToIndex[centerPostNumber];
-    final centerScrollIndex =
-        centerVisibleIndex == null ? 0 : (_postIndexToScrollIndex[centerVisibleIndex] ?? 0);
+    final centerScrollIndex = _postIndexToScrollIndex[centerPostIndex] ?? 0;
 
     // 不再包系统 SelectionArea:正文选区全部由 FluxdoRender 自研选区承担
     // (含未登录场景 —— toolbar 降级只留「复制」),header/footer 等本就
@@ -763,7 +748,7 @@ class _TopicPostListState extends State<TopicPostList> {
 
   /// 判断是否需要显示日期分割线
   bool _shouldShowDateSeparator(int postIndex) {
-    final posts = _visiblePosts;
+    final posts = detail.postStream.posts;
     if (postIndex <= 0) return false;
 
     final currentDate = posts[postIndex].createdAt;
@@ -791,7 +776,7 @@ class _TopicPostListState extends State<TopicPostList> {
     final dateSeparatorLabel = showTopSeparator
         ? TimeUtils.formatSmartDate(post.createdAt)
         : null;
-    final posts_ = _visiblePosts;
+    final posts_ = detail.postStream.posts;
     final nextPostIndex = postIndex + 1;
     final showBottomSeparator =
         nextPostIndex < posts_.length &&
@@ -805,10 +790,7 @@ class _TopicPostListState extends State<TopicPostList> {
     // 能匹配到具体 boost 时不高亮帖子，匹配不到时回退到高亮帖子
     final canLocateBoost =
         boostUsername != null &&
-        BlockedUserFilter.visibleBoosts(
-          post.boosts ?? const <Boost>[],
-          widget.blockedUsernames,
-        ).any((b) => b.user.username == boostUsername);
+        (post.boosts ?? []).any((b) => b.user.username == boostUsername);
     final highlight = isTargetPost && !canLocateBoost;
     final replyTarget = post.postNumber == 1 ? null : post;
     // OP 帖底部的 "俺也一样" 按钮; 非 OP 或服务端没启用时为 null

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -22,6 +22,7 @@ import 'search_page.dart';
 import '../models/search_filter.dart';
 import '../widgets/common/notification_icon_button.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
+import '../widgets/topic/keyword_filter_hint_bar.dart';
 import '../widgets/topic/sort_and_tags_bar.dart';
 import '../widgets/topic/filter_dropdown.dart';
 import '../widgets/topic/topic_item_builder.dart';
@@ -1337,7 +1338,7 @@ class _TopicListState extends ConsumerState<_TopicList>
     int visibleItemCount() {
       final raw =
           ref.read(topicListProvider(providerKey)).value ?? const <Topic>[];
-      final (visible, _) = TopicKeywordFilter.apply(
+      final (visible, _, _) = TopicKeywordFilter.apply(
         raw,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
@@ -1454,13 +1455,17 @@ class _TopicListState extends ConsumerState<_TopicList>
       preferencesProvider.select((p) => p.normalizedBlockedUsernames),
     );
     _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
+    var hiddenCount = 0;
+    var hiddenByBlocked = 0;
     final visibleTopicsAsync = topicsAsync.whenData((topics) {
-      final (visible, _) = TopicKeywordFilter.apply(
+      final (visible, hidden, byBlocked) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
         blockedUsernames: blockedUsernames,
       );
+      hiddenCount = hidden;
+      hiddenByBlocked = byBlocked;
       return visible;
     });
     final selectedTopicId = ref.watch(selectedTopicProvider).topicId;
@@ -1518,7 +1523,8 @@ class _TopicListState extends ConsumerState<_TopicList>
           widget.categoryId,
         );
         final newTopicOffset = hasNewTopics ? 1 : 0;
-        final headerOffset = newTopicOffset;
+        final hintOffset = hiddenCount > 0 ? 1 : 0;
+        final headerOffset = newTopicOffset + hintOffset;
 
         return DesktopRefreshIndicator(
           refreshIndicatorKey: _refreshIndicatorKey,
@@ -1561,6 +1567,12 @@ class _TopicListState extends ConsumerState<_TopicList>
                       context,
                       newTopicCount,
                       providerKey,
+                    );
+                  }
+                  if (hintOffset > 0 && index == newTopicOffset) {
+                    return KeywordFilterHintBar(
+                      hiddenCount: hiddenCount,
+                      hiddenByBlocked: hiddenByBlocked,
                     );
                   }
                   final topicIndex = index - headerOffset;

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -22,7 +22,6 @@ import 'search_page.dart';
 import '../models/search_filter.dart';
 import '../widgets/common/notification_icon_button.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
-import '../widgets/topic/keyword_filter_hint_bar.dart';
 import '../widgets/topic/sort_and_tags_bar.dart';
 import '../widgets/topic/filter_dropdown.dart';
 import '../widgets/topic/topic_item_builder.dart';
@@ -1206,6 +1205,7 @@ class _TopicListState extends ConsumerState<_TopicList>
   final TopicLoadMoreCoordinator _loadMoreCoordinator =
       TopicLoadMoreCoordinator();
   List<String> _lastAutoLoadKeywords = const [];
+  Set<String> _lastAutoLoadBlockedUsernames = const <String>{};
   bool? _lastAutoLoadWholeWord;
 
   @override
@@ -1328,6 +1328,7 @@ class _TopicListState extends ConsumerState<_TopicList>
     final prefs = ref.read(preferencesProvider);
     final keywords = prefs.normalizedFilterKeywords;
     final wholeWord = prefs.topicFilterWholeWord;
+    final blockedUsernames = prefs.normalizedBlockedUsernames;
 
     int itemCount() {
       return ref.read(topicListProvider(providerKey)).value?.length ?? 0;
@@ -1340,6 +1341,7 @@ class _TopicListState extends ConsumerState<_TopicList>
         raw,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
+        blockedUsernames: blockedUsernames,
       );
       return visible.length;
     }
@@ -1350,17 +1352,23 @@ class _TopicListState extends ConsumerState<_TopicList>
       isActive: () => mounted,
       itemCount: itemCount,
       visibleItemCount: visibleItemCount,
-      hasKeywordFilter: keywords.isNotEmpty,
+      hasKeywordFilter: keywords.isNotEmpty || blockedUsernames.isNotEmpty,
     );
   }
 
-  void _syncAutoLoadFilter(List<String> keywords, bool wholeWord) {
+  void _syncAutoLoadFilter(
+    List<String> keywords,
+    bool wholeWord,
+    Set<String> blockedUsernames,
+  ) {
     if (listEquals(_lastAutoLoadKeywords, keywords) &&
-        _lastAutoLoadWholeWord == wholeWord) {
+        _lastAutoLoadWholeWord == wholeWord &&
+        setEquals(_lastAutoLoadBlockedUsernames, blockedUsernames)) {
       return;
     }
     _lastAutoLoadKeywords = List.unmodifiable(keywords);
     _lastAutoLoadWholeWord = wholeWord;
+    _lastAutoLoadBlockedUsernames = Set.unmodifiable(blockedUsernames);
     _loadMoreCoordinator.resetCooldown();
   }
 
@@ -1442,15 +1450,17 @@ class _TopicListState extends ConsumerState<_TopicList>
     final wholeWord = ref.watch(
       preferencesProvider.select((p) => p.topicFilterWholeWord),
     );
-    _syncAutoLoadFilter(keywords, wholeWord);
-    var hiddenCount = 0;
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    _syncAutoLoadFilter(keywords, wholeWord, blockedUsernames);
     final visibleTopicsAsync = topicsAsync.whenData((topics) {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: keywords,
         wholeWord: wholeWord,
+        blockedUsernames: blockedUsernames,
       );
-      hiddenCount = hidden;
       return visible;
     });
     final selectedTopicId = ref.watch(selectedTopicProvider).topicId;
@@ -1507,9 +1517,8 @@ class _TopicListState extends ConsumerState<_TopicList>
         final newTopicCount = incomingState.incomingCountForCategory(
           widget.categoryId,
         );
-        final hintOffset = hiddenCount > 0 ? 1 : 0;
         final newTopicOffset = hasNewTopics ? 1 : 0;
-        final headerOffset = hintOffset + newTopicOffset;
+        final headerOffset = newTopicOffset;
 
         return DesktopRefreshIndicator(
           refreshIndicatorKey: _refreshIndicatorKey,
@@ -1554,10 +1563,6 @@ class _TopicListState extends ConsumerState<_TopicList>
                       providerKey,
                     );
                   }
-                  if (hintOffset > 0 && index == newTopicOffset) {
-                    return KeywordFilterHintBar(hiddenCount: hiddenCount);
-                  }
-
                   final topicIndex = index - headerOffset;
                   if (topicIndex >= topics.length) {
                     final notifier = ref.watch(

--- a/lib/providers/message_bus/notification_providers.dart
+++ b/lib/providers/message_bus/notification_providers.dart
@@ -5,6 +5,8 @@ import '../../services/message_bus_service.dart';
 import '../../services/local_notification_service.dart';
 import '../../models/notification.dart';
 import '../discourse_providers.dart';
+import '../preferences_provider.dart';
+import '../../utils/blocked_user_filter.dart';
 import 'models.dart';
 import 'message_bus_service_provider.dart';
 import 'topic_tracking_providers.dart';
@@ -113,8 +115,16 @@ class NotificationChannelNotifier extends Notifier<void> {
               if (notification is Map<String, dynamic>) {
                 try {
                   final newNotification = DiscourseNotification.fromJson(notification);
-                  debugPrint('[Notification] 添加新通知到列表: id=${newNotification.id}');
-                  recentNotifier.addNotification(newNotification);
+                  final blockedUsernames = ref
+                      .read(preferencesProvider)
+                      .normalizedBlockedUsernames;
+                  if (!BlockedUserFilter.isBlockedNotification(
+                    newNotification,
+                    blockedUsernames,
+                  )) {
+                    debugPrint('[Notification] 添加新通知到列表: id=${newNotification.id}');
+                    recentNotifier.addNotification(newNotification);
+                  }
                 } catch (e) {
                   debugPrint('[Notification] 解析新通知失败: $e');
                 }
@@ -215,6 +225,13 @@ class NotificationAlertChannelNotifier extends Notifier<void> {
         final excerpt = data['excerpt'] as String? ?? '';
         final username = data['username'] as String? ?? '';
         final notificationType = data['notification_type'] as int?;
+
+        final blockedUsernames = ref
+            .read(preferencesProvider)
+            .normalizedBlockedUsernames;
+        if (BlockedUserFilter.isBlockedUsername(username, blockedUsernames)) {
+          return;
+        }
 
         // 构建通知标题（参考 desktop-notifications.js 的 i18nKey 逻辑）
         String title = topicTitle;

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../navigation/nav_action_bus.dart';
 import '../services/network/request_scheduler_config.dart';
 import '../services/cf_challenge_service.dart';
+import '../utils/blocked_user_filter.dart';
 import 'theme_provider.dart';
 
 /// 嵌套视图连接线样式
@@ -108,12 +109,19 @@ class AppPreferences {
   /// 话题关键词过滤：是否启用完整词匹配（仅影响英文/数字等 word-char 关键词）
   final bool topicFilterWholeWord;
 
+  /// 本地内容屏蔽用户名列表。只影响本客户端的展示，不会同步到 Discourse。
+  final List<String> blockedUsernames;
+
   /// 话题关键词过滤的归一化形式（lowercase），匹配时使用
   late final List<String> normalizedFilterKeywords = List.unmodifiable(
     topicFilterKeywords
         .map((keyword) => keyword.trim().toLowerCase())
         .where((keyword) => keyword.isNotEmpty),
   );
+
+  /// 本地内容屏蔽用户名的归一化集合，匹配时使用。
+  late final Set<String> normalizedBlockedUsernames =
+      BlockedUserFilter.normalizedUsernames(blockedUsernames);
 
   /// 崩溃日志上报（仅 Android）
   final bool crashlytics;
@@ -219,6 +227,7 @@ class AppPreferences {
     required this.clipboardTopicLinkDetection,
     required this.topicFilterKeywords,
     this.topicFilterWholeWord = false,
+    this.blockedUsernames = const [],
     required this.crashlytics,
     required this.portraitLock,
     required this.hideBarOnScroll,
@@ -263,6 +272,7 @@ class AppPreferences {
     bool? clipboardTopicLinkDetection,
     List<String>? topicFilterKeywords,
     bool? topicFilterWholeWord,
+    List<String>? blockedUsernames,
     bool? crashlytics,
     bool? portraitLock,
     bool? hideBarOnScroll,
@@ -308,6 +318,7 @@ class AppPreferences {
           clipboardTopicLinkDetection ?? this.clipboardTopicLinkDetection,
       topicFilterKeywords: topicFilterKeywords ?? this.topicFilterKeywords,
       topicFilterWholeWord: topicFilterWholeWord ?? this.topicFilterWholeWord,
+      blockedUsernames: blockedUsernames ?? this.blockedUsernames,
       crashlytics: crashlytics ?? this.crashlytics,
       portraitLock: portraitLock ?? this.portraitLock,
       hideBarOnScroll: hideBarOnScroll ?? this.hideBarOnScroll,
@@ -370,6 +381,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
       'pref_clipboard_topic_link_detection';
   static const String _topicFilterKeywordsKey = 'pref_topic_filter_keywords';
   static const String _topicFilterWholeWordKey = 'pref_topic_filter_whole_word';
+  static const String _blockedUsernamesKey = 'pref_blocked_usernames';
   static const String _crashlyticsKey = 'pref_crashlytics';
   static const String _portraitLockKey = 'pref_portrait_lock';
   static const String _hideBarOnScrollKey = 'pref_hide_bar_on_scroll';
@@ -433,6 +445,8 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
               _prefs.getStringList(_topicFilterKeywordsKey) ?? const [],
           topicFilterWholeWord:
               _prefs.getBool(_topicFilterWholeWordKey) ?? false,
+          blockedUsernames:
+              _prefs.getStringList(_blockedUsernamesKey) ?? const [],
           crashlytics: _prefs.getBool(_crashlyticsKey) ?? true,
           portraitLock: _prefs.getBool(_portraitLockKey) ?? false,
           hideBarOnScroll: _prefs.getBool(_hideBarOnScrollKey) ?? true,
@@ -565,6 +579,17 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
     if (state.topicFilterWholeWord == enabled) return;
     state = state.copyWith(topicFilterWholeWord: enabled);
     await _prefs.setBool(_topicFilterWholeWordKey, enabled);
+  }
+
+  Future<void> setBlockedUsernames(List<String> usernames) async {
+    final sanitized = BlockedUserFilter.sanitizeUsernames(usernames);
+    final current = state.blockedUsernames;
+    if (sanitized.length == current.length &&
+        const ListEquality<String>().equals(sanitized, current)) {
+      return;
+    }
+    state = state.copyWith(blockedUsernames: sanitized);
+    await _prefs.setStringList(_blockedUsernamesKey, sanitized);
   }
 
   Future<void> setCrashlytics(bool enabled) async {

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -10,6 +10,7 @@ import '../../providers/ai_post_review_provider.dart';
 import '../../providers/preferences_provider.dart';
 import '../../services/toast_service.dart';
 import '../../utils/dialog_utils.dart';
+import '../../utils/blocked_user_filter.dart';
 import '../../widgets/ai/ai_model_select_sheet.dart';
 import '../../providers/sticker_provider.dart';
 import '../../services/sticker_market_service.dart';
@@ -66,6 +67,21 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
             return l10n.preferences_topicFilterKeywordsCount(count);
           },
           onTap: (context, ref) => showTopicFilterKeywordsDialog(context, ref),
+        ),
+        ActionModel(
+          id: 'blockedUsernames',
+          title: l10n.preferences_blockedUsernames,
+          subtitle: l10n.preferences_blockedUsernamesDesc,
+          icon: Symbols.person_off_rounded,
+          getDynamicSubtitle: (ref) {
+            final count = ref
+                .watch(preferencesProvider)
+                .blockedUsernames
+                .length;
+            if (count == 0) return l10n.preferences_blockedUsernamesEmpty;
+            return l10n.preferences_blockedUsernamesCount(count);
+          },
+          onTap: (context, ref) => showBlockedUsernamesDialog(context, ref),
         ),
         PlatformConditionalModel(
           inner: SwitchModel(
@@ -227,14 +243,14 @@ class _TopicFilterKeywordsDialogState
     extends State<_TopicFilterKeywordsDialog> {
   late final TextEditingController _controller;
   late bool _wholeWord;
+  late final List<String> _keywords;
 
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController(
-      text: widget.initialKeywords.join('\n'),
-    );
+    _controller = TextEditingController(text: '');
     _wholeWord = widget.initialWholeWord;
+    _keywords = List<String>.from(widget.initialKeywords);
   }
 
   @override
@@ -248,6 +264,7 @@ class _TopicFilterKeywordsDialogState
     final l10n = context.l10n;
 
     return AlertDialog(
+      scrollable: true,
       title: Text(l10n.preferences_topicFilterKeywords),
       content: SizedBox(
         width: 420,
@@ -260,26 +277,30 @@ class _TopicFilterKeywordsDialogState
               child: TextButton.icon(
                 icon: const Icon(Symbols.clear_all_rounded, size: 18),
                 label: Text(l10n.common_clear),
-                onPressed: () => _controller.clear(),
+                onPressed: () => setState(() {
+                  _keywords.clear();
+                  _controller.clear();
+                }),
               ),
             ),
-            TextField(
+            _EntryChipsEditor(
               controller: _controller,
-              decoration: InputDecoration(
-                hintText: l10n.preferences_topicFilterKeywordsHint,
-                helperText: l10n.preferences_topicFilterKeywordsHelper,
-                helperMaxLines: 2,
-                border: const OutlineInputBorder(),
-              ),
-              keyboardType: TextInputType.multiline,
-              minLines: 5,
-              maxLines: 10,
-              autofocus: true,
+              entries: _keywords,
+              hintText: l10n.preferences_topicFilterKeywordsHint,
+              helperText: l10n.preferences_topicFilterKeywordsHelper,
+              normalizeEntry: (value) => value.trim(),
+              isDuplicate: (existing, candidate) => existing == candidate,
+              onEntriesChanged: (entries) {
+                setState(() {
+                  _keywords
+                    ..clear()
+                    ..addAll(entries);
+                });
+              },
             ),
             const SizedBox(height: 8),
             SwitchListTile.adaptive(
               contentPadding: EdgeInsets.zero,
-              dense: true,
               title: Text(l10n.preferences_topicFilterWholeWord),
               subtitle: Text(l10n.preferences_topicFilterWholeWordDesc),
               value: _wholeWord,
@@ -295,14 +316,245 @@ class _TopicFilterKeywordsDialogState
         ),
         FilledButton(
           onPressed: () {
-            final keywords = _controller.text
-                .split('\n')
-                .map((keyword) => keyword.trim())
-                .where((keyword) => keyword.isNotEmpty)
-                .toList();
+            final keywords = _appendTokenEntries(
+              _keywords,
+              _controller.text,
+              normalizeEntry: (value) => value.trim(),
+              isDuplicate: (existing, candidate) => existing == candidate,
+            );
             Navigator.pop(context, (keywords: keywords, wholeWord: _wholeWord));
           },
           child: Text(l10n.common_confirm),
+        ),
+      ],
+    );
+  }
+}
+
+Future<void> showBlockedUsernamesDialog(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final usernames = ref.read(preferencesProvider).blockedUsernames;
+  final result = await showAppDialog<List<String>>(
+    context: context,
+    builder: (_) => _BlockedUsernamesDialog(initialUsernames: usernames),
+  );
+  if (result == null || !context.mounted) return;
+  await ref.read(preferencesProvider.notifier).setBlockedUsernames(result);
+}
+
+class _BlockedUsernamesDialog extends StatefulWidget {
+  final List<String> initialUsernames;
+
+  const _BlockedUsernamesDialog({required this.initialUsernames});
+
+  @override
+  State<_BlockedUsernamesDialog> createState() =>
+      _BlockedUsernamesDialogState();
+}
+
+class _BlockedUsernamesDialogState extends State<_BlockedUsernamesDialog> {
+  late final TextEditingController _controller;
+  late final List<String> _usernames;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: '');
+    _usernames = BlockedUserFilter.sanitizeUsernames(widget.initialUsernames);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return AlertDialog(
+      scrollable: true,
+      title: Text(l10n.preferences_blockedUsernames),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                icon: const Icon(Symbols.clear_all_rounded, size: 18),
+                label: Text(l10n.common_clear),
+                onPressed: () => setState(() {
+                  _usernames.clear();
+                  _controller.clear();
+                }),
+              ),
+            ),
+            _EntryChipsEditor(
+              controller: _controller,
+              entries: _usernames,
+              hintText: l10n.preferences_blockedUsernamesHint,
+              helperText: l10n.preferences_blockedUsernamesHelper,
+              normalizeEntry: BlockedUserFilter.stripAtPrefix,
+              isDuplicate: (existing, candidate) =>
+                  BlockedUserFilter.normalizeUsername(existing) ==
+                  BlockedUserFilter.normalizeUsername(candidate),
+              onEntriesChanged: (entries) {
+                setState(() {
+                  _usernames
+                    ..clear()
+                    ..addAll(entries);
+                });
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(l10n.common_cancel),
+        ),
+        FilledButton(
+          onPressed: () {
+            final usernames = _appendTokenEntries(
+              _usernames,
+              _controller.text,
+              normalizeEntry: BlockedUserFilter.stripAtPrefix,
+              isDuplicate: (existing, candidate) =>
+                  BlockedUserFilter.normalizeUsername(existing) ==
+                  BlockedUserFilter.normalizeUsername(candidate),
+            );
+            Navigator.pop(
+              context,
+              BlockedUserFilter.sanitizeUsernames(usernames),
+            );
+          },
+          child: Text(l10n.common_confirm),
+        ),
+      ],
+    );
+  }
+}
+
+typedef _TokenDuplicate = bool Function(String existing, String candidate);
+
+List<String> _appendTokenEntries(
+  List<String> existing,
+  String rawInput, {
+  required String Function(String value) normalizeEntry,
+  required _TokenDuplicate isDuplicate,
+}) {
+  final entries = List<String>.from(existing);
+  for (final part in rawInput.split(RegExp(r'[\r\n]+'))) {
+    final candidate = normalizeEntry(part);
+    if (candidate.isEmpty ||
+        entries.any((entry) => isDuplicate(entry, candidate))) {
+      continue;
+    }
+    entries.add(candidate);
+  }
+  return entries;
+}
+
+/// 回车后将本次输入立刻转成可删除的气泡，避免多行文本框在移动端键盘出现时
+/// 挤压其余设置项。粘贴多行内容时也会一次识别为多个条目。
+class _EntryChipsEditor extends StatefulWidget {
+  final TextEditingController controller;
+  final List<String> entries;
+  final String hintText;
+  final String helperText;
+  final String Function(String value) normalizeEntry;
+  final _TokenDuplicate isDuplicate;
+  final ValueChanged<List<String>> onEntriesChanged;
+
+  const _EntryChipsEditor({
+    required this.controller,
+    required this.entries,
+    required this.hintText,
+    required this.helperText,
+    required this.normalizeEntry,
+    required this.isDuplicate,
+    required this.onEntriesChanged,
+  });
+
+  @override
+  State<_EntryChipsEditor> createState() => _EntryChipsEditorState();
+}
+
+class _EntryChipsEditorState extends State<_EntryChipsEditor> {
+  final FocusNode _focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  void _commitInput([String? submittedValue]) {
+    final nextEntries = _appendTokenEntries(
+      widget.entries,
+      submittedValue ?? widget.controller.text,
+      normalizeEntry: widget.normalizeEntry,
+      isDuplicate: widget.isDuplicate,
+    );
+    widget.controller.clear();
+    if (nextEntries.length != widget.entries.length) {
+      widget.onEntriesChanged(nextEntries);
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _focusNode.requestFocus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (widget.entries.isNotEmpty) ...[
+          Semantics(
+            liveRegion: true,
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (var index = 0; index < widget.entries.length; index++)
+                  InputChip(
+                    label: Text(widget.entries[index]),
+                    onDeleted: () {
+                      final nextEntries = List<String>.from(widget.entries)
+                        ..removeAt(index);
+                      widget.onEntriesChanged(nextEntries);
+                    },
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+        ],
+        TextField(
+          controller: widget.controller,
+          focusNode: _focusNode,
+          decoration: InputDecoration(
+            hintText: widget.hintText,
+            helperText: widget.helperText,
+            helperMaxLines: 2,
+            border: const OutlineInputBorder(),
+          ),
+          keyboardType: TextInputType.text,
+          textInputAction: TextInputAction.done,
+          autofocus: true,
+          onSubmitted: _commitInput,
+          onChanged: (value) {
+            if (value.contains('\n')) _commitInput(value);
+          },
+          style: theme.textTheme.bodyLarge,
         ),
       ],
     );

--- a/lib/utils/blocked_user_filter.dart
+++ b/lib/utils/blocked_user_filter.dart
@@ -1,0 +1,123 @@
+import '../models/nested_topic.dart';
+import '../models/notification.dart';
+import '../models/topic.dart';
+
+/// 本地内容屏蔽名单的匹配与数据过滤。
+///
+/// 名单只由 [AppPreferences] 持久化在当前设备；这里绝不向 Discourse
+/// 发出 mute / ignore 请求。所有用户名以 trim + lowercase 的精确匹配处理。
+class BlockedUserFilter {
+  BlockedUserFilter._();
+
+  /// 用户名输入框无需填写 Discourse 展示时常见的 `@` 前缀。
+  ///
+  /// 兼容用户误输入 `@alice` 的情况，持久化和匹配均使用不带前缀的用户名。
+  static String stripAtPrefix(String username) {
+    final trimmed = username.trim();
+    return trimmed.startsWith('@') ? trimmed.substring(1).trim() : trimmed;
+  }
+
+  static String normalizeUsername(String username) =>
+      stripAtPrefix(username).toLowerCase();
+
+  /// 去空、按大小写无关的用户名去重，同时保留第一条输入的显示形式。
+  static List<String> sanitizeUsernames(Iterable<String> usernames) {
+    final seen = <String>{};
+    final result = <String>[];
+    for (final username in usernames) {
+      final cleaned = stripAtPrefix(username);
+      final normalized = normalizeUsername(cleaned);
+      if (normalized.isEmpty || !seen.add(normalized)) continue;
+      result.add(cleaned);
+    }
+    return result;
+  }
+
+  static Set<String> normalizedUsernames(Iterable<String> usernames) {
+    return Set.unmodifiable(
+      usernames.map(normalizeUsername).where((username) => username.isNotEmpty),
+    );
+  }
+
+  static bool isBlockedUsername(
+    String? username,
+    Set<String> blockedUsernames,
+  ) {
+    if (username == null || blockedUsernames.isEmpty) return false;
+    return blockedUsernames.contains(normalizeUsername(username));
+  }
+
+  /// 话题列表的 posters[0] 是 Discourse 返回的 Original Poster。
+  /// 无法确定楼主时宁可保留话题，避免把别人的话题误判为屏蔽对象。
+  static bool isBlockedTopic(Topic topic, Set<String> blockedUsernames) {
+    if (blockedUsernames.isEmpty || topic.posters.isEmpty) return false;
+    return isBlockedUsername(
+      topic.posters.first.user?.username,
+      blockedUsernames,
+    );
+  }
+
+  static List<Topic> visibleTopics(
+    Iterable<Topic> topics,
+    Set<String> blockedUsernames,
+  ) {
+    if (blockedUsernames.isEmpty) return List<Topic>.from(topics);
+    return topics
+        .where((topic) => !isBlockedTopic(topic, blockedUsernames))
+        .toList(growable: false);
+  }
+
+  static List<Post> visiblePosts(
+    Iterable<Post> posts,
+    Set<String> blockedUsernames,
+  ) {
+    if (blockedUsernames.isEmpty) return List<Post>.from(posts);
+    return posts
+        .where((post) => !isBlockedUsername(post.username, blockedUsernames))
+        .toList(growable: false);
+  }
+
+  static List<Boost> visibleBoosts(
+    Iterable<Boost> boosts,
+    Set<String> blockedUsernames,
+  ) {
+    if (blockedUsernames.isEmpty) return List<Boost>.from(boosts);
+    return boosts
+        .where(
+          (boost) => !isBlockedUsername(boost.user.username, blockedUsernames),
+        )
+        .toList(growable: false);
+  }
+
+  static bool isBlockedNotification(
+    DiscourseNotification notification,
+    Set<String> blockedUsernames,
+  ) {
+    return isBlockedUsername(notification.username, blockedUsernames) ||
+        isBlockedUsername(
+          notification.data.originalUsername,
+          blockedUsernames,
+        ) ||
+        isBlockedUsername(notification.data.username2, blockedUsernames);
+  }
+
+  /// 树状视图中会把被屏蔽节点的已加载子节点提升到最近可见祖先，
+  /// 因此屏蔽某条回复不会连带吞掉其他用户对它的回复。
+  static List<NestedNode> visibleNestedNodes(
+    Iterable<NestedNode> nodes,
+    Set<String> blockedUsernames,
+  ) {
+    if (blockedUsernames.isEmpty) return List<NestedNode>.from(nodes);
+
+    final result = <NestedNode>[];
+    for (final node in nodes) {
+      final children = visibleNestedNodes(node.children, blockedUsernames);
+      if (isBlockedUsername(node.post.username, blockedUsernames)) {
+        result.addAll(children);
+      } else {
+        result.add(node.copyWith(children: children));
+      }
+    }
+    return result;
+  }
+}

--- a/lib/utils/blocked_user_filter.dart
+++ b/lib/utils/blocked_user_filter.dart
@@ -89,6 +89,47 @@ class BlockedUserFilter {
         .toList(growable: false);
   }
 
+  /// 过滤话题详情：移除被屏蔽用户的楼层，并剔除可见楼层上他们的 Boost。
+  ///
+  /// 只替换 postStream.posts，stream（原始楼层 id 序列）保持不动——
+  /// 分页加载依赖 stream 定位窗口边界，必须始终反映服务端真实数据。
+  /// 名单为空或无命中时原样返回同一实例，调用方可据此做身份缓存。
+  static TopicDetail filterTopicDetail(
+    TopicDetail detail,
+    Set<String> blockedUsernames,
+  ) {
+    if (blockedUsernames.isEmpty) return detail;
+
+    final source = detail.postStream.posts;
+    final visible = <Post>[];
+    var changed = false;
+    for (final post in source) {
+      if (isBlockedUsername(post.username, blockedUsernames)) {
+        changed = true;
+        continue;
+      }
+      final boosts = post.boosts;
+      if (boosts != null && boosts.isNotEmpty) {
+        final filteredBoosts = visibleBoosts(boosts, blockedUsernames);
+        if (filteredBoosts.length != boosts.length) {
+          changed = true;
+          visible.add(post.copyWith(boosts: filteredBoosts));
+          continue;
+        }
+      }
+      visible.add(post);
+    }
+    if (!changed) return detail;
+
+    return detail.copyWith(
+      postStream: PostStream(
+        posts: visible,
+        stream: detail.postStream.stream,
+        gaps: detail.postStream.gaps,
+      ),
+    );
+  }
+
   static bool isBlockedNotification(
     DiscourseNotification notification,
     Set<String> blockedUsernames,

--- a/lib/utils/topic_keyword_filter.dart
+++ b/lib/utils/topic_keyword_filter.dart
@@ -11,14 +11,15 @@ class TopicKeywordFilter {
   static const int autoLoadVisibleThreshold = 5;
   static const int autoLoadMaxAttempts = 3;
 
-  /// 应用关键词过滤，返回 `(可见列表, 隐藏数量)`。
+  /// 应用关键词与本地屏蔽名单过滤，返回
+  /// `(可见列表, 隐藏总数, 其中因屏蔽名单隐藏的数量)`。
   ///
   /// - [normalizedKeywords] 必须是已 trim + lowercase + 去空的列表。
   /// - [wholeWord] 为 true 时：对纯 ASCII word-char 关键词（如 `ai`、`db_2`）
   ///   使用单词边界（`\b`）匹配；对含非 word-char（如中文）的关键词依然走子串
   ///   匹配——Dart 的 `\b` 不在两个非 word-char 之间产生边界，强制套 `\b`
   ///   会让 `\b中文\b` 几乎不可能命中。
-  static (List<Topic> visible, int hiddenCount) apply(
+  static (List<Topic> visible, int hiddenCount, int hiddenByBlocked) apply(
     List<Topic> topics, {
     required List<String> normalizedKeywords,
     required bool wholeWord,
@@ -26,7 +27,7 @@ class TopicKeywordFilter {
   }) {
     if ((normalizedKeywords.isEmpty && blockedUsernames.isEmpty) ||
         topics.isEmpty) {
-      return (topics, 0);
+      return (topics, 0, 0);
     }
 
     final substrings = <String>[];
@@ -43,15 +44,18 @@ class TopicKeywordFilter {
 
     final visible = <Topic>[];
     var hidden = 0;
+    var hiddenByBlocked = 0;
     for (final topic in topics) {
-      if (BlockedUserFilter.isBlockedTopic(topic, blockedUsernames) ||
-          _matches(topic.title, substrings, regexes)) {
+      if (BlockedUserFilter.isBlockedTopic(topic, blockedUsernames)) {
+        hidden++;
+        hiddenByBlocked++;
+      } else if (_matches(topic.title, substrings, regexes)) {
         hidden++;
       } else {
         visible.add(topic);
       }
     }
-    return (visible, hidden);
+    return (visible, hidden, hiddenByBlocked);
   }
 
   static bool _matches(

--- a/lib/utils/topic_keyword_filter.dart
+++ b/lib/utils/topic_keyword_filter.dart
@@ -1,4 +1,5 @@
 import '../models/topic.dart';
+import 'blocked_user_filter.dart';
 
 /// 标题关键词过滤工具。
 ///
@@ -21,8 +22,10 @@ class TopicKeywordFilter {
     List<Topic> topics, {
     required List<String> normalizedKeywords,
     required bool wholeWord,
+    Set<String> blockedUsernames = const <String>{},
   }) {
-    if (normalizedKeywords.isEmpty || topics.isEmpty) {
+    if ((normalizedKeywords.isEmpty && blockedUsernames.isEmpty) ||
+        topics.isEmpty) {
       return (topics, 0);
     }
 
@@ -41,7 +44,8 @@ class TopicKeywordFilter {
     final visible = <Topic>[];
     var hidden = 0;
     for (final topic in topics) {
-      if (_matches(topic.title, substrings, regexes)) {
+      if (BlockedUserFilter.isBlockedTopic(topic, blockedUsernames) ||
+          _matches(topic.title, substrings, regexes)) {
         hidden++;
       } else {
         visible.add(topic);

--- a/lib/widgets/bookmark/bookmarks_list_content.dart
+++ b/lib/widgets/bookmark/bookmarks_list_content.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/s.dart';
 import '../../models/topic.dart';
 import '../../pages/bookmarks/bookmarks_models.dart';
+import '../../providers/preferences_provider.dart';
+import '../../utils/blocked_user_filter.dart';
 import '../../utils/platform_utils.dart';
 import '../../utils/time_utils.dart';
 import 'bookmark_preview_quick_editor.dart';
@@ -16,7 +18,7 @@ import '../topic/topic_list_skeleton.dart';
 import '../topic/topic_item_builder.dart';
 import '../topic/topic_preview_dialog.dart';
 
-class BookmarksListContent extends StatelessWidget {
+class BookmarksListContent extends ConsumerWidget {
   const BookmarksListContent({
     super.key,
     required this.bookmarksAsync,
@@ -61,11 +63,19 @@ class BookmarksListContent extends StatelessWidget {
   final Future<void> Function(Topic topic) onDeleteBookmark;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return DesktopRefreshIndicator(
       onRefresh: onRefresh,
       child: bookmarksAsync.when(
-        data: (topics) => _buildDataContent(context, topics),
+        data: (topics) => _buildDataContent(
+          context,
+          BlockedUserFilter.visibleTopics(
+            topics,
+            ref.watch(
+              preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+            ),
+          ),
+        ),
         loading: () => const TopicListSkeleton(),
         error: (error, stack) =>
             ErrorView(error: error, stackTrace: stack, onRetry: onRefresh),

--- a/lib/widgets/nested/nested_post_card.dart
+++ b/lib/widgets/nested/nested_post_card.dart
@@ -100,8 +100,25 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
   int _page = 0;
   bool _depthLineHovered = false;
 
+  /// 过滤结果缓存：visibleNestedNodes 递归复制整棵子树，开销不小；
+  /// _children 只在明确的变更点（insert/addAll）改动，名单变化走
+  /// didUpdateWidget，两处都手动失效即可安全复用
+  List<NestedNode>? _visibleChildrenCache;
+
   List<NestedNode> get _visibleChildren =>
-      BlockedUserFilter.visibleNestedNodes(_children, widget.blockedUsernames);
+      _visibleChildrenCache ??= BlockedUserFilter.visibleNestedNodes(
+        _children,
+        widget.blockedUsernames,
+      );
+
+  @override
+  void didUpdateWidget(covariant NestedPostCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.blockedUsernames, widget.blockedUsernames) ||
+        !identical(oldWidget.node, widget.node)) {
+      _visibleChildrenCache = null;
+    }
+  }
 
   @override
   void initState() {
@@ -136,6 +153,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
 
         setState(() {
           _children.insert(0, NestedNode(post: next.post));
+          _visibleChildrenCache = null;
           _expanded = true;
           _collapsed = false;
           widget.expansionState?[widget.node.post.postNumber] = true;
@@ -187,6 +205,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
       if (!mounted) return;
       setState(() {
         _children.addAll(response.children);
+        _visibleChildrenCache = null;
         _hasMore = response.hasMore;
         _page = response.page + 1;
         _isLoadingMore = false;

--- a/lib/widgets/nested/nested_post_card.dart
+++ b/lib/widgets/nested/nested_post_card.dart
@@ -8,6 +8,7 @@ import '../../providers/nested_topic_provider.dart';
 import '../../providers/preferences_provider.dart';
 import '../../providers/topic_session_provider.dart';
 import '../../pages/user_profile_page.dart';
+import '../../utils/blocked_user_filter.dart';
 import '../../utils/fluxdo_render_callbacks.dart';
 import '../../utils/responsive.dart';
 import '../../utils/time_utils.dart';
@@ -53,6 +54,7 @@ class NestedPostCard extends ConsumerStatefulWidget {
   final int maxDepth;
   final bool isLastChild;
   final bool isLoggedIn;
+  final Set<String> blockedUsernames;
   final void Function(Post? replyToPost, {String? initialContent}) onReply;
   final void Function(Post post) onEdit;
   final void Function(int postId) onRefreshPost;
@@ -75,6 +77,7 @@ class NestedPostCard extends ConsumerStatefulWidget {
     this.maxDepth = 10,
     this.isLastChild = false,
     required this.isLoggedIn,
+    required this.blockedUsernames,
     required this.onReply,
     required this.onEdit,
     required this.onRefreshPost,
@@ -97,6 +100,9 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
   int _page = 0;
   bool _depthLineHovered = false;
 
+  List<NestedNode> get _visibleChildren =>
+      BlockedUserFilter.visibleNestedNodes(_children, widget.blockedUsernames);
+
   @override
   void initState() {
     super.initState();
@@ -109,7 +115,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
       _expanded = cached;
       _collapsed = !cached && _hasReplies;
     } else {
-      _expanded = _children.isNotEmpty;
+      _expanded = _visibleChildren.isNotEmpty;
       _collapsed = false;
     }
 
@@ -139,7 +145,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
   }
 
   bool get _hasReplies =>
-      widget.node.directReplyCount > 0 || _children.isNotEmpty;
+      widget.node.directReplyCount > 0 || _visibleChildren.isNotEmpty;
   bool get _atMaxDepth => widget.depth >= widget.maxDepth;
   bool get _showDepthLine => _hasReplies && !_collapsed && !_atMaxDepth;
 
@@ -159,7 +165,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
       } else {
         _expanded = true;
         _collapsed = false;
-        if (_children.isEmpty && widget.node.directReplyCount > 0) {
+        if (_visibleChildren.isEmpty && widget.node.directReplyCount > 0) {
           _loadChildren();
         }
       }
@@ -340,7 +346,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
         !_atMaxDepth &&
         _expanded &&
         !_collapsed &&
-        (_children.isNotEmpty || _isLoadingMore || _hasMore);
+        (_visibleChildren.isNotEmpty || _isLoadingMore || _hasMore);
     final bool showExpandBtn =
         !_atMaxDepth && !_expanded && !_collapsed && _hasReplies;
 
@@ -747,20 +753,22 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
   }
 
   Widget _buildChildren(ThemeData theme, {bool isMobile = false}) {
+    final children = _visibleChildren;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        for (int i = 0; i < _children.length; i++)
+        for (int i = 0; i < children.length; i++)
           NestedPostCard(
-            node: _children[i],
+            node: children[i],
             topicId: widget.topicId,
             detail: widget.detail,
             params: widget.params,
             depth: widget.depth + 1,
             maxDepth: widget.maxDepth,
-            isLastChild: i == _children.length - 1 && !_hasMore,
+            isLastChild: i == children.length - 1 && !_hasMore,
             isLoggedIn: widget.isLoggedIn,
+            blockedUsernames: widget.blockedUsernames,
             onReply: widget.onReply,
             onEdit: widget.onEdit,
             onRefreshPost: widget.onRefreshPost,

--- a/lib/widgets/nested/nested_thread_sheet.dart
+++ b/lib/widgets/nested/nested_thread_sheet.dart
@@ -4,6 +4,8 @@ import '../../l10n/s.dart';
 import '../../models/nested_topic.dart';
 import '../../models/topic.dart';
 import '../../providers/nested_topic_provider.dart';
+import '../../providers/preferences_provider.dart';
+import '../../utils/blocked_user_filter.dart';
 import '../../utils/dialog_utils.dart';
 import '../common/app_bottom_sheet.dart';
 import 'nested_post_card.dart';
@@ -123,6 +125,13 @@ class _NestedThreadSheetContentState
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final post = widget.node.post;
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    final children = BlockedUserFilter.visibleNestedNodes(
+      _children,
+      blockedUsernames,
+    );
 
     return DraggableScrollableSheet(
       initialChildSize: 0.7,
@@ -146,16 +155,17 @@ class _NestedThreadSheetContentState
             padding: const EdgeInsets.only(bottom: 32),
             children: [
               // 子回复列表，depth 从 0 重新开始
-              for (int i = 0; i < _children.length; i++)
+              for (int i = 0; i < children.length; i++)
                 NestedPostCard(
-                  node: _children[i],
+                  node: children[i],
                   topicId: widget.topicId,
                   detail: widget.detail,
                   params: widget.params,
                   depth: 0,
                   maxDepth: widget.maxDepth,
-                  isLastChild: i == _children.length - 1 && !_hasMore,
+                  isLastChild: i == children.length - 1 && !_hasMore,
                   isLoggedIn: widget.isLoggedIn,
+                  blockedUsernames: blockedUsernames,
                   onReply: widget.onReply,
                   onEdit: widget.onEdit,
                   onRefreshPost: widget.onRefreshPost,

--- a/lib/widgets/notification/notification_quick_panel.dart
+++ b/lib/widgets/notification/notification_quick_panel.dart
@@ -10,6 +10,7 @@ import '../../pages/notifications_page.dart';
 import '../../utils/blur_config.dart';
 import '../../utils/responsive.dart';
 import '../../utils/notification_navigation.dart';
+import '../../utils/blocked_user_filter.dart';
 import 'notification_item.dart';
 import 'notification_list_skeleton.dart';
 
@@ -470,7 +471,18 @@ class _NotificationBodyState extends ConsumerState<_NotificationBody> {
     return Expanded(
       child: notificationsAsync.when(
         data: (notifications) {
-          if (notifications.isEmpty) {
+          final blockedUsernames = ref.watch(
+            preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+          );
+          final visibleNotifications = notifications
+              .where(
+                (notification) => !BlockedUserFilter.isBlockedNotification(
+                  notification,
+                  blockedUsernames,
+                ),
+              )
+              .toList(growable: false);
+          if (visibleNotifications.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -494,9 +506,9 @@ class _NotificationBodyState extends ConsumerState<_NotificationBody> {
             padding: EdgeInsets.only(
               bottom: MediaQuery.of(context).padding.bottom,
             ),
-            itemCount: notifications.length,
+            itemCount: visibleNotifications.length,
             itemBuilder: (context, index) {
-              final notification = notifications[index];
+              final notification = visibleNotifications[index];
               return NotificationItem(
                 notification: notification,
                 systemAvatarTemplate: systemAvatarTemplate,

--- a/lib/widgets/post/post_item/post_item.dart
+++ b/lib/widgets/post/post_item/post_item.dart
@@ -6,6 +6,7 @@ import '../../../models/topic.dart';
 import '../../../l10n/s.dart';
 import '../../../providers/preferences_provider.dart';
 import '../../../services/toast_service.dart';
+import '../../../utils/blocked_user_filter.dart';
 import '../../../utils/code_selection_context.dart';
 import '../../../utils/fluxdo_render_callbacks.dart';
 import '../../content/collapsed_html_content.dart';
@@ -145,13 +146,20 @@ class _PostItemState extends ConsumerState<PostItem> {
     final danmakuPref = ref.watch(
       preferencesProvider.select((p) => p.boostDanmaku),
     );
-    final hasBoosts = post.boosts?.isNotEmpty ?? false;
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
+    final visibleBoosts = BlockedUserFilter.visibleBoosts(
+      post.boosts ?? const <Boost>[],
+      blockedUsernames,
+    );
+    final hasBoosts = visibleBoosts.isNotEmpty;
     final danmakuActive = danmakuPref && (_danmakuOverride ?? true);
     final showDanmaku = danmakuActive && hasBoosts;
     // 仅当全局开关开启且有 boost 时，才展示帖子级 toggle 按钮
     final showDanmakuToggle = danmakuPref && hasBoosts;
     // 按 boost 数量决定轨道数：1 条用 1 轨，2-4 用 2 轨，5+ 用 3 轨
-    final boostCount = post.boosts?.length ?? 0;
+    final boostCount = visibleBoosts.length;
     final danmakuTrackCount = boostCount <= 1
         ? 1
         : boostCount <= 4
@@ -270,7 +278,7 @@ class _PostItemState extends ConsumerState<PostItem> {
                     Positioned.fill(
                       child: BoostDanmaku(
                         visibilityKey: post.id,
-                        boosts: post.boosts!,
+                        boosts: visibleBoosts,
                         maxTrackCount: danmakuTrackCount,
                         trackHeight: danmakuTrackHeight,
                         highlightUsername: widget.highlightBoostUsername,

--- a/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
+++ b/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
@@ -11,6 +11,7 @@ import '../../../../../models/topic.dart';
 import '../../../../../modules/ldc_reward/ldc_reward.dart';
 import '../../../../../providers/discourse_providers.dart';
 import '../../../../../providers/preferences_provider.dart';
+import '../../../../../utils/blocked_user_filter.dart';
 import 'package:dio/dio.dart';
 import '../../../../../services/app_error_handler.dart';
 import '../../../../../services/discourse/discourse_service.dart';
@@ -479,8 +480,11 @@ class _PostFooterSectionState extends ConsumerState<PostFooterSection> {
     if (isDanmaku && !widget.forceShowBoostList) {
       return const SizedBox.shrink();
     }
+    final blockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.normalizedBlockedUsernames),
+    );
     return BoostList(
-      boosts: _boosts,
+      boosts: BlockedUserFilter.visibleBoosts(_boosts, blockedUsernames),
       canBoost: _canBoost,
       onAddBoost: _openBoostInput,
       onBoostTap: _showBoostActions,

--- a/lib/widgets/topic/keyword_filter_hint_bar.dart
+++ b/lib/widgets/topic/keyword_filter_hint_bar.dart
@@ -3,19 +3,26 @@ import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/s.dart';
-import '../../providers/preferences_provider.dart';
 import '../../settings/definitions/preferences_defs.dart';
 
 /// 话题列表顶部的「本地内容过滤」提示。
 ///
-/// 仅在有话题被隐藏时显示。整行可点击，优先打开本地屏蔽名单。
+/// 仅在有话题被隐藏时显示。整行可点击，按本次隐藏的实际来源打开对应
+/// 管理入口：本次隐藏全部来自屏蔽名单时打开名单，否则打开关键词编辑。
 /// 形态与 `_buildNewTopicIndicator` 保持一致（同样的胶囊容器、margin、圆角），
 /// 但使用 surfaceVariant 系颜色而非 primaryContainer，刻意做成次要状态层级，
 /// 与新话题 CTA 堆叠时形成「主操作 + 次要状态」的视觉层次。
 class KeywordFilterHintBar extends ConsumerWidget {
   final int hiddenCount;
 
-  const KeywordFilterHintBar({super.key, required this.hiddenCount});
+  /// [hiddenCount] 中因本地屏蔽名单隐藏的数量（其余为关键词命中）
+  final int hiddenByBlocked;
+
+  const KeywordFilterHintBar({
+    super.key,
+    required this.hiddenCount,
+    this.hiddenByBlocked = 0,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -23,9 +30,8 @@ class KeywordFilterHintBar extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final mutedColor = theme.colorScheme.onSurfaceVariant;
-    final hasBlockedUsernames = ref.watch(
-      preferencesProvider.select((p) => p.blockedUsernames.isNotEmpty),
-    );
+    // 全部由屏蔽名单导致才跳名单管理；混合或纯关键词时管理关键词
+    final onlyBlocked = hiddenByBlocked >= hiddenCount;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
@@ -34,7 +40,7 @@ class KeywordFilterHintBar extends ConsumerWidget {
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
-          onTap: () => hasBlockedUsernames
+          onTap: () => onlyBlocked
               ? showBlockedUsernamesDialog(context, ref)
               : showTopicFilterKeywordsDialog(context, ref),
           child: Padding(

--- a/lib/widgets/topic/keyword_filter_hint_bar.dart
+++ b/lib/widgets/topic/keyword_filter_hint_bar.dart
@@ -3,11 +3,12 @@ import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/s.dart';
+import '../../providers/preferences_provider.dart';
 import '../../settings/definitions/preferences_defs.dart';
 
-/// 话题列表顶部的「关键词过滤」提示。
+/// 话题列表顶部的「本地内容过滤」提示。
 ///
-/// 仅在有话题被隐藏时显示。整行可点击，打开关键词编辑弹窗。
+/// 仅在有话题被隐藏时显示。整行可点击，优先打开本地屏蔽名单。
 /// 形态与 `_buildNewTopicIndicator` 保持一致（同样的胶囊容器、margin、圆角），
 /// 但使用 surfaceVariant 系颜色而非 primaryContainer，刻意做成次要状态层级，
 /// 与新话题 CTA 堆叠时形成「主操作 + 次要状态」的视觉层次。
@@ -22,6 +23,9 @@ class KeywordFilterHintBar extends ConsumerWidget {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final mutedColor = theme.colorScheme.onSurfaceVariant;
+    final hasBlockedUsernames = ref.watch(
+      preferencesProvider.select((p) => p.blockedUsernames.isNotEmpty),
+    );
 
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
@@ -30,7 +34,9 @@ class KeywordFilterHintBar extends ConsumerWidget {
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
-          onTap: () => showTopicFilterKeywordsDialog(context, ref),
+          onTap: () => hasBlockedUsernames
+              ? showBlockedUsernamesDialog(context, ref)
+              : showTopicFilterKeywordsDialog(context, ref),
           child: Padding(
             padding: const EdgeInsets.symmetric(vertical: 6),
             child: Row(

--- a/test/pages/bookmarks/bookmarks_list_content_test.dart
+++ b/test/pages/bookmarks/bookmarks_list_content_test.dart
@@ -7,8 +7,10 @@ import 'package:fluxdo/l10n/slang/strings.g.dart';
 import 'package:fluxdo/models/category.dart';
 import 'package:fluxdo/models/topic.dart';
 import 'package:fluxdo/providers/category_provider.dart';
+import 'package:fluxdo/providers/theme_provider.dart';
 import 'package:fluxdo/utils/platform_utils.dart';
 import 'package:fluxdo/widgets/bookmark/bookmarks_list_content.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 Topic _topic({required int id, required String title, String? bookmarkName}) {
   return Topic(
@@ -25,10 +27,19 @@ Topic _topic({required int id, required String title, String? bookmarkName}) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferences prefs;
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
   testWidgets('汇总条只统计非空名称并按数量降序展示', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -54,6 +65,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -87,6 +99,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -113,6 +126,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -157,6 +171,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -200,6 +215,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -259,6 +275,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),
@@ -323,6 +340,7 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           categoryMapProvider.overrideWith(
             (ref) => const AsyncValue.data(<int, Category>{}),
           ),

--- a/test/utils/blocked_user_filter_test.dart
+++ b/test/utils/blocked_user_filter_test.dart
@@ -58,7 +58,63 @@ void main() {
       expect(visible, hasLength(1));
       expect(visible.single.post.username, 'bob');
     });
+
+    test('filterTopicDetail 过滤楼层与 Boost 但保留 stream', () {
+      final blocked = BlockedUserFilter.normalizedUsernames(['alice']);
+      final detail = _detail([
+        _post(1, 'bob'),
+        _post(2, 'alice'),
+        _post(3, 'carol', boosts: [_boost(31, 'alice'), _boost(32, 'bob')]),
+      ]);
+
+      final filtered = BlockedUserFilter.filterTopicDetail(detail, blocked);
+
+      expect(filtered.postStream.posts.map((post) => post.id), [1, 3]);
+      // stream 是分页窗口定位依据，必须保持服务端原始序列
+      expect(filtered.postStream.stream, detail.postStream.stream);
+      expect(
+        filtered.postStream.posts.last.boosts!.map((boost) => boost.id),
+        [32],
+      );
+    });
+
+    test('filterTopicDetail 名单为空或无命中时返回原实例', () {
+      final detail = _detail([_post(1, 'bob')]);
+      expect(
+        identical(
+          BlockedUserFilter.filterTopicDetail(detail, const <String>{}),
+          detail,
+        ),
+        isTrue,
+      );
+      expect(
+        identical(
+          BlockedUserFilter.filterTopicDetail(
+            detail,
+            BlockedUserFilter.normalizedUsernames(['alice']),
+          ),
+          detail,
+        ),
+        isTrue,
+      );
+    });
   });
+}
+
+TopicDetail _detail(List<Post> posts) {
+  return TopicDetail(
+    id: 1,
+    title: 'topic',
+    slug: 'topic',
+    postsCount: posts.length,
+    postStream: PostStream(
+      posts: posts,
+      stream: posts.map((post) => post.id).toList(),
+    ),
+    categoryId: 0,
+    closed: false,
+    archived: false,
+  );
 }
 
 Topic _topic(int id, String username) {
@@ -83,7 +139,7 @@ Topic _topic(int id, String username) {
   );
 }
 
-Post _post(int id, String username) {
+Post _post(int id, String username, {List<Boost>? boosts}) {
   final now = DateTime(2026, 1, 1);
   return Post(
     id: id,
@@ -96,6 +152,7 @@ Post _post(int id, String username) {
     createdAt: now,
     likeCount: 0,
     replyCount: 0,
+    boosts: boosts,
   );
 }
 

--- a/test/utils/blocked_user_filter_test.dart
+++ b/test/utils/blocked_user_filter_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/nested_topic.dart';
+import 'package:fluxdo/models/topic.dart';
+import 'package:fluxdo/utils/blocked_user_filter.dart';
+
+void main() {
+  group('BlockedUserFilter', () {
+    test('用户名去重和匹配均不区分大小写', () {
+      expect(
+        BlockedUserFilter.sanitizeUsernames([' Alice ', '@alice', '', '@BOB']),
+        ['Alice', 'BOB'],
+      );
+
+      final blocked = BlockedUserFilter.normalizedUsernames(['@Alice']);
+      expect(BlockedUserFilter.isBlockedUsername('ALICE', blocked), isTrue);
+      expect(BlockedUserFilter.isBlockedUsername('alice_2', blocked), isFalse);
+    });
+
+    test('只过滤楼主在名单中的话题', () {
+      final blocked = BlockedUserFilter.normalizedUsernames(['alice']);
+      final visible = BlockedUserFilter.visibleTopics([
+        _topic(1, 'alice'),
+        _topic(2, 'bob'),
+      ], blocked);
+
+      expect(visible.map((topic) => topic.id), [2]);
+    });
+
+    test('回复和 Boost 按发布者过滤', () {
+      final blocked = BlockedUserFilter.normalizedUsernames(['alice']);
+      final posts = [_post(1, 'alice'), _post(2, 'bob')];
+      final boosts = [_boost(1, 'alice'), _boost(2, 'bob')];
+
+      expect(
+        BlockedUserFilter.visiblePosts(posts, blocked).map((post) => post.id),
+        [2],
+      );
+      expect(
+        BlockedUserFilter.visibleBoosts(
+          boosts,
+          blocked,
+        ).map((boost) => boost.id),
+        [2],
+      );
+    });
+
+    test('树状回复会提升被屏蔽节点的可见子回复', () {
+      final blocked = BlockedUserFilter.normalizedUsernames(['alice']);
+      final child = NestedNode(post: _post(3, 'bob'));
+      final hiddenParent = NestedNode(
+        post: _post(2, 'alice'),
+        children: [child],
+      );
+      final visible = BlockedUserFilter.visibleNestedNodes([
+        hiddenParent,
+      ], blocked);
+
+      expect(visible, hasLength(1));
+      expect(visible.single.post.username, 'bob');
+    });
+  });
+}
+
+Topic _topic(int id, String username) {
+  final user = TopicUser(id: id, username: username, avatarTemplate: '');
+  return Topic(
+    id: id,
+    title: 'topic $id',
+    slug: 'topic-$id',
+    postsCount: 1,
+    replyCount: 0,
+    views: 0,
+    likeCount: 0,
+    categoryId: '0',
+    posters: [
+      TopicPoster(
+        userId: id,
+        description: 'Original Poster',
+        extras: '',
+        user: user,
+      ),
+    ],
+  );
+}
+
+Post _post(int id, String username) {
+  final now = DateTime(2026, 1, 1);
+  return Post(
+    id: id,
+    username: username,
+    avatarTemplate: '',
+    cooked: '',
+    postNumber: id,
+    postType: 1,
+    updatedAt: now,
+    createdAt: now,
+    likeCount: 0,
+    replyCount: 0,
+  );
+}
+
+Boost _boost(int id, String username) {
+  return Boost(
+    id: id,
+    cooked: '',
+    user: BoostUser(id: id, username: username, avatarTemplate: ''),
+  );
+}

--- a/test/utils/topic_keyword_filter_test.dart
+++ b/test/utils/topic_keyword_filter_test.dart
@@ -24,7 +24,7 @@ void main() {
     ];
 
     test('空关键词返回原列表，hidden 为 0', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const [],
         wholeWord: false,
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('空话题列表直接返回，hidden 为 0', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         const [],
         normalizedKeywords: const ['ai'],
         wholeWord: false,
@@ -44,7 +44,7 @@ void main() {
     });
 
     test('子串匹配不区分大小写', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const ['ai'],
         wholeWord: false,
@@ -58,7 +58,7 @@ void main() {
     });
 
     test('中文关键词命中', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const ['水帖'],
         wholeWord: false,
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('多关键词任一命中即过滤', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const ['ai', '水帖'],
         wholeWord: false,
@@ -79,7 +79,7 @@ void main() {
     });
 
     test('完整词模式下英文不再误匹配子串', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const ['ai'],
         wholeWord: true,
@@ -93,7 +93,7 @@ void main() {
     });
 
     test('完整词模式对中文关键词等价于子串', () {
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         topics,
         normalizedKeywords: const ['水帖'],
         wholeWord: true,
@@ -107,7 +107,7 @@ void main() {
         _topic(10, 'Use a.b.c notation'),
         _topic(11, 'No dots here'),
       ];
-      final (visible, hidden) = TopicKeywordFilter.apply(
+      final (visible, hidden, _) = TopicKeywordFilter.apply(
         special,
         normalizedKeywords: const ['a.b.c'],
         wholeWord: false,


### PR DESCRIPTION
## 摘要
- 添加了一个设备本地的用户拉黑功能，通过拉黑某个用户，可以在本地实现完全隐藏其发布的主题、回复、Boost、搜索结果、历史记录、收藏和通知，并且不调用 Discourse 的忽略 API。
- 添加用于管理被拉黑用户的设置界面（我的-应用设置-功能设置-基础-本地拉黑用户），并将筛选器优化为“输入后按换行添加的可移除标签形式；用户名不需要加 @ 前缀。标题关键词过滤也适用了此优化。

## 原因

Discourse 的忽略功能无法彻底屏蔽某个用户的所有可见活动。因此需要增加一个明确的、仅本地生效的展示层过滤机制，点赞等反应因需诚实的统计数量，所以保留了黑名单用户在点赞等反应交互中不受影响。

## 验证

- `dart analyze lib/settings/definitions/preferences_defs.dart lib/utils/blocked_user_filter.dart lib/pages/topics_page.dart` 通过
- `flutter test --no-pub test/utils/blocked_user_filter_test.dart` 通过
- Android release 包已构建，APK 签名、包名与支持的 ABI 验证符合预期