### PR TITLE
feat: 进度悬浮条支持「返回」动作

### DIFF
--- a/lib/l10n/modules/appearance/appearance_en.arb
+++ b/lib/l10n/modules/appearance/appearance_en.arb
@@ -43,6 +43,7 @@
   "progressGesture_action_aiAssistant": "AI Assistant",
   "progressGesture_action_bookmark": "Bookmark",
   "progressGesture_action_exportArticle": "Export article",
+  "progressGesture_action_goBack": "Go back",
   "progressGesture_action_filter": "Filter posts",
   "progressGesture_action_jumpToUnread": "Jump to unread",
   "progressGesture_action_none": "None (do nothing)",

--- a/lib/l10n/modules/appearance/appearance_zh.arb
+++ b/lib/l10n/modules/appearance/appearance_zh.arb
@@ -43,6 +43,7 @@
   "progressGesture_action_aiAssistant": "AI 助手",
   "progressGesture_action_bookmark": "收藏",
   "progressGesture_action_exportArticle": "导出文章",
+  "progressGesture_action_goBack": "返回",
   "progressGesture_action_filter": "过滤帖子",
   "progressGesture_action_jumpToUnread": "跳到未读",
   "progressGesture_action_none": "无（不触发）",

--- a/lib/l10n/modules/appearance/appearance_zh_HK.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_HK.arb
@@ -43,6 +43,7 @@
   "progressGesture_action_aiAssistant": "AI 助手",
   "progressGesture_action_bookmark": "收藏",
   "progressGesture_action_exportArticle": "匯出文章",
+  "progressGesture_action_goBack": "返回",
   "progressGesture_action_filter": "過濾帖子",
   "progressGesture_action_jumpToUnread": "跳到未讀",
   "progressGesture_action_none": "無（不觸發）",

--- a/lib/l10n/modules/appearance/appearance_zh_TW.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_TW.arb
@@ -43,6 +43,7 @@
   "progressGesture_action_aiAssistant": "AI 助手",
   "progressGesture_action_bookmark": "收藏",
   "progressGesture_action_exportArticle": "匯出文章",
+  "progressGesture_action_goBack": "返回",
   "progressGesture_action_filter": "過濾帖子",
   "progressGesture_action_jumpToUnread": "跳到未讀",
   "progressGesture_action_none": "無（不觸發）",

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -1445,6 +1445,10 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
             .enterSearchMode();
       case ProgressGestureAction.refresh:
         unawaited(_handleRefresh());
+      case ProgressGestureAction.goBack:
+        if (mounted) {
+          unawaited(Navigator.of(context).maybePop());
+        }
     }
   }
 

--- a/lib/pages/topic_detail_page/widgets/progress_gesture_action_meta.dart
+++ b/lib/pages/topic_detail_page/widgets/progress_gesture_action_meta.dart
@@ -112,5 +112,10 @@ import '../../../providers/preferences_provider.dart';
         icon: Symbols.refresh_rounded,
         label: l.progressGesture_action_refresh,
       );
+    case ProgressGestureAction.goBack:
+      return (
+        icon: Symbols.arrow_back_rounded,
+        label: l.progressGesture_action_goBack,
+      );
   }
 }

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -57,7 +57,8 @@ enum ProgressGestureAction {
   aiAssistant,
   readingSettings,
   search,
-  refresh;
+  refresh,
+  goBack;
 
   static ProgressGestureAction fromString(String? value) {
     return ProgressGestureAction.values.firstWhere(


### PR DESCRIPTION
## Summary
- `ProgressGestureAction` 新增 `goBack`
- 进度悬浮条的滑动手势 / 长按半圆菜单可选「返回」
- 触发后 `Navigator.maybePop()` 退出当前帖子页
- 方便手机端离开帖子，不必够到左上角返回

## Why
手机上帖子详情页顶部返回按钮不够顺手，希望能把「返回」绑定到底部进度悬浮条的关联功能上。

<img width="786" height="427" alt="image" src="https://github.com/user-attachments/assets/6c8f89dc-6db5-4fc8-bef5-dbd92702ce70" />
