### PR TITLE
feat: 扩展阅读字体上限并支持帖子列表标题字号

### DIFF
--- a/lib/l10n/modules/appearance/appearance_en.arb
+++ b/lib/l10n/modules/appearance/appearance_en.arb
@@ -11,6 +11,7 @@
   "appearance_colorRed": "Red",
   "appearance_colorTeal": "Teal",
   "appearance_contentFontSize": "Content font size",
+  "appearance_topicTitleFontSize": "Topic list title font size",
   "appearance_dialogBlur": "Dialog Blur",
   "appearance_dialogBlurDesc": "Blur background when dialog appears",
   "appearance_displayMode": "Display refresh rate",

--- a/lib/l10n/modules/appearance/appearance_zh.arb
+++ b/lib/l10n/modules/appearance/appearance_zh.arb
@@ -11,6 +11,7 @@
   "appearance_colorRed": "红色",
   "appearance_colorTeal": "青色",
   "appearance_contentFontSize": "内容字体大小",
+  "appearance_topicTitleFontSize": "帖子列表标题字体大小",
   "appearance_dialogBlur": "对话框模糊",
   "appearance_dialogBlurDesc": "对话框弹出时模糊背景",
   "appearance_displayMode": "屏幕帧率",

--- a/lib/l10n/modules/appearance/appearance_zh_HK.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_HK.arb
@@ -11,6 +11,7 @@
   "appearance_colorRed": "紅色",
   "appearance_colorTeal": "青色",
   "appearance_contentFontSize": "內容字體大小",
+  "appearance_topicTitleFontSize": "帖子列表標題字體大小",
   "appearance_dialogBlur": "對話框模糊",
   "appearance_dialogBlurDesc": "對話框彈出時模糊背景",
   "appearance_displayMode": "螢幕幀率",

--- a/lib/l10n/modules/appearance/appearance_zh_TW.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_TW.arb
@@ -11,6 +11,7 @@
   "appearance_colorRed": "紅色",
   "appearance_colorTeal": "青色",
   "appearance_contentFontSize": "內容字型大小",
