### PR TITLE
feat: 板块等级切换下拉

### DIFF
--- a/lib/l10n/modules/categoryTag/categoryTag_en.arb
+++ b/lib/l10n/modules/categoryTag/categoryTag_en.arb
@@ -24,6 +24,7 @@
   "category_noCategories": "No categories",
   "category_noCategoriesFound": "No categories found",
   "category_parentAll": "{name} (All)",
+  "category_levelAll": "All LV",
   "category_searchHint": "Search categories...",
   "tagTopics_empty": "No topics with this tag",
   "tag_maxTagsReached": "Maximum {max} tags allowed",

--- a/lib/l10n/modules/categoryTag/categoryTag_zh.arb
+++ b/lib/l10n/modules/categoryTag/categoryTag_zh.arb
@@ -38,6 +38,7 @@
       }
     }
   },
+  "category_levelAll": "全部LV",
   "category_searchHint": "搜索分类...",
   "tagTopics_empty": "该标签下暂无话题",
   "tag_maxTagsReached": "最多只能选择 {max} 个标签",

--- a/lib/l10n/modules/categoryTag/categoryTag_zh_HK.arb
+++ b/lib/l10n/modules/categoryTag/categoryTag_zh_HK.arb
@@ -38,6 +38,7 @@
       }
     }
   },
+  "category_levelAll": "全部LV",
   "category_searchHint": "搜索分類...",
   "tagTopics_empty": "該標籤下暫無話題",
   "tag_maxTagsReached": "最多隻能選擇 {max} 個標籤",

--- a/lib/l10n/modules/categoryTag/categoryTag_zh_TW.arb
+++ b/lib/l10n/modules/categoryTag/categoryTag_zh_TW.arb
@@ -38,6 +38,7 @@
       }
     }
   },
+  "category_levelAll": "全部LV",
   "category_searchHint": "搜尋分類...",
   "tagTopics_empty": "該標籤下暫無話題",
   "tag_maxTagsReached": "最多隻能選擇 {max} 個標籤",

--- a/lib/pages/category_topics_page.dart
+++ b/lib/pages/category_topics_page.dart
@@ -401,6 +401,16 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
     }
   }
 
+  /// 切换板块等级：替换当前分类页，保留返回栈
+  void _switchCategoryLevel(Category category) {
+    if (category.id == widget.category.id || !mounted) return;
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) => CategoryTopicsPage(category: category),
+      ),
+    );
+  }
+
   Future<void> _openTopic(Topic topic) async {
     // 分类详情页是独立 push 的页面，不在首页 MasterDetailLayout 内，
     // 始终 push 全屏详情页，禁用 autoSwitchToMasterDetail 防止双栏模式下自动 pop。
@@ -465,6 +475,8 @@ class _CategoryTopicsPageState extends ConsumerState<CategoryTopicsPage> {
             selectedTags: _selectedTags,
             onTagRemoved: _removeTag,
             onAddTag: _openTagSelection,
+            currentCategory: widget.category,
+            onCategoryChanged: _switchCategoryLevel,
             trailing: isLoggedIn
                 ? Row(
                     mainAxisSize: MainAxisSize.min,

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -332,6 +332,48 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
     }
   }
 
+  /// 切换板块等级：留在首页主从布局，固定并切换对应 Tab
+  void _switchCategoryLevel(Category category) {
+    final currentId = _currentCategoryId();
+    if (currentId == category.id) return;
+
+    final pinned = ref.read(pinnedCategoriesProvider);
+    final notifier = ref.read(pinnedCategoriesProvider.notifier);
+
+    if (pinned.contains(category.id)) {
+      // 目标已固定：直接切 Tab
+      final tabIndex = _visiblePinnedIds.indexOf(category.id);
+      if (tabIndex >= 0) {
+        _tabController.animateTo(tabIndex + 1);
+      } else {
+        ref.read(activeSidebarCategoryIdProvider.notifier).state = category.id;
+      }
+      return;
+    }
+
+    if (currentId != null && pinned.contains(currentId)) {
+      // 用同级等级替换当前固定项，保持 Tab 位置与主从布局
+      notifier.replace(currentId, category.id);
+      // 索引不变时不会触发 tab change，需手动同步
+      ref.read(currentTabCategoryIdProvider.notifier).state = category.id;
+      ref.read(activeSidebarCategoryIdProvider.notifier).state = category.id;
+      setState(() {});
+      return;
+    }
+
+    // 当前未固定：追加到 Tab 栏并切过去
+    notifier.add(category.id);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(activeSidebarCategoryIdProvider.notifier).state = category.id;
+      ref.read(currentTabCategoryIdProvider.notifier).state = category.id;
+      final tabIndex = _visiblePinnedIds.indexOf(category.id);
+      if (tabIndex >= 0 && _tabController.index != tabIndex + 1) {
+        _tabController.animateTo(tabIndex + 1);
+      }
+    });
+  }
+
   Future<void> _openTagSelection() async {
     final categoryId = _currentCategoryId();
     final currentTags = ref.read(tabTagsProvider(categoryId));
@@ -636,6 +678,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
                     }
                   },
                   onCategoryManager: _openCategoryManager,
