### PR TITLE
feat: 帖子页板块标签支持导航单击/双击动作

### DIFF
--- a/lib/navigation/topic_tab_tap_coordinator.dart
+++ b/lib/navigation/topic_tab_tap_coordinator.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'nav_action_bus.dart';
+
+/// Splits active topic-tab taps into the configured single and double actions.
+///
+/// The coordinator tracks a logical active index separately from TabController
+/// so the first tap on an inactive tab switches immediately without dispatching
+/// an action. A rapid second tap is then treated as the first active-tab tap,
+/// even while the controller animation is still settling.
+class TopicTabTapCoordinator {
+  TopicTabTapCoordinator({required int initialActiveIndex})
+    : _activeIndex = initialActiveIndex;
+
+  static const _doubleTapWindow = Duration(milliseconds: 300);
+
+  int _activeIndex;
+  int? _pendingTapIndex;
+  Timer? _pendingTapTimer;
+  bool _disposed = false;
+
+  void handleTap({
+    required int index,
+    required NavTapAction singleAction,
+    required NavTapAction doubleAction,
+    required void Function(NavAction action) dispatch,
+  }) {
+    if (_disposed) return;
+
+    if (index != _activeIndex) {
+      _cancelPendingTap();
+      _activeIndex = index;
+      return;
+    }
+
+    final hasSingle = singleAction != NavTapAction.none;
+    final hasDouble = doubleAction != NavTapAction.none;
+
+    if (!hasSingle && !hasDouble) {
+      _cancelPendingTap();
+      return;
+    }
+
+    final isDoubleTap =
+        hasDouble && _pendingTapTimer != null && _pendingTapIndex == index;
+
+    if (isDoubleTap) {
+      _cancelPendingTap();
+      final navAction = doubleAction.toNavAction();
+      if (navAction != null) {
+        dispatch(navAction);
+      }
+      return;
+    }
+
+    _cancelPendingTap();
+
+    final singleNavAction = singleAction.toNavAction();
+    if (!hasDouble) {
+      if (singleNavAction != null) {
+        dispatch(singleNavAction);
+      }
+      return;
+    }
+
+    _pendingTapIndex = index;
+    _pendingTapTimer = Timer(_doubleTapWindow, () {
+      _pendingTapTimer = null;
+      _pendingTapIndex = null;
+      if (_disposed || singleNavAction == null) return;
+      dispatch(singleNavAction);
+    });
+  }
+
+  /// Synchronizes programmatic/external tab changes.
+  ///
+  /// Settling the same tab selected by [handleTap] keeps its pending action;
+  /// changing to a different tab cancels stale pending work.
+  void syncActiveIndex(int index) {
+    if (_disposed || index == _activeIndex) return;
+    _cancelPendingTap();
+    _activeIndex = index;
+  }
+
+  /// Clears all pending gestures when the tab set changes.
+  void reset({required int activeIndex}) {
+    if (_disposed) return;
+    _cancelPendingTap();
+    _activeIndex = activeIndex;
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _cancelPendingTap();
+  }
+
+  void _cancelPendingTap() {
+    _pendingTapTimer?.cancel();
+    _pendingTapTimer = null;
+    _pendingTapIndex = null;
+  }
+}

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -31,6 +31,7 @@ import '../widgets/topic/category_tab_manager_sheet.dart';
 import '../widgets/common/tag_selection_sheet.dart';
 import '../widgets/common/paged_list_footer.dart';
 import '../navigation/nav_action_bus.dart';
+import '../navigation/topic_tab_tap_coordinator.dart';
 import '../providers/app_state_refresher.dart';
 import '../providers/preferences_provider.dart';
 import '../utils/load_more_coordinator.dart';