+  "appearance_topicTitleFontSize": "帖子列表標題字型大小",
   "appearance_dialogBlur": "對話框模糊",
   "appearance_dialogBlurDesc": "對話框彈出時模糊背景",
   "appearance_displayMode": "螢幕影格率",

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -79,6 +79,14 @@ const List<ProgressGestureAction> _defaultProgressGestureMenu = [
 
 const int kProgressGestureMenuMax = 8;
 
+const double kReadingFontScaleMin = 0.8;
+const double kReadingFontScaleMax = 3.0;
+const double kReadingFontScaleDefault = 1.0;
+const int kReadingFontScaleDivisions = 44;
+
+double _clampReadingFontScale(double value) =>
+    value.clamp(kReadingFontScaleMin, kReadingFontScaleMax).toDouble();
+
 class AppPreferences {
   static const Object _unset = Object();
 
@@ -90,8 +98,11 @@ class AppPreferences {
   final bool longPressPreview;
   final bool openExternalLinksInAppBrowser;
 
-  /// 内容字体缩放比例，范围 0.8 ~ 1.4，默认 1.0
+  /// 内容字体缩放比例，范围 0.8 ~ 3.0，默认 1.0
   final double contentFontScale;
+
+  /// 帖子列表标题字体缩放比例，范围 0.8 ~ 3.0，默认 1.0
+  final double topicTitleFontScale;
 
   /// 分享图片主题索引
   final int shareImageThemeIndex;
@@ -214,6 +225,7 @@ class AppPreferences {
     required this.longPressPreview,
     required this.openExternalLinksInAppBrowser,
     required this.contentFontScale,
+    required this.topicTitleFontScale,
     required this.shareImageThemeIndex,
     required this.autoFillLogin,
     required this.clipboardTopicLinkDetection,
@@ -258,6 +270,7 @@ class AppPreferences {
     bool? longPressPreview,
     bool? openExternalLinksInAppBrowser,
     double? contentFontScale,
+    double? topicTitleFontScale,
     int? shareImageThemeIndex,
     bool? autoFillLogin,
     bool? clipboardTopicLinkDetection,
@@ -302,6 +315,7 @@ class AppPreferences {
       openExternalLinksInAppBrowser:
           openExternalLinksInAppBrowser ?? this.openExternalLinksInAppBrowser,
       contentFontScale: contentFontScale ?? this.contentFontScale,
+      topicTitleFontScale: topicTitleFontScale ?? this.topicTitleFontScale,
       shareImageThemeIndex: shareImageThemeIndex ?? this.shareImageThemeIndex,
       autoFillLogin: autoFillLogin ?? this.autoFillLogin,
       clipboardTopicLinkDetection:
@@ -364,6 +378,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _openExternalLinksInAppBrowserKey =
       'pref_open_external_links_in_app_browser';
   static const String _contentFontScaleKey = 'pref_content_font_scale';
+  static const String _topicTitleFontScaleKey = 'pref_topic_title_font_scale';
   static const String _shareImageThemeIndexKey = 'pref_share_image_theme_index';
   static const String _autoFillLoginKey = 'pref_auto_fill_login';
   static const String _clipboardTopicLinkDetectionKey =
@@ -424,7 +439,13 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           longPressPreview: _prefs.getBool(_longPressPreviewKey) ?? true,
           openExternalLinksInAppBrowser:
               _prefs.getBool(_openExternalLinksInAppBrowserKey) ?? false,
-          contentFontScale: _prefs.getDouble(_contentFontScaleKey) ?? 1.0,
+          contentFontScale: _clampReadingFontScale(
+            _prefs.getDouble(_contentFontScaleKey) ?? kReadingFontScaleDefault,
+          ),
+          topicTitleFontScale: _clampReadingFontScale(
+            _prefs.getDouble(_topicTitleFontScaleKey) ??
+                kReadingFontScaleDefault,
+          ),
           shareImageThemeIndex: _prefs.getInt(_shareImageThemeIndexKey) ?? 0,
           autoFillLogin: _prefs.getBool(_autoFillLoginKey) ?? true,
           clipboardTopicLinkDetection:
@@ -525,10 +546,15 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   }
 
   Future<void> setContentFontScale(double scale) async {
-    // 限制范围在 0.8 ~ 1.4
-    final clampedScale = scale.clamp(0.8, 1.4);
+    final clampedScale = _clampReadingFontScale(scale);
     state = state.copyWith(contentFontScale: clampedScale);
     await _prefs.setDouble(_contentFontScaleKey, clampedScale);
+  }
+
+  Future<void> setTopicTitleFontScale(double scale) async {
+    final clampedScale = _clampReadingFontScale(scale);
+    state = state.copyWith(topicTitleFontScale: clampedScale);
+    await _prefs.setDouble(_topicTitleFontScaleKey, clampedScale);
   }
 
   Future<void> setShareImageThemeIndex(int index) async {

--- a/lib/settings/definitions/reading_defs.dart
+++ b/lib/settings/definitions/reading_defs.dart
@@ -23,15 +23,31 @@ List<SettingsGroup> buildReadingGroups(BuildContext context) {
           id: 'contentFontScale',
           title: l10n.appearance_contentFontSize,
           icon: Symbols.format_size_rounded,
-          min: 0.8,
-          max: 1.4,
-          divisions: 12,
+          min: kReadingFontScaleMin,
+          max: kReadingFontScaleMax,
+          divisions: kReadingFontScaleDivisions,
           labelBuilder: (v) => '${(v * 100).round()}%',
           getValue: (ref) => ref.watch(preferencesProvider).contentFontScale,
           onChanged: (ref, v) =>
               ref.read(preferencesProvider.notifier).setContentFontScale(v),
-          onReset: (ref) =>
-              ref.read(preferencesProvider.notifier).setContentFontScale(1.0),
+          onReset: (ref) => ref
+              .read(preferencesProvider.notifier)
+              .setContentFontScale(kReadingFontScaleDefault),
+        ),
+        DoubleSliderModel(
+          id: 'topicTitleFontScale',
+          title: l10n.appearance_topicTitleFontSize,
+          icon: Symbols.title_rounded,
+          min: kReadingFontScaleMin,
+          max: kReadingFontScaleMax,
+          divisions: kReadingFontScaleDivisions,
+          labelBuilder: (v) => '${(v * 100).round()}%',
+          getValue: (ref) => ref.watch(preferencesProvider).topicTitleFontScale,
+          onChanged: (ref, v) =>
+              ref.read(preferencesProvider.notifier).setTopicTitleFontScale(v),
+          onReset: (ref) => ref
+              .read(preferencesProvider.notifier)
+              .setTopicTitleFontScale(kReadingFontScaleDefault),
         ),
         SwitchModel(
           id: 'displayPanguSpacing',
@@ -450,10 +466,7 @@ void _showGestureActionPicker(
       final dialogWidth = math.min(screen.width - 48, 560.0);
       final dialogMaxHeight = math.min(screen.height * 0.85, 640.0);
       return Dialog(
-        insetPadding: const EdgeInsets.symmetric(
-          horizontal: 24,
-          vertical: 24,
-        ),
+        insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
         clipBehavior: Clip.antiAlias,
         child: ConstrainedBox(
           constraints: BoxConstraints(
@@ -476,13 +489,12 @@ void _showGestureActionPicker(
                 child: GridView.builder(
                   padding: const EdgeInsets.fromLTRB(12, 4, 12, 8),
                   shrinkWrap: true,
-                  gridDelegate:
-                      const SliverGridDelegateWithMaxCrossAxisExtent(
-                        maxCrossAxisExtent: 240,
-                        mainAxisExtent: 52,
-                        crossAxisSpacing: 4,
-                        mainAxisSpacing: 4,
-                      ),
+                  gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 240,
+                    mainAxisExtent: 52,
+                    crossAxisSpacing: 4,
+                    mainAxisSpacing: 4,
+                  ),
                   itemCount: ProgressGestureAction.values.length,
                   itemBuilder: (context, index) {
                     final action = ProgressGestureAction.values[index];
@@ -556,4 +568,3 @@ void _showGestureActionPicker(
     if (selected != null) onPicked(selected);
   });
 }
-

--- a/lib/widgets/topic/topic_card.dart
+++ b/lib/widgets/topic/topic_card.dart
@@ -5,6 +5,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../../models/topic.dart';
 import '../../models/category.dart';
 import '../../providers/discourse_providers.dart';
+import '../../providers/preferences_provider.dart';
 import '../../utils/font_awesome_helper.dart';
 import '../../utils/platform_utils.dart';
 import '../../utils/url_helper.dart';
@@ -42,6 +43,20 @@ class TopicCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final isUnread = topic.unseen || topic.unread > 0;
+    final topicTitleFontScale = ref.watch(
+      preferencesProvider.select(
+        (preferences) => preferences.topicTitleFontScale,
+      ),
+    );
+    final baseTitleStyle = theme.textTheme.titleMedium ?? const TextStyle();
+    final titleStyle = baseTitleStyle.copyWith(
+      fontSize: (baseTitleStyle.fontSize ?? 16) * topicTitleFontScale,
+      fontWeight: FontWeight.w500,
+      height: 1.3,
+      color: isUnread
+          ? theme.colorScheme.onSurface
+          : theme.colorScheme.onSurfaceVariant,
+    );
     // 全部读完：进入过话题且没有未读帖子
     final isFullyRead =
         !topic.unseen && topic.unread == 0 && topic.lastReadPostNumber != null;
@@ -119,16 +134,7 @@ class TopicCard extends ConsumerWidget {
                                 Expanded(
                                   child: Text.rich(
                                     TextSpan(
-                                      style: theme.textTheme.titleMedium
-                                          ?.copyWith(
-                                            fontWeight: FontWeight.w500,
-                                            height: 1.3,
-                                            color: isUnread
-                                                ? theme.colorScheme.onSurface
-                                                : theme
-                                                      .colorScheme
-                                                      .onSurfaceVariant,
-                                          ),
+                                      style: titleStyle,
                                       children: [
                                         if (topic.closed)
                                           WidgetSpan(
@@ -175,7 +181,8 @@ class TopicCard extends ConsumerWidget {
                                                 right: 4,
                                               ),
                                               child: Icon(
-                                                Symbols.check_box_outline_blank_rounded,
+                                                Symbols
+                                                    .check_box_outline_blank_rounded,
                                                 size: 16,
                                                 color:
                                                     theme.colorScheme.outline,
@@ -185,15 +192,7 @@ class TopicCard extends ConsumerWidget {
                                         ...EmojiText.buildEmojiSpans(
                                           context,
                                           topic.title,
-                                          theme.textTheme.titleMedium?.copyWith(
-                                            fontWeight: FontWeight.w500,
-                                            height: 1.3,
-                                            color: isUnread
-                                                ? theme.colorScheme.onSurface
-                                                : theme
-                                                      .colorScheme
-                                                      .onSurfaceVariant,
-                                          ),
+                                          titleStyle,
                                         ),
                                         // 未读蓝点追加在标题末尾
                                         if (topic.unseen)
@@ -440,6 +439,19 @@ class CompactTopicCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final isUnread = topic.unseen || topic.unread > 0;
+    final topicTitleFontScale = ref.watch(
+      preferencesProvider.select(
+        (preferences) => preferences.topicTitleFontScale,
+      ),
+    );
+    final baseTitleStyle = theme.textTheme.labelMedium ?? const TextStyle();
+    final titleStyle = baseTitleStyle.copyWith(
+      fontSize: (baseTitleStyle.fontSize ?? 12) * topicTitleFontScale,
+      fontWeight: isUnread ? FontWeight.w500 : FontWeight.w400,
+      color: isUnread
+          ? theme.colorScheme.onSurface
+          : theme.colorScheme.onSurfaceVariant,
+    );
 
     // 获取分类信息
     final categoryMap = ref.watch(categoryMapProvider).value;
@@ -518,14 +530,7 @@ class CompactTopicCard extends ConsumerWidget {
                 Expanded(
                   child: Text.rich(
                     TextSpan(
-                      style: theme.textTheme.labelMedium?.copyWith(
-                        fontWeight: isUnread
-                            ? FontWeight.w500
-                            : FontWeight.w400,
-                        color: isUnread
-                            ? theme.colorScheme.onSurface
-                            : theme.colorScheme.onSurfaceVariant,
-                      ),
+                      style: titleStyle,
                       children: [
                         if (topic.closed)
                           WidgetSpan(
@@ -568,14 +573,7 @@ class CompactTopicCard extends ConsumerWidget {
                         ...EmojiText.buildEmojiSpans(
                           context,
                           topic.title,
-                          theme.textTheme.labelMedium?.copyWith(
-                            fontWeight: isUnread
-                                ? FontWeight.w500
-                                : FontWeight.w400,
-                            color: isUnread
-                                ? theme.colorScheme.onSurface
-                                : theme.colorScheme.onSurfaceVariant,
-                          ),
+                          titleStyle,
                         ),
                       ],
                     ),

--- a/test/providers/preferences_provider_test.dart
+++ b/test/providers/preferences_provider_test.dart
@@ -55,4 +55,51 @@ void main() {
       BookmarksOpenMode.defaultRoute,
     );
   });
+
+  group('reading font scales', () {
+    test('both font scales default to 100 percent', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+
+      final preferences = container.read(preferencesProvider);
+      expect(preferences.contentFontScale, kReadingFontScaleDefault);
+      expect(preferences.topicTitleFontScale, kReadingFontScaleDefault);
+    });
+
+    test('persisted font scales are clamped on initialization', () async {
+      final container = await _createContainer(
+        initialValues: {
+          'pref_content_font_scale': 4.2,
+          'pref_topic_title_font_scale': 0.2,
+        },
+      );
+      addTearDown(container.dispose);
+
+      final preferences = container.read(preferencesProvider);
+      expect(preferences.contentFontScale, kReadingFontScaleMax);
+      expect(preferences.topicTitleFontScale, kReadingFontScaleMin);
+    });
+
+    test('font scale setters clamp and persist values', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(preferencesProvider.notifier);
+
+      await notifier.setContentFontScale(9);
+      await notifier.setTopicTitleFontScale(0.1);
+
+      final preferences = container.read(preferencesProvider);
+      final storage = container.read(sharedPreferencesProvider);
+      expect(preferences.contentFontScale, kReadingFontScaleMax);
+      expect(preferences.topicTitleFontScale, kReadingFontScaleMin);
+      expect(
+        storage.getDouble('pref_content_font_scale'),
+        kReadingFontScaleMax,
+      );
+      expect(
+        storage.getDouble('pref_topic_title_font_scale'),
+        kReadingFontScaleMin,
+      );
+    });
+  });
 }

--- a/test/settings/reading_defs_test.dart
+++ b/test/settings/reading_defs_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluxdo/l10n/s.dart';
+import 'package:fluxdo/providers/preferences_provider.dart';
 import 'package:fluxdo/settings/definitions/reading_defs.dart';
 import 'package:fluxdo/settings/settings_model.dart';
 import 'package:fluxdo/utils/platform_utils.dart';
@@ -10,6 +11,7 @@ Future<List<SettingsModel>> _pumpAndCollectBasicItems(
   WidgetTester tester, {
   required Size size,
   bool? desktopOverride,
+  bool readingGroup = false,
 }) async {
   addTearDown(() async {
     PlatformUtils.debugDesktopOverride = null;
@@ -31,8 +33,11 @@ Future<List<SettingsModel>> _pumpAndCollectBasicItems(
           data: MediaQueryData(size: size),
           child: Builder(
             builder: (context) {
+              final targetTitle = readingGroup
+                  ? context.l10n.appearance_reading
+                  : context.l10n.preferences_basic;
               items = buildReadingGroups(context)
-                  .firstWhere((group) => group.title == context.l10n.preferences_basic)
+                  .firstWhere((group) => group.title == targetTitle)
                   .items
                   .where((item) {
                     if (item is PlatformConditionalModel) {
@@ -40,7 +45,10 @@ Future<List<SettingsModel>> _pumpAndCollectBasicItems(
                     }
                     return true;
                   })
-                  .map((item) => item is PlatformConditionalModel ? item.inner : item)
+                  .map(
+                    (item) =>
+                        item is PlatformConditionalModel ? item.inner : item,
+                  )
                   .toList();
               return const SizedBox.shrink();
             },
@@ -82,5 +90,32 @@ void main() {
     );
 
     expect(items.map((item) => item.id), contains('bookmarksOpenMode'));
+  });
+
+  testWidgets('reading font sliders share the 80 to 300 percent range', (
+    tester,
+  ) async {
+    final items = await _pumpAndCollectBasicItems(
+      tester,
+      size: const Size(390, 844),
+      desktopOverride: false,
+      readingGroup: true,
+    );
+    final ids = items.map((item) => item.id).toList();
+    final contentIndex = ids.indexOf('contentFontScale');
+    final topicIndex = ids.indexOf('topicTitleFontScale');
+
+    expect(contentIndex, greaterThanOrEqualTo(0));
+    expect(topicIndex, contentIndex + 1);
+    for (final slider in <DoubleSliderModel>[
+      items[contentIndex] as DoubleSliderModel,
+      items[topicIndex] as DoubleSliderModel,
+    ]) {
+      expect(slider.min, kReadingFontScaleMin);
+      expect(slider.max, kReadingFontScaleMax);
+      expect(slider.divisions, kReadingFontScaleDivisions);
+      expect(slider.labelBuilder(1.75), '175%');
+      expect(slider.onReset, isNotNull);
+    }
   });
 }

--- a/test/widgets/topic/topic_card_test.dart
+++ b/test/widgets/topic/topic_card_test.dart
@@ -1,0 +1,106 @@
+import 'package:app_icons/app_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/category.dart';
+import 'package:fluxdo/models/topic.dart';
+import 'package:fluxdo/providers/discourse_providers.dart';
+import 'package:fluxdo/providers/theme_provider.dart';
+import 'package:fluxdo/widgets/topic/topic_card.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _titlePrefix = 'Scaled';
+
+Topic _topic() => Topic(
+  id: 1,
+  title: '$_titlePrefix :smile:',
+  slug: 'scaled-topic',
+  postsCount: 5,
+  replyCount: 4,
+  views: 10,
+  likeCount: 0,
+  categoryId: '0',
+  closed: true,
+);
+
+Future<void> _pumpCard(WidgetTester tester, Widget card) async {
+  SharedPreferences.setMockInitialValues({'pref_topic_title_font_scale': 2.0});
+  final preferences = await SharedPreferences.getInstance();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        sharedPreferencesProvider.overrideWithValue(preferences),
+        categoryMapProvider.overrideWithValue(
+          const AsyncData<Map<int, Category>>({}),
+        ),
+      ],
+      child: MaterialApp(
+        theme: ThemeData(
+          useMaterial3: true,
+          textTheme: const TextTheme(
+            titleMedium: TextStyle(fontSize: 20),
+            labelMedium: TextStyle(fontSize: 12),
+            labelSmall: TextStyle(fontSize: 8),
+          ),
+        ),
+        home: Scaffold(
+          body: Center(child: SizedBox(width: 800, child: card)),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+Text _findTitleText(WidgetTester tester) {
+  return tester
+      .widgetList<Text>(find.byType(Text))
+      .singleWhere(
+        (widget) =>
+            widget.textSpan?.toPlainText().contains(_titlePrefix) ?? false,
+      );
+}
+
+Image _findEmojiImage(Text title) {
+  final root = title.textSpan! as TextSpan;
+  final emojiSpan = root.children!.whereType<WidgetSpan>().singleWhere((span) {
+    final child = span.child;
+    return child is Padding && child.child is Image;
+  });
+  return (emojiSpan.child as Padding).child! as Image;
+}
+
+void main() {
+  testWidgets('TopicCard scales only title text and emoji', (tester) async {
+    await _pumpCard(tester, TopicCard(topic: _topic()));
+
+    final title = _findTitleText(tester);
+    final emoji = _findEmojiImage(title);
+    final replyCount = tester.widget<Text>(find.text('4'));
+    final lockIcon = tester.widget<Icon>(find.byIcon(Symbols.lock_rounded));
+
+    expect(title.textSpan!.style?.fontSize, 40);
+    expect(title.maxLines, 2);
+    expect(title.overflow, TextOverflow.ellipsis);
+    expect(emoji.width, 48);
+    expect(replyCount.style?.fontSize, 8);
+    expect(lockIcon.size, 16);
+  });
+
+  testWidgets('CompactTopicCard scales title and keeps one-line ellipsis', (
+    tester,
+  ) async {
+    await _pumpCard(tester, CompactTopicCard(topic: _topic()));
+
+    final title = _findTitleText(tester);
+    final emoji = _findEmojiImage(title);
+    final lockIcon = tester.widget<Icon>(find.byIcon(Symbols.lock_rounded));
+
+    expect(title.textSpan!.style?.fontSize, 24);
+    expect(title.maxLines, 1);
+    expect(title.overflow, TextOverflow.ellipsis);
+    expect(emoji.width, closeTo(28.8, 0.001));
+    expect(lockIcon.size, 12);
+  });
+}


### PR DESCRIPTION
## 改动说明

- 将「内容字体大小」可调范围从 **80%～140%** 扩展为 **80%～300%**（步长 5%，默认/重置 100%）
- 在阅读设置中新增 **「帖子列表标题字体大小」**，紧跟在内容字体滑块下方
- 新设置通过共享的 `TopicCard` / `CompactTopicCard` 生效，覆盖首页、分类、标签、书签、浏览历史、我的话题、私信话题列表等所有复用这些卡片的页面
- 仅缩放标题文字与标题 Emoji；回复数、分类标签、时间、头像、状态图标等元数据尺寸不变
- 普通卡片标题仍最多两行、紧凑卡片仍一行，省略规则不变
- 新增稳定持久化键 `pref_topic_title_font_scale`；读取与写入均 clamp 到 0.8～3.0，无需数据迁移
- 补充中英/港繁/台繁本地化文案与相关单元 / Widget 测试

## 动机

当前内容字体上限 140% 对部分用户偏紧；帖子列表标题又没有独立缩放，放大内容后列表标题观感不一致。希望在不改卡片信息密度、不引入新依赖的前提下，统一阅读相关字号能力。

## 非目标

- 不缩放帖子列表中的元数据与状态图标
- 不改标题最大行数、卡片密度或省略规则
- 不修改帖子正文渲染、Discourse API 或缓存格式
- 不包含帖子页顶部板块标签的单击/双击动作（另开 PR）

## 主要改动文件

- `lib/providers/preferences_provider.dart` — `topicTitleFontScale`、公共缩放常量、clamp
- `lib/settings/definitions/reading_defs.dart` — 阅读设置双滑块
- `lib/widgets/topic/topic_card.dart` — 普通/紧凑标题应用缩放
- `lib/l10n/modules/appearance/appearance_*.arb` — 文案
- `test/providers/preferences_provider_test.dart`
- `test/settings/reading_defs_test.dart`
- `test/widgets/topic/topic_card_test.dart`

## 行为约定

| 项 | 值 |
| --- | --- |
| 最小 | 0.8（80%） |
| 最大 | 3.0（300%） |
| 默认 / 重置 | 1.0（100%） |
| 步长 | 0.05 |
| Slider divisions | 44 |
| 持久化键 | `pref_topic_title_font_scale` |

## 测试

- [x] 偏好默认值、持久化、边界 clamp
- [x] 阅读设置项顺序与滑块元数据
- [x] 普通/紧凑标题字号随比例变化，元数据不变
- [x] `just analyze`
- [x] 相关 `just test` / `flutter test`
- [x] 设置页人工验证 80% / 100% / 300% 列表标题显示

## 截图

原100%大小
<img width="2650" height="1381" alt="2026-07-12_045032" src="https://github.com/user-attachments/assets/c0cce764-5d7b-4392-a2f1-7d901ba17fcc" />
现200%大小
<img width="2560" height="1380" alt="2026-07-12_045101" src="https://github.com/user-attachments/assets/b5960d24-0072-4ca7-b3eb-772db50113ff" />
现300%大小
<img width="2566" height="1378" alt="2026-07-12_045229" src="https://github.com/user-attachments/assets/7520fa23-6dd7-4e9f-8745-12fa7135eebf" />


设置截图
<img width="2555" height="446" alt="2026-07-12_045219" src="https://github.com/user-attachments/assets/d48f5ba4-9af6-4795-a32d-0cd194f7bb48" />


## 检查清单

- [ ] 未引入第三方依赖
- [ ] 未提交 `lib/l10n/slang/`、生成物等不应入库的文件
- [ ] Commit 使用 Conventional Commits（`feat:` / `test:` / `docs:`）
- [ ] 与「板块标签动作」功能拆分，不混在同一 PR