+                  onCategoryChanged: _switchCategoryLevel,
                   onSearch: () {
                     SearchFilter? filter;
                     if (currentCategory != null) {
@@ -909,6 +952,7 @@ class _TopicsHeaderDelegate extends SliverPersistentHeaderDelegate {
   final VoidCallback onAddTag;
   final ValueChanged<int> onTabTap;
   final VoidCallback onCategoryManager;
+  final ValueChanged<Category> onCategoryChanged;
   final VoidCallback onSearch;
   final VoidCallback onDebugTopicId;
   final Widget? trailing;
@@ -928,6 +972,7 @@ class _TopicsHeaderDelegate extends SliverPersistentHeaderDelegate {
     required this.onAddTag,
     required this.onTabTap,
     required this.onCategoryManager,
+    required this.onCategoryChanged,
     required this.onSearch,
     required this.onDebugTopicId,
     this.trailing,
@@ -1147,6 +1192,8 @@ class _TopicsHeaderDelegate extends SliverPersistentHeaderDelegate {
                         selectedTags: currentTags,
                         onTagRemoved: onTagRemoved,
                         onAddTag: onAddTag,
+                        currentCategory: currentCategory,
+                        onCategoryChanged: onCategoryChanged,
                         trailing: trailing,
                       );
                     },

--- a/lib/providers/pinned_categories_provider.dart
+++ b/lib/providers/pinned_categories_provider.dart
@@ -27,6 +27,25 @@ class PinnedCategoriesNotifier extends StateNotifier<List<int>> {
     _save();
   }
 
+  /// 用新分类替换已固定的分类（保持原位置）
+  void replace(int fromId, int toId) {
+    if (fromId == toId) return;
+    final index = state.indexOf(fromId);
+    if (index < 0) {
+      add(toId);
+      return;
+    }
+    if (state.contains(toId)) {
+      // 目标已固定：移除来源即可
+      state = state.where((id) => id != fromId).toList();
+    } else {
+      final list = [...state];
+      list[index] = toId;
+      state = list;
+    }
+    _save();
+  }
+
   void reorder(int oldIndex, int newIndex) {
     final list = [...state];
     final item = list.removeAt(oldIndex);

--- a/lib/widgets/topic/category_level_dropdown.dart
+++ b/lib/widgets/topic/category_level_dropdown.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'package:app_icons/app_icons.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:common_ui/common_ui.dart';
+
+import '../../models/category.dart';
+import '../../providers/discourse_providers.dart';
+
+/// 同级板块等级选项：父分类 + 子分类列表
+class CategoryLevelOptions {
+  final Category parent;
+  final List<Category> children;
+
+  const CategoryLevelOptions({
+    required this.parent,
+    required this.children,
+  });
+
+  List<Category> get all => [parent, ...children];
+}
+
+/// 解析当前分类的同级等级列表。
+/// 无子分类时返回 null（不显示下拉）。
+CategoryLevelOptions? resolveCategoryLevels(
+  Category current,
+  List<Category> all,
+  Map<int, Category> map,
+) {
+  final Category parent;
+  final List<Category> children;
+
+  if (current.parentCategoryId != null) {
+    final p = map[current.parentCategoryId];
+    if (p == null) return null;
+    parent = p;
+    children = all
+        .where((c) => c.parentCategoryId == parent.id)
+        .toList(growable: false);
+  } else {
+    parent = current;
+    children = all
+        .where((c) => c.parentCategoryId == current.id)
+        .toList(growable: false);
+  }
+
+  if (children.isEmpty) return null;
+  return CategoryLevelOptions(parent: parent, children: children);
+}
+
+/// 按钮/菜单项短标签：去掉父分类名前缀与分隔符，父分类显示「全部LV」
+String categoryLevelLabel(Category category, Category parent) {
+  if (category.id == parent.id) return '全部LV';
+  final name = category.name;
+  final parentName = parent.name;
+  if (name.startsWith(parentName)) {
+    final rest = name.substring(parentName.length);
+    // 去掉前缀后的分隔符（空格、逗号、斜杠、中点等）
+    final cleaned = rest.replaceFirst(RegExp(r'^[\s,，\-_/·:：]+'), '');
+    if (cleaned.isNotEmpty) return cleaned;
+  }
+  // 名称本身含「LV数字」时优先只显示等级
+  final lvMatch = RegExp(r'LV\s*\d+', caseSensitive: false).firstMatch(name);
+  if (lvMatch != null) {
+    return lvMatch.group(0)!.toUpperCase().replaceAll(' ', '');
+  }
+  return name;
+}
+
+/// 板块等级切换下拉（风格与 FilterDropdown / OrderDropdown 一致）
+class CategoryLevelDropdown extends ConsumerWidget {
+  final Category currentCategory;
+  final ValueChanged<Category> onCategoryChanged;
+
+  const CategoryLevelDropdown({
+    super.key,
+    required this.currentCategory,
+    required this.onCategoryChanged,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final categoriesAsync = ref.watch(categoriesProvider);
+    final categories = categoriesAsync.value;
+    if (categories == null) return const SizedBox.shrink();
+
+    final map = {for (final c in categories) c.id: c};
+    // 若 map 中有更新后的 current，优先用它
+    final current = map[currentCategory.id] ?? currentCategory;
+    final options = resolveCategoryLevels(current, categories, map);
+    if (options == null) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = categoryLevelLabel(current, options.parent);
+    final isParentSelected = current.id == options.parent.id;
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: SwipeDismissiblePopupMenuButton<int>(
+        onSelected: (id) {
+          if (id == current.id) return;
+          final target = map[id];
+          if (target != null) onCategoryChanged(target);
+        },
+        offset: const Offset(0, 36),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        tooltip: label,
+        itemBuilder: (context) {
+          return options.all.map((cat) {
+            final isSelected = cat.id == current.id;
+            final itemLabel = categoryLevelLabel(cat, options.parent);
+            return PopupMenuItem<int>(
+              value: cat.id,
+              child: Row(
+                children: [
+                  if (isSelected)
+                    Icon(Symbols.check_rounded, size: 16, color: colorScheme.primary)
+                  else
+                    const SizedBox(width: 16),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      itemLabel,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }).toList();
+        },
+        child: _buildChild(colorScheme, label, !isParentSelected),
+      ),
+    );
+  }
+
+  Widget _buildChild(ColorScheme colorScheme, String label, bool isActive) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: isActive
+            ? colorScheme.primaryContainer.withValues(alpha: 0.3)
+            : colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 96),
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
+                color: isActive ? colorScheme.primary : colorScheme.onSurface,
+              ),
+            ),
+          ),
+          const SizedBox(width: 2),
+          Icon(
+            Symbols.arrow_drop_down_rounded,
+            size: 18,
+            color: isActive ? colorScheme.primary : colorScheme.onSurfaceVariant,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/topic/sort_and_tags_bar.dart
+++ b/lib/widgets/topic/sort_and_tags_bar.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
+import '../../models/category.dart';
 import '../../providers/topic_list/filter_provider.dart';
 import '../../providers/topic_list/sort_provider.dart';
 import '../common/topic_badges.dart';
 import 'filter_dropdown.dart';
+import 'category_level_dropdown.dart';
 import '../../l10n/s.dart';
 
 /// 筛选选项定义
@@ -40,6 +42,8 @@ class SortAndTagsBar extends StatelessWidget {
   final List<String> selectedTags;
   final ValueChanged<String> onTagRemoved;
   final VoidCallback? onAddTag;
+  final Category? currentCategory;
+  final ValueChanged<Category>? onCategoryChanged;
   final Widget? trailing;
 
   const SortAndTagsBar({
@@ -56,6 +60,8 @@ class SortAndTagsBar extends StatelessWidget {
     required this.selectedTags,
     required this.onTagRemoved,
     this.onAddTag,
+    this.currentCategory,
+    this.onCategoryChanged,
     this.trailing,
   });
 
@@ -90,6 +96,12 @@ class SortAndTagsBar extends StatelessWidget {
             onOrderChanged: onOrderChanged,
             onToggleAscending: onToggleAscending,
           ),
+          // 板块等级切换（内部无同级时自隐藏）
+          if (currentCategory != null && onCategoryChanged != null)
+            CategoryLevelDropdown(
+              currentCategory: currentCategory!,
+              onCategoryChanged: onCategoryChanged!,
+            ),
           const SizedBox(width: 8),
           // 标签区域
           Expanded(


### PR DESCRIPTION
## Summary
- 在最新/默认右侧增加同风格等级下拉
- 首页切换时固定/替换 Tab，保持左右主从布局
- 独立分类页切换时 pushReplacement
- 短标签去掉父分类前缀与逗号

<img width="2560" height="1385" alt="image" src="https://github.com/user-attachments/assets/93084a8e-132a-4f76-8d3d-f480885ef599" />