@@ -127,6 +128,7 @@ class TopicsPage extends ConsumerStatefulWidget {
 class _TopicsPageState extends ConsumerState<TopicsPage>
     with TickerProviderStateMixin {
   late TabController _tabController;
+  late final TopicTabTapCoordinator _topicTabTapCoordinator;
   late final ShortcutScopeBinding _tabShortcutBinding = ShortcutScopeBinding(
     ref: ref,
     scope: ShortcutScope.master,
@@ -146,6 +148,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
   @override
   void initState() {
     super.initState();
+    _topicTabTapCoordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
     _visiblePinnedIds = ref.read(pinnedCategoriesProvider);
     _tabLength = 1 + _visiblePinnedIds.length;
     _tabController = TabController(length: _tabLength, vsync: this);
@@ -170,6 +173,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
 
   @override
   void dispose() {
+    _topicTabTapCoordinator.dispose();
     _snapAnim?.dispose();
     _pointerScrollIdleTimer?.cancel();
     _outerScrollController.dispose();
@@ -206,6 +210,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
   void _handleTabChange() {
     if (_tabController.indexIsChanging) return;
     if (_currentTabIndex == _tabController.index) return;
+    _topicTabTapCoordinator.syncActiveIndex(_tabController.index);
     setState(() {
       _currentTabIndex = _tabController.index;
     });
@@ -227,9 +232,15 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
 
   /// 检测 pinnedCategories 变化，重建 TabController
   void _syncTabsIfNeeded(List<int> pinnedIds) {
+    final pinnedIdsChanged = !listEquals(_visiblePinnedIds, pinnedIds);
     final desiredLength = 1 + pinnedIds.length;
     _visiblePinnedIds = pinnedIds;
-    if (desiredLength == _tabLength) return;
+    if (desiredLength == _tabLength) {
+      if (pinnedIdsChanged) {
+        _topicTabTapCoordinator.reset(activeIndex: _currentTabIndex);
+      }
+      return;
+    }
 
     final oldIndex = _tabController.index;
     _tabController.removeListener(_handleTabChange);
@@ -239,6 +250,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
     _tabController.addListener(_handleTabChange);
     _currentTabIndex = oldIndex < _tabLength ? oldIndex : 0;
     _tabController.index = _currentTabIndex;
+    _topicTabTapCoordinator.reset(activeIndex: _currentTabIndex);
   }
 
   Future<void> _goToLogin() async {
@@ -631,9 +643,15 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
                   },
                   onAddTag: _openTagSelection,
                   onTabTap: (index) {
-                    if (index == _currentTabIndex) {
-                      ref.read(scrollToTopProvider.notifier).trigger();
-                    }
+                    final preferences = ref.read(preferencesProvider);
+                    _topicTabTapCoordinator.handleTap(
+                      index: index,
+                      singleAction: preferences.bottomSingleTapAction,
+                      doubleAction: preferences.bottomDoubleTapAction,
+                      dispatch: (navAction) {
+                        ref.dispatchNavAction(NavEntryIds.home, navAction);
+                      },
+                    );
                   },
                   onCategoryManager: _openCategoryManager,
                   onSearch: () {

--- a/test/navigation/topic_tab_tap_coordinator_test.dart
+++ b/test/navigation/topic_tab_tap_coordinator_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/navigation/nav_action_bus.dart';
+import 'package:fluxdo/navigation/topic_tab_tap_coordinator.dart';
+
+void main() {
+  group('TopicTabTapCoordinator', () {
+    testWidgets(
+      'inactive first tap switches and second tap starts active single action',
+      (tester) async {
+        final actions = <NavAction>[];
+        final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+        addTearDown(coordinator.dispose);
+
+        coordinator.handleTap(
+          index: 1,
+          singleAction: NavTapAction.scrollToTop,
+          doubleAction: NavTapAction.refresh,
+          dispatch: actions.add,
+        );
+        expect(actions, isEmpty);
+
+        coordinator.handleTap(
+          index: 1,
+          singleAction: NavTapAction.scrollToTop,
+          doubleAction: NavTapAction.refresh,
+          dispatch: actions.add,
+        );
+        coordinator.syncActiveIndex(1);
+
+        await tester.pump(const Duration(milliseconds: 299));
+        expect(actions, isEmpty);
+        await tester.pump(const Duration(milliseconds: 1));
+        expect(actions, [NavAction.scrollToTop]);
+      },
+    );
+
+    testWidgets('active double tap cancels pending single action', (
+      tester,
+    ) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.scrollToTop,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+      await tester.pump(const Duration(milliseconds: 100));
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.scrollToTop,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+
+      expect(actions, [NavAction.refresh]);
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(actions, [NavAction.refresh]);
+    });
+
+    testWidgets('single-only action dispatches immediately', (tester) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.refresh,
+        doubleAction: NavTapAction.none,
+        dispatch: actions.add,
+      );
+
+      expect(actions, [NavAction.refresh]);
+    });
+
+    testWidgets('double-only action dispatches on the second active tap', (
+      tester,
+    ) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.none,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+      expect(actions, isEmpty);
+
+      await tester.pump(const Duration(milliseconds: 100));
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.none,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+
+      expect(actions, [NavAction.refresh]);
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(actions, [NavAction.refresh]);
+    });
+
+    testWidgets('none actions never dispatch', (tester) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.none,
+        doubleAction: NavTapAction.none,
+        dispatch: actions.add,
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(actions, isEmpty);
+    });
+
+    testWidgets('external tab switch cancels a pending single action', (
+      tester,
+    ) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.scrollToTop,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+      coordinator.syncActiveIndex(1);
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(actions, isEmpty);
+    });
+
+    testWidgets('reset cancels pending action and replaces active index', (
+      tester,
+    ) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+      addTearDown(coordinator.dispose);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.scrollToTop,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+      coordinator.reset(activeIndex: 1);
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(actions, isEmpty);
+
+      coordinator.handleTap(
+        index: 1,
+        singleAction: NavTapAction.refresh,
+        doubleAction: NavTapAction.none,
+        dispatch: actions.add,
+      );
+      expect(actions, [NavAction.refresh]);
+
+      actions.clear();
+      coordinator.reset(activeIndex: 1);
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.refresh,
+        doubleAction: NavTapAction.none,
+        dispatch: actions.add,
+      );
+      expect(actions, isEmpty);
+    });
+
+    testWidgets('dispose cancels a pending single action', (tester) async {
+      final actions = <NavAction>[];
+      final coordinator = TopicTabTapCoordinator(initialActiveIndex: 0);
+
+      coordinator.handleTap(
+        index: 0,
+        singleAction: NavTapAction.scrollToTop,
+        doubleAction: NavTapAction.refresh,
+        dispatch: actions.add,
+      );
+      coordinator.dispose();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(actions, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## 改动说明

- 帖子页顶部 `TabBar`（「全部」及用户固定的板块标签，如「开发调优」）在**已激活**时，复用导航栏已有配置：
  - `bottomSingleTapAction`（单击已选中项）
  - `bottomDoubleTapAction`（双击已选中项）
- **未激活**标签：单击立即切换板块，**不**派发回到顶部 / 刷新等动作
- 快速双击一个起初未激活的标签：第一次只切换，第二次视为切换后的**第一次激活点击**，不直接当成双击
- 单击 / 双击分流与现有导航栏一致，**300ms** 互斥窗口：
  - 仅单击：立即派发
  - 仅双击：第一次只记录，窗口内第二次派发双击
  - 两者都有：第一次延迟，窗口内第二次取消单击只派发双击
  - 均为 `none`：不记录、不派发
- 动作经现有 `NavEntryIds.home` 动作总线派发（`scrollToTop` / `refresh`），**不新建刷新路径**
- 标签切换（点击、滑动、外部入口）、固定板块集合变化、页面 dispose 时取消待执行 timer，避免误触
- 抽出 `TopicTabTapCoordinator`，**不修改**现有底部/侧边导航实现
- 补充聚焦单元测试

## 动机

导航栏已支持「单击/双击已选中项」配置，但帖子页顶部板块标签重复点击已激活项时只会回到顶部，语义不一致。希望在不增加新设置项、不重构导航栏的前提下，让顶部板块标签与导航动作配置对齐。

## 非目标

- 不新增单击/双击相关设置项
- 不重构 `adaptive_navigation.dart` 或改变现有导航栏行为
- 不修改 Discourse API、数据层或帖子内容渲染
- 不包含阅读字体 / 列表标题字号改动（另开 PR）

## 默认行为（沿用现有导航默认配置）

| 手势 | 默认动作 |
| --- | --- |
| 单击已激活板块 | 回到顶部 |
| 双击已激活板块 | 刷新（回顶 + 刷新指示 + 数据刷新） |
| 单击未激活板块 | 仅切换标签 |

用户修改设置后立即生效（每次点击读取当前配置）。

## 主要改动文件

- `lib/navigation/topic_tab_tap_coordinator.dart` — 单击/双击分流与激活索引同步
- `lib/pages/topics_page.dart` — 接入 coordinator 与动作派发
- （如有）`lib/widgets/layout/category_shortcuts.dart` — 与标签切换相关的状态清理
- `test/navigation/topic_tab_tap_coordinator_test.dart`

## 测试

- [x] 未激活标签只切换、不派发动作
- [x] 未激活上的快速双击：第一次切换，第二次作首次激活点击
- [x] 仅单击 / 仅双击 / 两者都有 / 均为 none
- [x] 标签切换与 dispose 取消待执行动作
- [ ] `just analyze`
- [ ] 相关 `just test` / `flutter test`
- [ ] 人工验证：单击回顶、双击刷新、未激活切换、滑动切换后无延迟误触

## 截图 / 录屏

<img width="2559" height="1382" alt="2026-07-12_045407" src="https://github.com/user-attachments/assets/4ea5f555-144a-4c6f-a453-677f04679bb2" />


## 检查清单

- [ ] 未引入第三方依赖
- [ ] 未改变现有底部/侧边导航行为
- [ ] Commit 使用 Conventional Commits（`feat:` / `test:`）
- [ ] 与「阅读字体 / 列表标题字号」功能拆分，不混在同一 PR
- [ ] 手机 / 平板 / 桌面逻辑一致（同一套 coordinator）
