### PR TITLE
fix(windows): 修复 WebView 冷启动主线程卡顿（iframe 懒加载 + bootstrap/CF 延后）

### DIFF
--- a/lib/services/browser_trust_coordinator.dart
+++ b/lib/services/browser_trust_coordinator.dart
@@ -79,7 +79,18 @@ class BrowserTrustCoordinator {
   }
 
   /// 启动期轻量准备：只做 cookie priming，不加载首页，不阻塞 runApp。
+  ///
+  /// Windows 上跳过：CookieManager IPC 会抢平台主线程(实测 priming ~4s)，
+  /// 真正创建 WebView 的路径会自己 await prime。
   void prepareStartup({String reason = 'startup'}) {
+    // Windows: 启动期 CookieManager priming 实测 ~4s 且走平台主线程,
+    // 是"进应用几秒后突然变钝"的主要来源之一。真正创建 WebView 的
+    // 路径(session bootstrap / login / iframe)都会自己 await prime,
+    // 这里不再抢跑。
+    if (io.Platform.isWindows) {
+      _log('skip startup priming on Windows reason=$reason');
+      return;
+    }
     unawaited(
       _primeWebViewCookies(reason: reason).catchError((Object e) {
         _log('startup priming failed: $e', level: 'warning');
@@ -277,6 +288,11 @@ class BrowserTrustCoordinator {
 
     unawaited(() async {
       try {
+        // Windows:与 session bootstrap 同窗口延后,避免首屏被 priming+headless
+        // WebView 创建销毁打断。Dio 侧 ensureInBackground 也会在 25s 后补跑。
+        if (io.Platform.isWindows) {
+          await Future<void>.delayed(const Duration(seconds: 25));
+        }
         final synced = await ensureBrowserTrust(
           reason: '$reason:native_preload_settle',
         );

--- a/lib/services/cf_clearance_refresh_service.dart
+++ b/lib/services/cf_clearance_refresh_service.dart
@@ -58,6 +58,9 @@ class CfClearanceRefreshService {
   bool _isForeground = true;
   bool _pausedByLifecycle = false;
   bool _isSyncingCookies = false;
+  /// Windows 冷启动：是否已安排延后；是否已允许立即拉起。
+  bool _windowsColdDeferred = false;
+  bool _windowsAllowImmediate = false;
 
   int _generation = 0;
   int _consecutiveFailures = 0;
@@ -125,6 +128,23 @@ class CfClearanceRefreshService {
     if (_isRunning && !_isDisposing) return;
     if (!_isForeground) {
       CfChallengeLogger.log('[CfRefresh] 当前处于后台，延后启动');
+      return;
+    }
+
+    // Windows:Turnstile 常驻 headless WebView 与冷启动 bootstrap 叠在一起
+    // 会抢平台主线程。首屏 40s 内只记账不拉起,到期后补 start。
+    if (io.Platform.isWindows && !_windowsAllowImmediate) {
+      if (!_windowsColdDeferred) {
+        _windowsColdDeferred = true;
+        _cancelDelayedTimers();
+        CfChallengeLogger.log('[CfRefresh] Windows 冷启动延后 40s 再拉起');
+        _delayedRestartTimer = Timer(const Duration(seconds: 40), () {
+          _windowsAllowImmediate = true;
+          if (_shouldBeRunning && _isForeground && !_isRunning && !_isDisposing) {
+            start();
+          }
+        });
+      }
       return;
     }
 

--- a/lib/services/cf_clearance_refresh_service.dart
+++ b/lib/services/cf_clearance_refresh_service.dart
@@ -74,7 +74,7 @@ class CfClearanceRefreshService {
   Timer? _delayedRestartTimer;
   Timer? _delayedStopTimer;
 
-  /// 滚动挂起状态机(仅 Android):500ms 检查一次滚动繁忙信号,
+  /// 滚动挂起状态机(Android/Windows):500ms 检查一次滚动繁忙信号,
   /// 见 [_updateScrollPause]
   Timer? _scrollPauseTicker;
   bool _webViewPausedForScroll = false;
@@ -592,13 +592,14 @@ document.close();
       }
     });
 
-    // 滚动窗口内把 headless WebView 挂起(Android onPause:暂停 JS 定时
-    // 器与渲染,不销毁实例):Turnstile 是活网页,常驻 JS 把平台主线程
-    // 烧到 60%+ 单核(生产 CPU 采样),而 vsync 分发/触摸事件与其同
-    // 线程。滚动繁忙即挂起、静默 ~1s 后恢复,JS 信号与刷新逻辑 resume
-    // 后自然补上。初始 Turnstile 运行期(_initialTimer 未清)只恢复不
-    // 挂起,避免把首次验证拖到超时误判重建。
-    if (io.Platform.isAndroid) {
+    // 滚动窗口内把 headless WebView 挂起(Android onPause / WebView2 pause:
+    // 暂停 JS 定时器与渲染,不销毁实例):Turnstile 是活网页,常驻 JS 把
+    // 平台主线程烧到 60%+ 单核(生产 CPU 采样),而 vsync 分发/触摸事件
+    // 与其同线程。Windows 同样会常驻一个 headless WebView2,滚动中也
+    // 需要让路。滚动繁忙即挂起、静默 ~1s 后恢复,JS 信号与刷新逻辑
+    // resume 后自然补上。初始 Turnstile 运行期(_initialTimer 未清)只
+    // 恢复不挂起,避免把首次验证拖到超时误判重建。
+    if (io.Platform.isAndroid || io.Platform.isWindows) {
       _scrollPauseTicker = Timer.periodic(
         const Duration(milliseconds: 500),
         (_) {
@@ -612,7 +613,7 @@ document.close();
     }
   }
 
-  /// 滚动繁忙 ↔ 静默的 WebView 挂起切换(仅 Android,由
+  /// 滚动繁忙 ↔ 静默的 WebView 挂起切换(Android/Windows,由
   /// [_scrollPauseTicker] 驱动)。pause/resume 是单实例 onPause/onResume,
   /// 一次轻量平台调用;失败时复位标记,避免卡死在挂起态。
   Future<void> _updateScrollPause() async {

--- a/lib/services/webview_session_cookie_refresh_service.dart
+++ b/lib/services/webview_session_cookie_refresh_service.dart
@@ -7,6 +7,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 
 import '../constants.dart';
 import '../utils/frame_jank_monitor.dart';
+import '../utils/scroll_busy_signal.dart';
 import 'log/log_writer.dart';
 import 'network/cookie/boundary_sync_service.dart';
 import 'network/cookie/cookie_jar_service.dart';
@@ -95,6 +96,13 @@ class WebViewSessionCookieRefreshService {
   /// 绕过注入候选并以 no-cache 拉插件 JS,强制新鲜 discover;成功即复位。
   bool _forceFreshPlugin = false;
 
+  /// Windows:冷启动后立即 headless bootstrap 会抢平台主线程,表现为
+  /// "刚进很顺,几秒后整窗变钝"。把非 force 的 bootstrap 延后到首屏交互后。
+  static const Duration _windowsBootstrapDelay = Duration(seconds: 25);
+  DateTime? _firstEnsureAt;
+  bool _windowsDeferredScheduled = false;
+  Timer? _windowsDeferredTimer;
+
   /// 当前失败退避冷却:45s → 90s → 3m → 6m → 12m → 15m 封顶。
   Duration get _effectiveCooldown {
     if (_failureStreak <= 1) return _attemptCooldown;
@@ -141,6 +149,10 @@ class WebViewSessionCookieRefreshService {
     _lastAttemptAt = null;
     _failureStreak = 0;
     _forceFreshPlugin = false;
+    _firstEnsureAt = null;
+    _windowsDeferredScheduled = false;
+    _windowsDeferredTimer?.cancel();
+    _windowsDeferredTimer = null;
     _logEnsureEvent(
       event: 'webview_session_sync_reset',
       reason: reason,
@@ -173,6 +185,26 @@ class WebViewSessionCookieRefreshService {
         extra: {'skipReason': 'no_t'},
       );
       return const SessionBootstrapResult.failure(phase: 'no_t');
+    }
+
+    // Windows:首屏交互窗口内推迟 bootstrap(非 force)。force / CF recover
+    // 仍立即执行。延后只调度一次,到期后自动补跑。
+    if (!force && io.Platform.isWindows) {
+      _firstEnsureAt ??= DateTime.now();
+      final age = DateTime.now().difference(_firstEnsureAt!);
+      if (age < _windowsBootstrapDelay) {
+        _scheduleWindowsDeferredBootstrap(reason);
+        _logEnsureEvent(
+          event: 'webview_session_sync_skipped',
+          reason: reason,
+          level: 'info',
+          extra: {
+            'skipReason': 'windows_startup_defer',
+            'deferMs': (_windowsBootstrapDelay - age).inMilliseconds,
+          },
+        );
+        return const SessionBootstrapResult.failure(phase: 'windows_startup_defer');
+      }
     }
 
     // fingerprint 上报对齐浏览器语义:每次完整页面加载跑一次(SPA 内路由
@@ -259,6 +291,26 @@ class WebViewSessionCookieRefreshService {
         });
     _activeRefresh = future;
     return future;
+  }
+
+  void _scheduleWindowsDeferredBootstrap(String reason) {
+    if (_windowsDeferredScheduled) return;
+    _windowsDeferredScheduled = true;
+    final started = _firstEnsureAt ?? DateTime.now();
+    final wait = _windowsBootstrapDelay - DateTime.now().difference(started);
+    _windowsDeferredTimer?.cancel();
+    _windowsDeferredTimer = Timer(wait.isNegative ? Duration.zero : wait, () {
+      unawaited(_runWindowsDeferredBootstrap(reason));
+    });
+  }
+
+  /// 到期后若用户仍在滚动,再等最多 15s 空闲,避免 headless create 撞上首屏滑动。
+  Future<void> _runWindowsDeferredBootstrap(String reason) async {
+    final idleDeadline = DateTime.now().add(const Duration(seconds: 15));
+    while (ScrollBusySignal.isBusy && DateTime.now().isBefore(idleDeadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+    }
+    ensureInBackground(reason: 'windows_deferred:$reason');
   }
 
   void ensureInBackground({String reason = 'unknown', bool force = false}) {

--- a/lib/widgets/content/discourse_html_content/builders/iframe_builder.dart
+++ b/lib/widgets/content/discourse_html_content/builders/iframe_builder.dart
@@ -5,6 +5,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:fluxdo_render/fluxdo_render.dart' show ScreenshotMode;
+import 'package:visibility_detector/visibility_detector.dart';
 import '../../../../constants.dart';
 import '../../../../utils/layout_lock.dart';
 import '../../../../utils/url_helper.dart';
@@ -13,6 +15,7 @@ import '../../../../l10n/s.dart';
 import '../../../../services/navigation/app_route_observer.dart';
 import '../../../../services/webview_settings.dart';
 import '../../../../services/windows_webview_environment_service.dart';
+import '../../../content/lazy_load_scope.dart';
 
 /// 是否需要交互遮罩（macOS 上 WebView 会捕获滚动事件）
 bool get _needsInteractionMask => !kIsWeb && Platform.isMacOS;
@@ -149,6 +152,12 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
   bool _hasError = false;
   bool _didLockLayout = false;
 
+  /// 是否真正创建 InAppWebView。
+  /// 默认 false：先放占位，进入视口或用户点按后再挂载，避免一帖多个
+  /// iframe 在 cacheExtent 内同时拉起 WebView2 进程（Windows 上尤其贵）。
+  bool _webViewMounted = false;
+  bool _initialized = false;
+
   /// 桌面平台：是否进入交互模式
   bool _interacting = false;
   OverlayEntry? _overlayEntry;
@@ -156,6 +165,9 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
   /// 上层路由（对话框/BottomSheet）出现时隐藏 WebView，
   /// 避免 hybrid composition 持续脏帧触发 BackdropFilter 全屏重算。
   bool _routeOverlayed = false;
+
+  String get _cacheKey =>
+      'iframe_${widget.attributes.fullUrl.hashCode}_${widget.attributes.width}_${widget.attributes.height}';
 
   @override
   void initState() {
@@ -165,10 +177,28 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    if (!_initialized) {
+      _initialized = true;
+      // 同页已加载过、或截图离屏渲染：直接挂 WebView，避免占位漏出。
+      if (LazyLoadScope.isLoaded(context, _cacheKey) ||
+          ScreenshotMode.of(context)) {
+        _webViewMounted = true;
+      }
+    }
     final route = ModalRoute.of(context);
     if (route != null) {
       appRouteObserver.subscribe(this, route);
     }
+  }
+
+  void _mountWebView() {
+    if (_webViewMounted) return;
+    LazyLoadScope.markLoaded(context, _cacheKey);
+    setState(() {
+      _webViewMounted = true;
+      _isLoaded = false;
+      _hasError = false;
+    });
   }
 
   @override
@@ -247,58 +277,138 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
   Widget build(BuildContext context) {
     final attrs = widget.attributes;
     final theme = Theme.of(context);
+    final Widget content = _webViewMounted
+        ? _buildWebViewContent(theme, attrs)
+        : _buildPlaceholder(theme);
+
+    // 始终使用响应式宽高比布局，忽略固定像素尺寸
+    // 这样可以适配不同屏幕尺寸，避免在小屏幕上溢出或在大屏幕上显得太小
+    Widget sizedContent;
+
+    // 特殊情况：如果只有固定高度（没有宽度或宽度是百分比），使用固定高度
+    // 例如：width="100%" height="111"
+    if (attrs.height != null && attrs.height! > 0 && attrs.width == null) {
+      sizedContent = SizedBox(
+        width: double.infinity,
+        height: attrs.height,
+        child: content,
+      );
+    } else {
+      // 其他情况使用宽高比
+      sizedContent = AspectRatio(
+        aspectRatio: attrs.aspectRatio,
+        child: content,
+      );
+    }
+
+    final padded = Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: sizedContent,
+    );
+
+    // 未挂载时用 VisibilityDetector：刚进视口就创建 WebView。
+    // 已挂载后不再包一层，避免无意义的可见性回调。
+    if (_webViewMounted) return padded;
+
+    return VisibilityDetector(
+      key: Key(_cacheKey),
+      onVisibilityChanged: (info) {
+        if (!_webViewMounted && info.visibleFraction > 0.01) {
+          _mountWebView();
+        }
+      },
+      child: padded,
+    );
+  }
+
+  Widget _buildPlaceholder(ThemeData theme) {
+    final surface = theme.colorScheme.surfaceContainerHighest;
+    final onSurface = theme.colorScheme.onSurfaceVariant;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Material(
+        color: surface,
+        child: InkWell(
+          onTap: _mountWebView,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Symbols.play_circle_rounded,
+                  size: 44,
+                  color: onSurface.withValues(alpha: 0.75),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '点击加载嵌入内容',
+                  style: TextStyle(
+                    color: onSurface,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWebViewContent(ThemeData theme, IframeAttributes attrs) {
     final windowsWebViewEnvironment =
         WindowsWebViewEnvironmentService.instance.environment;
 
-    // 构建内容 Widget
-    Widget content = ClipRRect(
+    return ClipRRect(
       borderRadius: BorderRadius.circular(8),
       child: Stack(
         children: [
-          // WebView - 始终渲染
-          // 直接加载 URL，通过设置 Referer 头解决 origin 验证问题
+          // 真正的 WebView：仅在 _webViewMounted 后进入树。
+          // 直接加载 URL，通过设置 Referer 头解决 origin 验证问题。
           Offstage(
             offstage: _routeOverlayed,
             child: InAppWebView(
-            webViewEnvironment: windowsWebViewEnvironment,
-            initialUrlRequest: URLRequest(
-              url: WebUri(attrs.fullUrl),
-              headers: {'Referer': AppConstants.baseUrl},
-            ),
-            initialSettings: _buildSettings(attrs),
-            initialUserScripts: WebViewSettings.compatPolyfillScripts,
-            onWebViewCreated: (controller) {
-              WebViewSettings.registerJsErrorReporter(controller);
-            },
-            onReceivedServerTrustAuthRequest: (_, challenge) =>
-                WebViewSettings.handleServerTrustAuthRequest(challenge),
-            // 允许 WebView 接收水平滑动手势
-            gestureRecognizers: {
-              Factory<HorizontalDragGestureRecognizer>(
-                () => HorizontalDragGestureRecognizer(),
+              webViewEnvironment: windowsWebViewEnvironment,
+              initialUrlRequest: URLRequest(
+                url: WebUri(attrs.fullUrl),
+                headers: {'Referer': AppConstants.baseUrl},
               ),
-            },
-            onEnterFullscreen: (controller) {
-              _lockLayout();
-            },
-            onExitFullscreen: (controller) {
-              _unlockLayoutIfNeeded();
-            },
-            onLoadStart: (controller, url) {
-              if (mounted) {
-                setState(() {
-                  _isLoaded = false;
-                  _hasError = false;
-                });
-              }
-            },
-            onLoadStop: (controller, url) async {
-              if (mounted) {
-                setState(() => _isLoaded = true);
-              }
-              // 注入 viewport meta 标签，确保内容正确缩放
-              await controller.evaluateJavascript(
-                source: '''
+              initialSettings: _buildSettings(attrs),
+              initialUserScripts: WebViewSettings.compatPolyfillScripts,
+              onWebViewCreated: (controller) {
+                WebViewSettings.registerJsErrorReporter(controller);
+                // 嵌入实例同样压低 WebView2 内存目标，减轻后台占用。
+                WebViewSettings.applyWindowsHeadlessMemoryTarget(controller);
+              },
+              onReceivedServerTrustAuthRequest: (_, challenge) =>
+                  WebViewSettings.handleServerTrustAuthRequest(challenge),
+              // 允许 WebView 接收水平滑动手势
+              gestureRecognizers: {
+                Factory<HorizontalDragGestureRecognizer>(
+                  () => HorizontalDragGestureRecognizer(),
+                ),
+              },
+              onEnterFullscreen: (controller) {
+                _lockLayout();
+              },
+              onExitFullscreen: (controller) {
+                _unlockLayoutIfNeeded();
+              },
+              onLoadStart: (controller, url) {
+                if (mounted) {
+                  setState(() {
+                    _isLoaded = false;
+                    _hasError = false;
+                  });
+                }
+              },
+              onLoadStop: (controller, url) async {
+                if (mounted) {
+                  setState(() => _isLoaded = true);
+                }
+                // 注入 viewport meta 标签，确保内容正确缩放
+                await controller.evaluateJavascript(
+                  source: '''
                     (function() {
                       var meta = document.querySelector('meta[name="viewport"]');
                       if (!meta) {
@@ -309,35 +419,35 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
                       meta.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no';
                     })();
                   ''',
-              );
-            },
-            onReceivedError: (controller, request, error) {
-              // 只有主框架加载失败才显示错误
-              // 忽略子资源（JS、图片、视频海报等）的加载错误
-              if (mounted && request.isForMainFrame == true) {
-                setState(() => _hasError = true);
-              }
-            },
-            // 拦截用户点击的链接，使用 WebViewPage 打开
-            shouldOverrideUrlLoading: (controller, navigationAction) async {
-              // 只拦截用户主动点击的链接
-              if (navigationAction.navigationType !=
-                  NavigationType.LINK_ACTIVATED) {
-                return NavigationActionPolicy.ALLOW;
-              }
+                );
+              },
+              onReceivedError: (controller, request, error) {
+                // 只有主框架加载失败才显示错误
+                // 忽略子资源（JS、图片、视频海报等）的加载错误
+                if (mounted && request.isForMainFrame == true) {
+                  setState(() => _hasError = true);
+                }
+              },
+              // 拦截用户点击的链接，使用 WebViewPage 打开
+              shouldOverrideUrlLoading: (controller, navigationAction) async {
+                // 只拦截用户主动点击的链接
+                if (navigationAction.navigationType !=
+                    NavigationType.LINK_ACTIVATED) {
+                  return NavigationActionPolicy.ALLOW;
+                }
 
-              final url = navigationAction.request.url?.toString();
-              if (url == null) {
-                return NavigationActionPolicy.ALLOW;
-              }
+                final url = navigationAction.request.url?.toString();
+                if (url == null) {
+                  return NavigationActionPolicy.ALLOW;
+                }
 
-              // 使用 WebViewPage 打开
-              if (mounted) {
-                WebViewPage.open(context, url);
-              }
-              return NavigationActionPolicy.CANCEL;
-            },
-          ),
+                // 使用 WebViewPage 打开
+                if (mounted) {
+                  WebViewPage.open(context, url);
+                }
+                return NavigationActionPolicy.CANCEL;
+              },
+            ),
           ),
           // 加载指示器
           if (!_isLoaded && !_hasError)
@@ -388,31 +498,6 @@ class _IframeWidgetState extends State<IframeWidget> with RouteAware {
             ),
         ],
       ),
-    );
-
-    // 始终使用响应式宽高比布局，忽略固定像素尺寸
-    // 这样可以适配不同屏幕尺寸，避免在小屏幕上溢出或在大屏幕上显得太小
-    Widget sizedContent;
-
-    // 特殊情况：如果只有固定高度（没有宽度或宽度是百分比），使用固定高度
-    // 例如：width="100%" height="111"
-    if (attrs.height != null && attrs.height! > 0 && attrs.width == null) {
-      sizedContent = SizedBox(
-        width: double.infinity,
-        height: attrs.height,
-        child: content,
-      );
-    } else {
-      // 其他情况使用宽高比
-      sizedContent = AspectRatio(
-        aspectRatio: attrs.aspectRatio,
-        child: content,
-      );
-    }
-
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      child: sizedContent,
     );
   }
 


### PR DESCRIPTION
## Summary
修复 Windows 上 FluxDO **CPU 不高但整窗卡死/点不动** 的问题。根因是 WebView2 创建销毁与 CookieManager IPC 抢平台主线程，而不是算力打满。

### 已修
1. **iframe 懒加载**：帖子内嵌不再始终挂 `InAppWebView`，进入视口或点击后再创建，避免 WebView2 进程风暴
2. **CF 滚动挂起扩展到 Windows**：滚动中 pause 常驻 Turnstile headless WebView
3. **冷启动避让（本 commit 新增）**
   - Windows 跳过启动期 cookie priming（真正开 WebView 时仍会 prime）
   - 非 force 的 session bootstrap 延后约 25s，滚动繁忙时再等空闲
   - native preload 后的 browser-trust settle 同步延后
   - CF 常驻 refresh 启动延后到约 40s，避免与 bootstrap 叠峰

## Why / Root cause
- Windows 上 headless WebView 创建/销毁、CookieManager IPC 走平台主线程
- 冷启动路径会在首屏几秒内叠：`prepareStartup` priming + Dio 触发 session bootstrap + CF refresh
- 表现：刚进应用很顺 → 过几秒突然整窗变钝；任务管理器 CPU 可仍只有个位数
- 生产/自测：iframe eager 时单页可出现大量 `msedgewebview2`；懒加载后仍有“几秒后卡”由 bootstrap/priming 导致

## Test plan
- [x] Windows Release：冷启动前 20s 可交互，日志可见 `windows_startup_defer`，无早期 `priming_failed`
- [x] 约 25s 后出现延后的 `windows_deferred:*` session bootstrap；约 40s CF refresh 拉起
- [ ] Windows：纯文字帖 `msedgewebview2` 保持很少
- [ ] Windows：多 iframe 帖初始占位，滚入/点击后加载
- [ ] 滚动列表/帖子时不明显掉帧
- [ ] 分享成图不截到 iframe 占位
- [ ] macOS/Android 既有 lazy/CF 行为不受影响
- [ ] force / CF recover 路径仍可立即 bootstrap（不走 25s defer）

## Notes
- 这是 **bugfix / jank fix**，不是功能增强
- 延后只影响 Windows 冷启动非 force 路径；登录失效恢复等 force 路径保持即时