### PR TITLE
feat: 进度条左右滑动连续跳楼

### DIFF
--- a/lib/pages/topic_detail_page/actions/_scroll_actions.dart
+++ b/lib/pages/topic_detail_page/actions/_scroll_actions.dart
@@ -366,6 +366,86 @@ extension _ScrollActions on _TopicDetailPageState {
     _controller.triggerHighlight(postNumber);
   }
 
+  /// 进度条水平 scrub：按真实楼层号跳转（拖动中尽量轻量，避免狂刷 rebuild）
+  Future<void> _scrubToPostNumber(
+    int postNumber, {
+    bool finalize = false,
+  }) async {
+    final detail = ref.read(topicDetailProvider(_params)).value;
+    if (detail == null) return;
+
+    final maxPost = detail.postsCount > 0
+        ? detail.postsCount
+        : detail.postStream.stream.length;
+    final target = postNumber.clamp(1, maxPost < 1 ? 1 : maxPost);
+
+    final posts = detail.postStream.posts;
+    final postIndex = posts.indexWhere((p) => p.postNumber == target);
+
+    if (postIndex != -1) {
+      final post = posts[postIndex];
+      _controller.updateViewportPostNumber(post.postNumber);
+
+      final streamIndex = detail.postStream.stream.indexOf(post.id);
+      if (streamIndex != -1) {
+        _controller.updateStreamIndex(streamIndex + 1);
+      }
+
+      // 已渲染：直接 scrollToIndex（1ms），不重置列表状态
+      if (_controller.isPostRendered(postIndex)) {
+        await _controller.scrollToPost(post.postNumber, posts);
+        return;
+      }
+
+      // 已加载未渲染：本地瞬跳，不 setState、不高亮
+      int? anchorPostNumber;
+      if (posts.length - 1 - postIndex < 20) {
+        final safeIndex = (posts.length - 20).clamp(0, posts.length - 1);
+        anchorPostNumber = posts[safeIndex].postNumber;
+      }
+      _controller.jumpToPostLocally(
+        post.postNumber,
+        anchorPostNumber: anchorPostNumber,
+      );
+      return;
+    }
+
+    // 目标楼未加载：拖动中先落到最近已加载楼，避免每次 reload
+    if (!finalize && posts.isNotEmpty) {
+      Post nearest = posts.first;
+      var best = (posts.first.postNumber - target).abs();
+      for (final p in posts) {
+        final d = (p.postNumber - target).abs();
+        if (d < best) {
+          best = d;
+          nearest = p;
+        }
+      }
+      if (nearest.postNumber != target) {
+        await _scrubToPostNumber(nearest.postNumber, finalize: false);
+      }
+      return;
+    }
+
+    // 松手时再做完整跳转（可能 reload）
+    await _scrollToPost(target);
+  }
+
+  /// stream 1-based 索引 → 真实 post_number（隐藏楼时二者不等）
+  int _resolvePostNumberFromStreamIndex(
+    TopicDetail detail,
+    int streamIndex1Based,
+  ) {
+    final stream = detail.postStream.stream;
+    if (stream.isEmpty) return 1;
+    final index = streamIndex1Based.clamp(1, stream.length) - 1;
+    final postId = stream[index];
+    final posts = detail.postStream.posts;
+    final loaded = posts.where((p) => p.id == postId).firstOrNull;
+    if (loaded != null) return loaded.postNumber;
+    return streamIndex1Based;
+  }
+
   Future<void> _scrollToPostById(int postId) async {
     final params = _params;
     final detail = ref.read(topicDetailProvider(params)).value;

--- a/lib/pages/topic_detail_page/actions/_scroll_actions.dart
+++ b/lib/pages/topic_detail_page/actions/_scroll_actions.dart
@@ -10,6 +10,9 @@ extension _ScrollActions on _TopicDetailPageState {
     _scheduleCheckTitleVisibility();
     _controller.handleScroll();
 
+    // scrub 拖动中禁止自动 loadPrevious/loadMore，避免列表结构突变导致空白
+    if (_isProgressScrubbing) return;
+
     final params = _params;
     final detailAsync = ref.read(topicDetailProvider(params));
 
@@ -366,10 +369,76 @@ extension _ScrollActions on _TopicDetailPageState {
     _controller.triggerHighlight(postNumber);
   }
 
-  /// 进度条水平 scrub：按真实楼层号跳转（拖动中尽量轻量，避免狂刷 rebuild）
+  /// scrub 取消 / 异常结束：解锁底栏与自动分页
+  void _endProgressScrub() {
+    _scrubPendingPostNumber = null;
+    _scrubPendingFinalize = false;
+    _isProgressScrubbing = false;
+    _controller.setScrubbing(false);
+  }
+
+  /// 进度条水平 scrub：边拖边看贴（必须立刻看到目标楼正文）
+  ///
+  /// 约束（修「快速左拉整屏空白 + 底栏消失」）：
+  /// 1. **绝不**在拖动中 [prepareJumpToPost] 后整页骨架 / 清空 detail 的 reload
+  /// 2. 本地重定位 [jumpToPostLocally] 一律 hideUntilPositioned: false
+  /// 3. 拖动期间锁底栏、禁止 scroll 触发 loadPrevious/loadMore
+  /// 4. 串行只保留最新目标，避免快速拖动 async 堆叠
   Future<void> _scrubToPostNumber(
     int postNumber, {
     bool finalize = false,
+  }) async {
+    if (!finalize && !_isProgressScrubbing) {
+      _isProgressScrubbing = true;
+      _controller.setScrubbing(true);
+    }
+
+    _scrubPendingPostNumber = postNumber;
+    if (finalize) {
+      _scrubPendingFinalize = true;
+    }
+
+    // 串行：上一次 jump 未完成则只更新 pending，结束后再冲最新目标
+    if (_scrubJumpInFlight) return;
+    _scrubJumpInFlight = true;
+    var sawFinalize = false;
+    try {
+      while (mounted) {
+        final targetRaw = _scrubPendingPostNumber;
+        if (targetRaw == null) break;
+        _scrubPendingPostNumber = null;
+
+        // finalize 只作用在「当前取出的目标」上；若 await 期间又有新目标，
+        // 把 finalize 语义留给队列里的最终目标
+        var doFinalize = _scrubPendingFinalize;
+        _scrubPendingFinalize = false;
+        if (doFinalize) sawFinalize = true;
+
+        await _scrubToPostNumberOnce(targetRaw, finalize: doFinalize);
+        if (!mounted) break;
+
+        if (_scrubPendingPostNumber != null) {
+          if (doFinalize) {
+            _scrubPendingFinalize = true;
+          }
+          continue;
+        }
+        break;
+      }
+    } finally {
+      _scrubJumpInFlight = false;
+      // 仅松手 finalize 后解锁；拖动中即使单次 jump 结束也保持锁定，
+      // 避免中途 loadPrevious/loadMore 或藏底栏
+      if (sawFinalize && _scrubPendingPostNumber == null) {
+        _isProgressScrubbing = false;
+        _controller.setScrubbing(false);
+      }
+    }
+  }
+
+  Future<void> _scrubToPostNumberOnce(
+    int postNumber, {
+    required bool finalize,
   }) async {
     final detail = ref.read(topicDetailProvider(_params)).value;
     if (detail == null) return;
@@ -382,6 +451,7 @@ extension _ScrollActions on _TopicDetailPageState {
     final posts = detail.postStream.posts;
     final postIndex = posts.indexWhere((p) => p.postNumber == target);
 
+    // —— 目标已在已加载列表 ——
     if (postIndex != -1) {
       final post = posts[postIndex];
       _controller.updateViewportPostNumber(post.postNumber);
@@ -391,13 +461,13 @@ extension _ScrollActions on _TopicDetailPageState {
         _controller.updateStreamIndex(streamIndex + 1);
       }
 
-      // 已渲染：直接 scrollToIndex（1ms），不重置列表状态
+      // 已渲染：直接 scroll，立刻看到该楼
       if (_controller.isPostRendered(postIndex)) {
         await _controller.scrollToPost(post.postNumber, posts);
         return;
       }
 
-      // 已加载未渲染：本地瞬跳，不 setState、不高亮
+      // 已加载未渲染：本地重定位到该楼（不隐列表、不整页骨架）
       int? anchorPostNumber;
       if (posts.length - 1 - postIndex < 20) {
         final safeIndex = (posts.length - 20).clamp(0, posts.length - 1);
@@ -406,11 +476,14 @@ extension _ScrollActions on _TopicDetailPageState {
       _controller.jumpToPostLocally(
         post.postNumber,
         anchorPostNumber: anchorPostNumber,
+        hideUntilPositioned: false,
       );
+      if (mounted) setState(() {});
       return;
     }
 
-    // 目标楼未加载：拖动中先落到最近已加载楼，避免每次 reload
+    // —— 目标未加载 ——
+    // 拖动中：落到最近已加载楼并滚过去（继续能看贴），绝不 reload
     if (!finalize && posts.isNotEmpty) {
       Post nearest = posts.first;
       var best = (posts.first.postNumber - target).abs();
@@ -421,14 +494,40 @@ extension _ScrollActions on _TopicDetailPageState {
           nearest = p;
         }
       }
-      if (nearest.postNumber != target) {
-        await _scrubToPostNumber(nearest.postNumber, finalize: false);
+      _controller.updateViewportPostNumber(nearest.postNumber);
+      final streamIndex = detail.postStream.stream.indexOf(nearest.id);
+      if (streamIndex != -1) {
+        _controller.updateStreamIndex(streamIndex + 1);
+      }
+      final nearestIndex = posts.indexWhere(
+        (p) => p.postNumber == nearest.postNumber,
+      );
+      if (nearestIndex != -1 && _controller.isPostRendered(nearestIndex)) {
+        await _controller.scrollToPost(nearest.postNumber, posts);
+      } else if (nearestIndex != -1) {
+        _controller.jumpToPostLocally(
+          nearest.postNumber,
+          hideUntilPositioned: false,
+        );
+        if (mounted) setState(() {});
       }
       return;
     }
 
-    // 松手时再做完整跳转（可能 reload）
-    await _scrollToPost(target);
+    // 松手且目标未加载：完整跳转（可能 reload）。
+    // reload 已用 copyWithPrevious；整页骨架改为只替换列表区，Overlay 保留。
+    // 仍避免 prepareJump 把 isPositioned 打 false 造成 Opacity(0)。
+    final params = _params;
+    final notifier = ref.read(topicDetailProvider(params).notifier);
+    _controller.prepareJumpToPost(target, hideUntilPositioned: false);
+    _controller.skipNextJumpHighlight = true;
+    if (notifier.isSummaryMode ||
+        notifier.isAuthorOnlyMode ||
+        notifier.isTopLevelMode) {
+      await _reloadWithFilterFallback(postNumber: target);
+    } else {
+      await notifier.reloadWithPostNumber(target);
+    }
   }
 
   /// stream 1-based 索引 → 真实 post_number（隐藏楼时二者不等）

--- a/lib/pages/topic_detail_page/controllers/topic_detail_controller.dart
+++ b/lib/pages/topic_detail_page/controllers/topic_detail_controller.dart
@@ -71,6 +71,9 @@ class TopicDetailController extends ChangeNotifier {
   TopicScrollState _scrollState;
   double _accumulatedScrollDelta = 0;
 
+  /// scrub 拖动中：禁止程序滚动把底栏藏起来，并保持底栏可见
+  bool _scrubbing = false;
+
   /// 底部栏显示状态
   final ValueNotifier<bool> showBottomBarNotifier = ValueNotifier<bool>(false);
 
@@ -230,8 +233,23 @@ class TopicDetailController extends ChangeNotifier {
     _handleBottomBarScrollDelta(delta);
   }
 
+  /// 进入/退出进度条 scrub：拖动中保持底栏，忽略程序滚动触发的显隐
+  void setScrubbing(bool value) {
+    if (_scrubbing == value) return;
+    _scrubbing = value;
+    _accumulatedScrollDelta = 0;
+    if (value && !_scrollState.showBottomBar) {
+      _scrollState = _scrollState.copyWith(showBottomBar: true);
+      showBottomBarNotifier.value = true;
+    }
+  }
+
+  bool get isScrubbing => _scrubbing;
+
   void _handleBottomBarScrollDelta(double delta) {
     if (delta == 0) return;
+    // scrub 程序滚动方向杂乱，勿据此藏底栏
+    if (_scrubbing) return;
 
     if ((_accumulatedScrollDelta > 0 && delta < 0) ||
         (_accumulatedScrollDelta < 0 && delta > 0)) {
@@ -308,13 +326,20 @@ class TopicDetailController extends ChangeNotifier {
   }
 
   /// 准备跳转到帖子（重新加载数据）
-  void prepareJumpToPost(int postNumber) {
+  ///
+  /// [hideUntilPositioned] 为 true 时列表 Opacity 置 0，适合一次定位跳转。
+  /// scrub 等连续看贴场景应传 false，并配合 preserve 内容的 reload。
+  void prepareJumpToPost(
+    int postNumber, {
+    bool hideUntilPositioned = true,
+  }) {
     _updateScrollState(
       TopicScrollState(
         showBackToTop: _scrollState.showBackToTop,
         showBottomBar: _scrollState.showBottomBar,
         hasInitialScrolled: false,
-        isPositioned: false,
+        isPositioned:
+            hideUntilPositioned ? false : _scrollState.isPositioned,
         jumpTargetPostNumber: postNumber,
         initialCenterPostNumber: null,
         viewportPostNumber: _scrollState.viewportPostNumber,
@@ -381,14 +406,23 @@ class TopicDetailController extends ChangeNotifier {
   }
 
   /// 本地跳转到帖子（不重新请求，仅重置视图中心）
-  void jumpToPostLocally(int postNumber, {int? anchorPostNumber}) {
+  ///
+  /// [hideUntilPositioned] 为 true（默认）时会将列表 Opacity 置 0，
+  /// 等定位完成后再显示，避免大跨度重排时闪到错误位置。
+  /// scrub 拖动等连续交互应传 false，否则会出现「中间没内容」。
+  void jumpToPostLocally(
+    int postNumber, {
+    int? anchorPostNumber,
+    bool hideUntilPositioned = true,
+  }) {
     // 重置可见性数据
     resetVisibility();
 
     _updateScrollState(
       _scrollState.copyWith(
         hasInitialScrolled: false,
-        isPositioned: false,
+        // hideUntilPositioned=false 时保持当前 isPositioned，不隐列表
+        isPositioned: hideUntilPositioned ? false : _scrollState.isPositioned,
         jumpTargetPostNumber: postNumber,
         initialCenterPostNumber: anchorPostNumber ?? postNumber,
         keyboardSelectedPostNumber: postNumber,

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -1905,6 +1905,20 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
                     onProgressTap: () => _showTimelineSheet(detail),
                     onProgressGesture: (action) =>
                         _handleProgressGesture(action, detail, notifier),
+                    onProgressScrubToPostNumber: (postNumber) =>
+                        unawaited(_scrubToPostNumber(postNumber)),
+                    onProgressScrubEnd: (postNumber) => unawaited(
+                      _scrubToPostNumber(postNumber, finalize: true),
+                    ),
+                    currentPostNumber: _controller.viewportPostNumber ??
+                        _controller.keyboardSelectedPostNumber ??
+                        _resolvePostNumberFromStreamIndex(
+                          detail,
+                          currentStreamIndex,
+                        ),
+                    maxPostNumber: detail.postsCount > 0
+                        ? detail.postsCount
+                        : detail.postStream.stream.length,
                     isSummaryMode: notifier.isSummaryMode,
                     isAuthorOnlyMode: notifier.isAuthorOnlyMode,
                     isTopLevelMode: notifier.isTopLevelMode,

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -210,6 +210,13 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   bool _isParentActive = true;
   bool _isScreenTrackRunning = false;
 
+  /// 进度条水平 scrub：拖动中锁底栏、禁止自动分页，并串行跳楼
+  bool _isProgressScrubbing = false;
+  bool _scrubJumpInFlight = false;
+  int? _scrubPendingPostNumber;
+  /// 队列中是否有「松手 finalize」语义（只对最后一次目标生效）
+  bool _scrubPendingFinalize = false;
+
   bool get _usesEmbeddedMobileWorkspaceChrome {
     return widget.embeddedMode &&
         PlatformUtils.isMobile &&
@@ -1830,20 +1837,6 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       );
     }
 
-    // 跳转中：等待包含目标帖子的新数据 - 显示骨架屏
-    final jumpTarget = _controller.jumpTargetPostNumber;
-    if (jumpTarget != null && detail != null) {
-      final posts = detail.postStream.posts;
-      // 检查目标帖子是否在当前加载的范围内
-      final hasTarget =
-          posts.isNotEmpty &&
-          posts.first.postNumber <= jumpTarget &&
-          posts.last.postNumber >= jumpTarget;
-      if (!hasTarget) {
-        return _wrapWithConstraint(const PostListSkeleton(withHeader: false));
-      }
-    }
-
     Widget content = const SizedBox();
 
     if (detailAsync.hasError && detail == null) {
@@ -1857,8 +1850,19 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         ],
       );
     } else if (detail != null) {
-      // 正常内容构建 (保持原有逻辑，但简化提取)
-      content = _buildPostListContent(context, detail, notifier, isLoggedIn);
+      // 跳转中目标尚未加载：骨架只替换列表区域，绝不 early-return 整页，
+      // 否则 Overlay（进度条/底栏）会一起消失，scrub 快速拖时像「整屏空白」。
+      final jumpTarget = _controller.jumpTargetPostNumber;
+      final posts = detail.postStream.posts;
+      final hasJumpTarget = jumpTarget == null ||
+          (posts.isNotEmpty &&
+              posts.first.postNumber <= jumpTarget &&
+              posts.last.postNumber >= jumpTarget);
+      if (!hasJumpTarget) {
+        content = const PostListSkeleton(withHeader: false);
+      } else {
+        content = _buildPostListContent(context, detail, notifier, isLoggedIn);
+      }
     }
 
     // Stack 组装
@@ -1910,6 +1914,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
                     onProgressScrubEnd: (postNumber) => unawaited(
                       _scrubToPostNumber(postNumber, finalize: true),
                     ),
+                    onProgressScrubCancel: _endProgressScrub,
                     currentPostNumber: _controller.viewportPostNumber ??
                         _controller.keyboardSelectedPostNumber ??
                         _resolvePostNumberFromStreamIndex(

--- a/lib/pages/topic_detail_page/widgets/topic_detail_overlay.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_detail_overlay.dart
@@ -26,6 +26,8 @@ class TopicDetailOverlay extends StatelessWidget {
   final ValueChanged<int>? onProgressScrubToPostNumber;
   /// scrub 松手时的最终楼层（可做完整跳转）
   final ValueChanged<int>? onProgressScrubEnd;
+  /// scrub 取消（pan cancel 等）时解锁底栏 / 分页
+  final VoidCallback? onProgressScrubCancel;
   /// 当前可见帖的 post_number，供 scrub 起点
   final int currentPostNumber;
   /// 话题最大楼层号（posts_count）
@@ -58,6 +60,7 @@ class TopicDetailOverlay extends StatelessWidget {
     this.onProgressGesture,
     this.onProgressScrubToPostNumber,
     this.onProgressScrubEnd,
+    this.onProgressScrubCancel,
     this.currentPostNumber = 1,
     this.maxPostNumber = 1,
     this.isSummaryMode = false,
@@ -97,6 +100,7 @@ class TopicDetailOverlay extends StatelessWidget {
                 totalCount: maxPostNumber > 0 ? maxPostNumber : totalCount,
                 onScrubToIndex: onProgressScrubToPostNumber ?? (_) {},
                 onScrubEnd: onProgressScrubEnd,
+                onScrubCancel: onProgressScrubCancel,
                 child: TopicProgress(
                   currentIndex: currentStreamIndex,
                   totalCount: totalCount,

--- a/lib/pages/topic_detail_page/widgets/topic_detail_overlay.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_detail_overlay.dart
@@ -22,6 +22,14 @@ class TopicDetailOverlay extends StatelessWidget {
   final VoidCallback onReply;
   final VoidCallback onProgressTap;
   final ValueChanged<ProgressGestureAction>? onProgressGesture;
+  /// scrub 目标为真实楼层号 post_number（不是 stream 序号）
+  final ValueChanged<int>? onProgressScrubToPostNumber;
+  /// scrub 松手时的最终楼层（可做完整跳转）
+  final ValueChanged<int>? onProgressScrubEnd;
+  /// 当前可见帖的 post_number，供 scrub 起点
+  final int currentPostNumber;
+  /// 话题最大楼层号（posts_count）
+  final int maxPostNumber;
   final bool isSummaryMode;
   final bool isAuthorOnlyMode;
   final bool isTopLevelMode;
@@ -48,6 +56,10 @@ class TopicDetailOverlay extends StatelessWidget {
     required this.onReply,
     required this.onProgressTap,
     this.onProgressGesture,
+    this.onProgressScrubToPostNumber,
+    this.onProgressScrubEnd,
+    this.currentPostNumber = 1,
+    this.maxPostNumber = 1,
     this.isSummaryMode = false,
     this.isAuthorOnlyMode = false,
     this.isTopLevelMode = false,
@@ -80,6 +92,11 @@ class TopicDetailOverlay extends StatelessWidget {
             child: Center(
               child: TopicProgressGestures(
                 onAction: onProgressGesture ?? (_) {},
+                // scrub 用真实楼层号，避免隐藏楼导致序号错位
+                currentIndex: currentPostNumber,
+                totalCount: maxPostNumber > 0 ? maxPostNumber : totalCount,
+                onScrubToIndex: onProgressScrubToPostNumber ?? (_) {},
+                onScrubEnd: onProgressScrubEnd,
                 child: TopicProgress(
                   currentIndex: currentStreamIndex,
                   totalCount: totalCount,

--- a/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui' show ImageFilter;
 
@@ -16,11 +17,21 @@ const double _kSwipeTriggerDistance = 56.0;
 /// 滑动方向判定的死区（小于此值不判断方向）
 const double _kSwipeDeadZone = 6.0;
 
-/// 进度悬浮条手势包装：在 [TopicProgress] 上识别左/右/上滑与长按
+/// 水平 scrub：每移动多少像素切换 1 楼（基础灵敏度）
+const double _kScrubPixelsPerFloor = 14.0;
+
+/// 单次左右 scrub 最大跨度（相对按下时楼层），减轻压力并提高细腻度
+const int _kScrubMaxDeltaFloors = 20;
+
+/// 拖动中实时跳楼的最小间隔，避免每楼都触发重渲染 / 无障碍树报错
+const Duration _kScrubJumpThrottle = Duration(milliseconds: 100);
+
+/// 进度悬浮条手势包装：在 [TopicProgress] 上识别左右 scrub / 上滑与长按
 ///
 /// - 按压进度环：手指落下即在悬浮条边缘累积一圈描边，按住越久环越满，
 ///   可视化反馈"按压时间"。pan 胜出或松开会让环回缩。
-/// - 左/右/上滑：实时显示预览药丸，距离 ≥ [_kSwipeTriggerDistance] 后可触发
+/// - 左右滑动：连续 scrub 跳楼（左=往前/更早，右=往后/更晚），拖动中实时跳转
+/// - 上滑：仍走可配置动作，距离 ≥ [_kSwipeTriggerDistance] 后可触发
 /// - 长按 200ms：弹出半圆向上展开菜单，拖到目标松开触发；拖到死区取消
 /// - tap 由内层 InkWell 处理，本组件只处理 swipe + long press
 /// - 总开关关闭时本组件退化为透传
@@ -29,10 +40,26 @@ class TopicProgressGestures extends ConsumerStatefulWidget {
     super.key,
     required this.child,
     required this.onAction,
+    required this.currentIndex,
+    required this.totalCount,
+    required this.onScrubToIndex,
+    this.onScrubEnd,
   });
 
   final Widget child;
   final ValueChanged<ProgressGestureAction> onAction;
+
+  /// 当前楼层号（真实 post_number）
+  final int currentIndex;
+
+  /// 最大楼层号
+  final int totalCount;
+
+  /// scrub 过程中跳转到目标楼层（真实 post_number；拖动时随楼层变化实时调用）
+  final ValueChanged<int> onScrubToIndex;
+
+  /// scrub 松手时的最终楼层（可做完整跳转 / 补齐未加载楼）
+  final ValueChanged<int>? onScrubEnd;
 
   @override
   ConsumerState<TopicProgressGestures> createState() =>
@@ -73,8 +100,23 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   ProgressGestureAction? _swipeAction;
   bool _swipeTriggerable = false;
 
+  /// 水平 scrub：按下时的楼层（1-based）
+  int _scrubStartIndex = 1;
+
+  /// 水平 scrub：当前预览楼层（1-based）
+  int? _scrubTargetIndex;
+
+  /// 水平 scrub：最近一次已实际跳转的楼层（避免重复触发）
+  int? _scrubAppliedIndex;
+
+  /// 待应用的 scrub 目标（节流队列，只保留最新）
+  int? _pendingScrubIndex;
+
+  Timer? _scrubThrottleTimer;
+
   @override
   void dispose() {
+    _scrubThrottleTimer?.cancel();
     _disposeMenuOverlay();
     _disposeSwipeOverlay();
     _pressController.dispose();
@@ -246,6 +288,9 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   // ===== 滑动预览 =====
 
   void _disposeSwipeOverlay() {
+    _scrubThrottleTimer?.cancel();
+    _scrubThrottleTimer = null;
+    _pendingScrubIndex = null;
     _swipeEntry?.remove();
     _swipeEntry = null;
     _swipeOrigin = null;
@@ -254,6 +299,70 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
     _swipeDirection = null;
     _swipeAction = null;
     _swipeTriggerable = false;
+    _scrubTargetIndex = null;
+    _scrubAppliedIndex = null;
+  }
+
+  /// 根据水平位移计算 scrub 目标楼层（真实 post_number）
+  int _scrubIndexForDelta(double dx) {
+    final total = widget.totalCount;
+    if (total <= 1) return widget.currentIndex.clamp(1, math.max(1, total));
+
+    // 固定灵敏度：小范围（±30 楼）内更细腻，不再按话题总长放大跨度
+    final deltaFloors = (dx / _kScrubPixelsPerFloor)
+        .round()
+        .clamp(-_kScrubMaxDeltaFloors, _kScrubMaxDeltaFloors);
+    final minFloor = math.max(1, _scrubStartIndex - _kScrubMaxDeltaFloors);
+    final maxFloor = math.min(total, _scrubStartIndex + _kScrubMaxDeltaFloors);
+    return (_scrubStartIndex + deltaFloors).clamp(minFloor, maxFloor);
+  }
+
+  /// 节流后应用跳楼：预览立即更新，列表最多约 70ms 跳一次
+  void _scheduleScrubJump(int target) {
+    if (widget.totalCount <= 1) return;
+    if (target == _scrubAppliedIndex) return;
+
+    _pendingScrubIndex = target;
+    if (_scrubThrottleTimer?.isActive ?? false) return;
+
+    void apply() {
+      final next = _pendingScrubIndex;
+      _pendingScrubIndex = null;
+      _scrubThrottleTimer = null;
+      if (next == null || next == _scrubAppliedIndex) return;
+      _scrubAppliedIndex = next;
+      widget.onScrubToIndex(next);
+    }
+
+    // 首次立刻跳，后续进入节流窗口
+    if (_scrubAppliedIndex == _scrubStartIndex ||
+        _scrubAppliedIndex == null) {
+      apply();
+      _scrubThrottleTimer = Timer(_kScrubJumpThrottle, () {
+        if (_pendingScrubIndex != null) apply();
+      });
+      return;
+    }
+
+    _scrubThrottleTimer = Timer(_kScrubJumpThrottle, apply);
+  }
+
+  /// 松手时冲刷节流队列，保证落到最终预览楼层
+  void _flushScrubJump() {
+    _scrubThrottleTimer?.cancel();
+    _scrubThrottleTimer = null;
+    final next = _pendingScrubIndex ?? _scrubTargetIndex;
+    _pendingScrubIndex = null;
+    if (next == null) return;
+    if (widget.totalCount <= 1) return;
+    _scrubAppliedIndex = next;
+    // 优先走 finalize 回调，让页面可做完整跳转
+    final end = widget.onScrubEnd;
+    if (end != null) {
+      end(next);
+    } else {
+      widget.onScrubToIndex(next);
+    }
   }
 
   void _handlePanStart(DragStartDetails details, AppPreferences prefs) {
@@ -273,6 +382,12 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
     _swipeDirection = null;
     _swipeAction = null;
     _swipeTriggerable = false;
+    _scrubStartIndex = widget.currentIndex.clamp(
+      1,
+      math.max(1, widget.totalCount),
+    );
+    _scrubTargetIndex = null;
+    _scrubAppliedIndex = _scrubStartIndex;
 
     final overlay = Overlay.of(context, rootOverlay: true);
     _swipeEntry = OverlayEntry(builder: (_) => _buildSwipeOverlay());
@@ -299,27 +414,33 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
       }
     }
 
+    // 左右：连续 scrub 跳楼；上滑：保留可配置动作
     ProgressGestureAction? action;
-    switch (direction) {
-      case _SwipeDirection.left:
-        action = prefs.progressGestureSwipeLeft;
-      case _SwipeDirection.right:
-        action = prefs.progressGestureSwipeRight;
-      case _SwipeDirection.up:
-        action = prefs.progressGestureSwipeUp;
-      case null:
-        action = null;
-    }
-    // 绑定为「无」时等同于未绑定：不显示 pill、不可触发
-    if (action == ProgressGestureAction.none) {
-      action = null;
-    }
+    int? scrubTarget;
+    var triggerable = false;
 
-    final triggerable = action != null && maxDelta >= _kSwipeTriggerDistance;
+    if (direction == _SwipeDirection.left ||
+        direction == _SwipeDirection.right) {
+      scrubTarget = _scrubIndexForDelta(dx);
+      triggerable = scrubTarget != _scrubStartIndex && widget.totalCount > 1;
+      action = null;
+    } else if (direction == _SwipeDirection.up) {
+      action = prefs.progressGestureSwipeUp;
+      if (action == ProgressGestureAction.none) {
+        action = null;
+      }
+      triggerable = action != null && maxDelta >= _kSwipeTriggerDistance;
+      scrubTarget = null;
+    }
 
     final directionChanged = direction != _swipeDirection;
     final triggerChanged = triggerable != _swipeTriggerable;
-    if (triggerChanged && triggerable) {
+    final scrubChanged = scrubTarget != _scrubTargetIndex;
+    if (scrubChanged && scrubTarget != null) {
+      HapticFeedback.selectionClick();
+      // 预览立刻变；实际列表跳转走节流，避免拖太快卡死
+      _scheduleScrubJump(scrubTarget);
+    } else if (triggerChanged && triggerable) {
       HapticFeedback.lightImpact();
     } else if (directionChanged && direction != null) {
       HapticFeedback.selectionClick();
@@ -328,12 +449,23 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
     _swipeDirection = direction;
     _swipeAction = action;
     _swipeTriggerable = triggerable;
+    _scrubTargetIndex = scrubTarget;
     _swipeEntry?.markNeedsBuild();
   }
 
   void _handlePanEnd(DragEndDetails details) {
     final triggered = _swipeTriggerable;
     final action = _swipeAction;
+    final isHorizontal = _swipeDirection == _SwipeDirection.left ||
+        _swipeDirection == _SwipeDirection.right;
+
+    if (isHorizontal) {
+      _flushScrubJump();
+      HapticFeedback.mediumImpact();
+      _disposeSwipeOverlay();
+      return;
+    }
+
     _disposeSwipeOverlay();
     if (triggered && action != null) {
       HapticFeedback.mediumImpact();
@@ -350,6 +482,8 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
       origin: _swipeOrigin ?? Offset.zero,
       direction: _swipeDirection,
       action: _swipeAction,
+      scrubTargetIndex: _scrubTargetIndex,
+      totalCount: widget.totalCount,
       triggerable: _swipeTriggerable,
       delta: (_swipeStart == null)
           ? Offset.zero
@@ -802,6 +936,8 @@ class _SwipePreviewOverlay extends StatelessWidget {
     required this.origin,
     required this.direction,
     required this.action,
+    required this.scrubTargetIndex,
+    required this.totalCount,
     required this.triggerable,
     required this.delta,
     required this.triggerDistance,
@@ -811,6 +947,8 @@ class _SwipePreviewOverlay extends StatelessWidget {
   final Offset origin;
   final _SwipeDirection? direction;
   final ProgressGestureAction? action;
+  final int? scrubTargetIndex;
+  final int totalCount;
   final bool triggerable;
   final Offset delta;
   final double triggerDistance;
@@ -822,10 +960,18 @@ class _SwipePreviewOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    if (action == null || direction == null) {
+    final isScrub = direction == _SwipeDirection.left ||
+        direction == _SwipeDirection.right;
+    if (direction == null) {
       return const IgnorePointer(child: SizedBox.shrink());
     }
-    final meta = progressGestureActionMeta(context, action!);
+    if (isScrub && scrubTargetIndex == null) {
+      return const IgnorePointer(child: SizedBox.shrink());
+    }
+    if (!isScrub && action == null) {
+      return const IgnorePointer(child: SizedBox.shrink());
+    }
+
     final progress = (math.max(delta.dx.abs(), delta.dy.abs()) / triggerDistance)
         .clamp(0.0, 1.0);
 
@@ -859,52 +1005,67 @@ class _SwipePreviewOverlay extends StatelessWidget {
         ? theme.colorScheme.primary.withValues(alpha: 0.4)
         : Colors.black.withValues(alpha: 0.12);
 
+    final IconData icon;
+    final String label;
+    if (isScrub) {
+      icon = direction == _SwipeDirection.left
+          ? Symbols.keyboard_double_arrow_left_rounded
+          : Symbols.keyboard_double_arrow_right_rounded;
+      label = '${scrubTargetIndex!}/$totalCount';
+    } else {
+      final meta = progressGestureActionMeta(context, action!);
+      icon = meta.icon;
+      label = meta.label;
+    }
+
     final screenSize = MediaQuery.of(context).size;
     final clampedX = pillCenter.dx.clamp(60.0, screenSize.width - 60.0);
     final clampedY = pillCenter.dy.clamp(40.0, screenSize.height - 40.0);
 
     return IgnorePointer(
-      child: Stack(
-        children: [
-          Positioned(
-            left: clampedX,
-            top: clampedY,
-            child: FractionalTranslation(
-              translation: const Offset(-0.5, -0.5),
-              child: AnimatedScale(
-                duration: const Duration(milliseconds: 140),
-                curve: Curves.easeOutBack,
-                scale: triggerable ? 1.04 : 1.0,
-                child: Material(
-                  color: bgColor,
-                  borderRadius: BorderRadius.circular(20),
-                  elevation: triggerable ? 6 : 3,
-                  shadowColor: shadow,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 8,
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(meta.icon, size: 18, color: fgColor),
-                        const SizedBox(width: 6),
-                        Text(
-                          meta.label,
-                          style: theme.textTheme.labelMedium?.copyWith(
-                            color: fgColor,
-                            fontWeight: FontWeight.w600,
+      child: ExcludeSemantics(
+        child: Stack(
+          children: [
+            Positioned(
+              left: clampedX,
+              top: clampedY,
+              child: FractionalTranslation(
+                translation: const Offset(-0.5, -0.5),
+                child: AnimatedScale(
+                  duration: const Duration(milliseconds: 140),
+                  curve: Curves.easeOutBack,
+                  scale: triggerable ? 1.04 : 1.0,
+                  child: Material(
+                    color: bgColor,
+                    borderRadius: BorderRadius.circular(20),
+                    elevation: triggerable ? 6 : 3,
+                    shadowColor: shadow,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(icon, size: 18, color: fgColor),
+                          const SizedBox(width: 6),
+                          Text(
+                            label,
+                            style: theme.textTheme.labelMedium?.copyWith(
+                              color: fgColor,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
@@ -21,7 +21,7 @@ const double _kSwipeDeadZone = 6.0;
 const double _kScrubPixelsPerFloor = 14.0;
 
 /// 单次左右 scrub 最大跨度（相对按下时楼层），减轻压力并提高细腻度
-const int _kScrubMaxDeltaFloors = 20;
+const int _kScrubMaxDeltaFloors = 10;
 
 /// 拖动中实时跳楼的最小间隔，避免每楼都触发重渲染 / 无障碍树报错
 const Duration _kScrubJumpThrottle = Duration(milliseconds: 100);
@@ -44,6 +44,7 @@ class TopicProgressGestures extends ConsumerStatefulWidget {
     required this.totalCount,
     required this.onScrubToIndex,
     this.onScrubEnd,
+    this.onScrubCancel,
   });
 
   final Widget child;
@@ -60,6 +61,9 @@ class TopicProgressGestures extends ConsumerStatefulWidget {
 
   /// scrub 松手时的最终楼层（可做完整跳转 / 补齐未加载楼）
   final ValueChanged<int>? onScrubEnd;
+
+  /// scrub 被取消且未 finalize 时解锁页面状态
+  final VoidCallback? onScrubCancel;
 
   @override
   ConsumerState<TopicProgressGestures> createState() =>
@@ -308,7 +312,7 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
     final total = widget.totalCount;
     if (total <= 1) return widget.currentIndex.clamp(1, math.max(1, total));
 
-    // 固定灵敏度：小范围（±30 楼）内更细腻，不再按话题总长放大跨度
+    // 固定灵敏度：小范围（±10 楼）内更细腻，不再按话题总长放大跨度
     final deltaFloors = (dx / _kScrubPixelsPerFloor)
         .round()
         .clamp(-_kScrubMaxDeltaFloors, _kScrubMaxDeltaFloors);
@@ -348,15 +352,23 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   }
 
   /// 松手时冲刷节流队列，保证落到最终预览楼层
+  ///
+  /// 即使楼层未变也要回调 finalize，以便页面解锁 scrub 态（底栏/分页锁）
   void _flushScrubJump() {
     _scrubThrottleTimer?.cancel();
     _scrubThrottleTimer = null;
-    final next = _pendingScrubIndex ?? _scrubTargetIndex;
+    final next = _pendingScrubIndex ??
+        _scrubTargetIndex ??
+        _scrubAppliedIndex ??
+        _scrubStartIndex;
     _pendingScrubIndex = null;
-    if (next == null) return;
-    if (widget.totalCount <= 1) return;
+    if (widget.totalCount <= 1) {
+      // 单楼话题也走 end，避免锁死
+      widget.onScrubEnd?.call(next);
+      return;
+    }
     _scrubAppliedIndex = next;
-    // 优先走 finalize 回调，让页面可做完整跳转
+    // 优先走 finalize 回调，让页面可做完整跳转并解锁
     final end = widget.onScrubEnd;
     if (end != null) {
       end(next);
@@ -437,7 +449,12 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
     final triggerChanged = triggerable != _swipeTriggerable;
     final scrubChanged = scrubTarget != _scrubTargetIndex;
     if (scrubChanged && scrubTarget != null) {
-      HapticFeedback.selectionClick();
+      // 触觉降频：每 3 楼一次，减轻快速拖时的系统开销
+      if ((scrubTarget - _scrubStartIndex).abs() % 3 == 0 ||
+          scrubTarget == 1 ||
+          scrubTarget == widget.totalCount) {
+        HapticFeedback.selectionClick();
+      }
       // 预览立刻变；实际列表跳转走节流，避免拖太快卡死
       _scheduleScrubJump(scrubTarget);
     } else if (triggerChanged && triggerable) {
@@ -474,6 +491,14 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   }
 
   void _handlePanCancel() {
+    // 与松手一致冲刷最终楼层；若未发生水平 scrub 也通知取消以解锁
+    final isHorizontal = _swipeDirection == _SwipeDirection.left ||
+        _swipeDirection == _SwipeDirection.right;
+    if (isHorizontal) {
+      _flushScrubJump();
+    } else {
+      widget.onScrubCancel?.call();
+    }
     _disposeSwipeOverlay();
   }
 

--- a/lib/providers/topic_detail/_loading_methods.dart
+++ b/lib/providers/topic_detail/_loading_methods.dart
@@ -260,12 +260,17 @@ extension LoadingMethods on TopicDetailNotifier {
   }
 
   /// 使用新的起始帖子号重新加载数据
+  ///
+  /// 使用 copyWithPrevious 保留旧 detail，避免 loading 期间 detail==null
+  /// 把整页（含底栏 Overlay）换成纯骨架。
   Future<void> reloadWithPostNumber(int postNumber) async {
-    state = const AsyncValue.loading();
     _hasMoreAfter = true;
     _hasMoreBefore = true;
     _isLoadMoreFailed = false;
     _isLoadPreviousFailed = false;
+
+    // ignore: invalid_use_of_internal_member
+    state = const AsyncLoading<TopicDetail>().copyWithPrevious(state);
 
     await Future.delayed(Duration.zero);
 


### PR DESCRIPTION
## Summary
- 进度条左右滑动改为连续 scrub 跳楼（真实 post_number）
- 单次最多 ±20 楼
- 拖动中本地跳转，松手再补齐未加载楼
- 长按/上滑不变

当前的机制是 帖子内底部按钮左滑显示上一贴，右滑下一贴，改成了左右滑直接跳转楼层，两边一次最多各跳20楼

<img width="2559" height="1380" alt="image" src="https://github.com/user-attachments/assets/0235c8c5-637e-4217-b0ff-d605a44a0dd5" />