### PR TITLE
feat: import CC Switch credentials from OP posts

### DIFF
--- a/lib/l10n/modules/appearance/appearance_en.arb
+++ b/lib/l10n/modules/appearance/appearance_en.arb
@@ -84,6 +84,41 @@
   "reading_aiSwipeEntryDesc": "Swipe left in topic detail to open AI Assistant",
   "reading_boostDanmaku": "Boost as danmaku",
   "reading_boostDanmakuDesc": "Overlay Boosts on top of post content as scrolling danmaku. Pauses on touch.",
+  "ccswitch_fill": "Fill CC Switch",
+  "ccswitch_rescan": "Rescan",
+  "ccswitch_copy": "Copy",
+  "ccswitch_open": "Open CC Switch",
+  "ccswitch_app": "App",
+  "ccswitch_name": "Name",
+  "ccswitch_nameHint": "Optional, defaults to time + URL",
+  "ccswitch_importEnabled": "CC Switch import",
+  "ccswitch_importEnabledDesc": "Show Fill CC Switch on the OP post to detect BASE URL and API key",
+  "ccswitch_importApp": "CC Switch import app",
+  "ccswitch_importAppDesc": "Default target app when filling credentials from the OP post",
+  "ccswitch_appClaude": "Claude",
+  "ccswitch_appCodex": "Codex",
+  "ccswitch_appGemini": "Gemini",
+  "ccswitch_appAll": "All three",
+  "ccswitch_statusReady": "Ready",
+  "ccswitch_statusPartial": "Partial",
+  "ccswitch_notFound": "No URL or API key found in the OP post",
+  "ccswitch_partial": "Partial credentials found; fill URL and KEY",
+  "ccswitch_needUrlAndKey": "Please provide both URL and KEY",
+  "ccswitch_detected": "Detected: {url} / {key}",
+  "@ccswitch_detected": {
+    "placeholders": {
+      "url": { "type": "String" },
+      "key": { "type": "String" }
+    }
+  },
+  "ccswitch_opened": "Opened CC Switch ({count})",
+  "@ccswitch_opened": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "ccswitch_openFailed": "Could not open CC Switch. Is it installed?",
+  "ccswitch_linkCopied": "Deeplink copied",
   "reading_expandRelatedLinks": "Expand related links by default",
   "reading_expandRelatedLinksDesc": "Show related links expanded in posts",
   "reading_showSignatures": "Show user signatures",

--- a/lib/l10n/modules/appearance/appearance_zh.arb
+++ b/lib/l10n/modules/appearance/appearance_zh.arb
@@ -84,6 +84,41 @@
   "reading_aiSwipeEntryDesc": "在话题详情页向左滑动打开 AI 助手",
   "reading_boostDanmaku": "Boost 弹幕化",
   "reading_boostDanmakuDesc": "把 Boost 以弹幕形式叠加在帖子内容上方滚动，触摸暂停",
+  "ccswitch_fill": "填入 CC Switch",
+  "ccswitch_rescan": "重识别",
+  "ccswitch_copy": "复制",
+  "ccswitch_open": "打开 CC Switch",
+  "ccswitch_app": "应用",
+  "ccswitch_name": "名称",
+  "ccswitch_nameHint": "可选，默认时间+URL",
+  "ccswitch_importEnabled": "CC Switch 导入",
+  "ccswitch_importEnabledDesc": "在主帖显示填入 CC Switch 按钮，识别 BASE URL 与 API Key",
+  "ccswitch_importApp": "CC Switch 导入应用",
+  "ccswitch_importAppDesc": "识别主帖凭据后默认填入的目标应用",
+  "ccswitch_appClaude": "Claude",
+  "ccswitch_appCodex": "Codex",
+  "ccswitch_appGemini": "Gemini",
+  "ccswitch_appAll": "三个都导",
+  "ccswitch_statusReady": "已识别",
+  "ccswitch_statusPartial": "部分识别",
+  "ccswitch_notFound": "主帖内未识别到 URL 或 API Key",
+  "ccswitch_partial": "已识别部分字段，请补齐 URL 和 KEY",
+  "ccswitch_needUrlAndKey": "请先补齐 URL 和 KEY",
+  "ccswitch_detected": "已识别：{url} / {key}",
+  "@ccswitch_detected": {
+    "placeholders": {
+      "url": { "type": "String" },
+      "key": { "type": "String" }
+    }
+  },
+  "ccswitch_opened": "已打开 CC Switch（{count}）",
+  "@ccswitch_opened": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "ccswitch_openFailed": "无法打开 CC Switch，请确认已安装",
+  "ccswitch_linkCopied": "深链接已复制",
   "reading_expandRelatedLinks": "默认展开相关链接",
   "reading_expandRelatedLinksDesc": "帖子中的相关链接区域默认展开显示",
   "reading_showSignatures": "显示用户签名",

--- a/lib/l10n/modules/appearance/appearance_zh_HK.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_HK.arb
@@ -84,6 +84,41 @@
   "reading_aiSwipeEntryDesc": "在話題詳情頁向左滑動打開 AI 助手",
   "reading_boostDanmaku": "Boost 彈幕化",
   "reading_boostDanmakuDesc": "把 Boost 以彈幕形式疊加喺帖子內容上方滾動，觸碰暫停",
+  "ccswitch_fill": "填入 CC Switch",
+  "ccswitch_rescan": "重識別",
+  "ccswitch_copy": "複製",
+  "ccswitch_open": "開啟 CC Switch",
+  "ccswitch_app": "應用",
+  "ccswitch_name": "名稱",
+  "ccswitch_nameHint": "可選，預設時間+URL",
+  "ccswitch_importEnabled": "CC Switch 匯入",
+  "ccswitch_importEnabledDesc": "喺主帖顯示填入 CC Switch 按鈕，識別 BASE URL 同 API Key",
+  "ccswitch_importApp": "CC Switch 匯入應用",
+  "ccswitch_importAppDesc": "識別主帖憑據後預設填入的目標應用",
+  "ccswitch_appClaude": "Claude",
+  "ccswitch_appCodex": "Codex",
+  "ccswitch_appGemini": "Gemini",
+  "ccswitch_appAll": "三個都導",
+  "ccswitch_statusReady": "已識別",
+  "ccswitch_statusPartial": "部分識別",
+  "ccswitch_notFound": "主帖內未識別到 URL 或 API Key",
+  "ccswitch_partial": "已識別部分欄位，請補齊 URL 和 KEY",
+  "ccswitch_needUrlAndKey": "請先補齊 URL 和 KEY",
+  "ccswitch_detected": "已識別：{url} / {key}",
+  "@ccswitch_detected": {
+    "placeholders": {
+      "url": { "type": "String" },
+      "key": { "type": "String" }
+    }
+  },
+  "ccswitch_opened": "已開啟 CC Switch（{count}）",
+  "@ccswitch_opened": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "ccswitch_openFailed": "無法開啟 CC Switch，請確認已安裝",
+  "ccswitch_linkCopied": "深連結已複製",
   "reading_expandRelatedLinks": "預設展開相關鏈接",
   "reading_expandRelatedLinksDesc": "帖子中的相關鏈接區域預設展開顯示",
   "reading_showSignatures": "顯示用户簽名",

--- a/lib/l10n/modules/appearance/appearance_zh_TW.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_TW.arb
@@ -84,6 +84,41 @@
   "reading_aiSwipeEntryDesc": "在話題詳情頁向左滑動開啟 AI 助手",
   "reading_boostDanmaku": "Boost 彈幕化",
   "reading_boostDanmakuDesc": "把 Boost 以彈幕形式疊加在帖子內容上方滾動，觸控暫停",
+  "ccswitch_fill": "填入 CC Switch",
+  "ccswitch_rescan": "重識別",
+  "ccswitch_copy": "複製",
+  "ccswitch_open": "開啟 CC Switch",
+  "ccswitch_app": "應用",
+  "ccswitch_name": "名稱",
+  "ccswitch_nameHint": "可選，預設時間+URL",
+  "ccswitch_importEnabled": "CC Switch 匯入",
+  "ccswitch_importEnabledDesc": "在主帖顯示填入 CC Switch 按鈕，識別 BASE URL 與 API Key",
+  "ccswitch_importApp": "CC Switch 匯入應用",
+  "ccswitch_importAppDesc": "識別主帖憑據後預設填入的目標應用",
+  "ccswitch_appClaude": "Claude",
+  "ccswitch_appCodex": "Codex",
+  "ccswitch_appGemini": "Gemini",
+  "ccswitch_appAll": "三個都導",
+  "ccswitch_statusReady": "已識別",
+  "ccswitch_statusPartial": "部分識別",
+  "ccswitch_notFound": "主帖內未識別到 URL 或 API Key",
+  "ccswitch_partial": "已識別部分欄位，請補齊 URL 和 KEY",
+  "ccswitch_needUrlAndKey": "請先補齊 URL 和 KEY",
+  "ccswitch_detected": "已識別：{url} / {key}",
+  "@ccswitch_detected": {
+    "placeholders": {
+      "url": { "type": "String" },
+      "key": { "type": "String" }
+    }
+  },
+  "ccswitch_opened": "已開啟 CC Switch（{count}）",
+  "@ccswitch_opened": {
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "ccswitch_openFailed": "無法開啟 CC Switch，請確認已安裝",
+  "ccswitch_linkCopied": "深連結已複製",
   "reading_expandRelatedLinks": "預設展開相關連結",
   "reading_expandRelatedLinksDesc": "帖子中的相關連結區域預設展開顯示",
   "reading_showSignatures": "顯示使用者簽名",

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -10,6 +10,8 @@ import '../services/network/request_scheduler_config.dart';
 import '../services/cf_challenge_service.dart';
 import '../utils/blocked_user_filter.dart';
 import 'theme_provider.dart';
+import '../utils/ccswitch/ccswitch_credentials.dart';
+export '../utils/ccswitch/ccswitch_credentials.dart' show CcswitchImportApp;
 
 /// 嵌套视图连接线样式
 enum NestedLineStyle {
@@ -167,6 +169,12 @@ class AppPreferences {
   /// Boost 弹幕化（默认关闭）
   final bool boostDanmaku;
 
+  /// 主帖 CC Switch 导入条开关
+  final bool ccswitchImportEnabled;
+
+  /// CC Switch 默认导入应用（claude/codex/gemini/all）
+  final CcswitchImportApp ccswitchImportApp;
+
   /// 默认使用树形视图
   final bool defaultNestedView;
 
@@ -245,6 +253,8 @@ class AppPreferences {
     required this.dialogBlur,
     this.showSignatures = true,
     this.boostDanmaku = false,
+    this.ccswitchImportEnabled = true,
+    this.ccswitchImportApp = CcswitchImportApp.codex,
     this.defaultNestedView = false,
     this.nestedLineStyle = NestedLineStyle.auto,
     this.bookmarksOpenMode = BookmarksOpenMode.defaultRoute,
@@ -291,6 +301,8 @@ class AppPreferences {
     bool? dialogBlur,
     bool? showSignatures,
     bool? boostDanmaku,
+    bool? ccswitchImportEnabled,
+    CcswitchImportApp? ccswitchImportApp,
     bool? defaultNestedView,
     NestedLineStyle? nestedLineStyle,
     BookmarksOpenMode? bookmarksOpenMode,
@@ -342,6 +354,9 @@ class AppPreferences {
       dialogBlur: dialogBlur ?? this.dialogBlur,
       showSignatures: showSignatures ?? this.showSignatures,
       boostDanmaku: boostDanmaku ?? this.boostDanmaku,
+      ccswitchImportEnabled:
+          ccswitchImportEnabled ?? this.ccswitchImportEnabled,
+      ccswitchImportApp: ccswitchImportApp ?? this.ccswitchImportApp,
       defaultNestedView: defaultNestedView ?? this.defaultNestedView,
       nestedLineStyle: nestedLineStyle ?? this.nestedLineStyle,
       bookmarksOpenMode: bookmarksOpenMode ?? this.bookmarksOpenMode,
@@ -403,6 +418,9 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _dialogBlurKey = 'pref_dialog_blur';
   static const String _showSignaturesKey = 'pref_show_signatures';
   static const String _boostDanmakuKey = 'pref_boost_danmaku';
+  static const String _ccswitchImportEnabledKey =
+      'pref_ccswitch_import_enabled';
+  static const String _ccswitchImportAppKey = 'pref_ccswitch_import_app';
   static const String _defaultNestedViewKey = 'pref_default_nested_view';
   static const String _nestedLineStyleKey = 'pref_nested_line_style';
   static const String _bookmarksOpenModeKey = 'pref_bookmarks_open_mode';
@@ -468,6 +486,11 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           dialogBlur: _prefs.getBool(_dialogBlurKey) ?? true,
           showSignatures: _prefs.getBool(_showSignaturesKey) ?? true,
           boostDanmaku: _prefs.getBool(_boostDanmakuKey) ?? false,
+          ccswitchImportEnabled:
+              _prefs.getBool(_ccswitchImportEnabledKey) ?? true,
+          ccswitchImportApp: CcswitchImportApp.fromString(
+            _prefs.getString(_ccswitchImportAppKey),
+          ),
           defaultNestedView: _prefs.getBool(_defaultNestedViewKey) ?? false,
           nestedLineStyle: NestedLineStyle.fromString(
             _prefs.getString(_nestedLineStyleKey),
@@ -683,6 +706,18 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
     if (state.boostDanmaku == enabled) return;
     state = state.copyWith(boostDanmaku: enabled);
     await _prefs.setBool(_boostDanmakuKey, enabled);
+  }
+
+  Future<void> setCcswitchImportEnabled(bool enabled) async {
+    if (state.ccswitchImportEnabled == enabled) return;
+    state = state.copyWith(ccswitchImportEnabled: enabled);
+    await _prefs.setBool(_ccswitchImportEnabledKey, enabled);
+  }
+
+  Future<void> setCcswitchImportApp(CcswitchImportApp app) async {
+    if (state.ccswitchImportApp == app) return;
+    state = state.copyWith(ccswitchImportApp: app);
+    await _prefs.setString(_ccswitchImportAppKey, app.name);
   }
 
   Future<void> setDefaultNestedView(bool enabled) async {

--- a/lib/settings/definitions/reading_defs.dart
+++ b/lib/settings/definitions/reading_defs.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +10,7 @@ import '../../l10n/s.dart';
 import '../../pages/topic_detail_page/widgets/progress_gesture_action_meta.dart';
 import '../../pages/topic_detail_page/widgets/progress_gesture_menu_settings_page.dart';
 import '../../providers/preferences_provider.dart';
+import '../../utils/ccswitch/ccswitch_credentials.dart';
 import '../../services/preloaded_data_service.dart';
 import '../settings_model.dart';
 
@@ -51,6 +53,56 @@ List<SettingsGroup> buildReadingGroups(BuildContext context) {
           getValue: (ref) => ref.watch(preferencesProvider).boostDanmaku,
           onChanged: (ref, v) =>
               ref.read(preferencesProvider.notifier).setBoostDanmaku(v),
+        ),
+        // CC Switch 导入仅 Windows / macOS 有意义（桌面端 deeplink）
+        PlatformConditionalModel(
+          condition: () => !kIsWeb && (Platform.isWindows || Platform.isMacOS),
+          inner: SwitchModel(
+            id: 'ccswitchImportEnabled',
+            title: l10n.ccswitch_importEnabled,
+            subtitle: l10n.ccswitch_importEnabledDesc,
+            icon: Symbols.vpn_key_rounded,
+            getValue: (ref) =>
+                ref.watch(preferencesProvider).ccswitchImportEnabled,
+            onChanged: (ref, v) => ref
+                .read(preferencesProvider.notifier)
+                .setCcswitchImportEnabled(v),
+          ),
+        ),
+        PlatformConditionalModel(
+          condition: () => !kIsWeb && (Platform.isWindows || Platform.isMacOS),
+          inner: CustomModel(
+            id: 'ccswitchImportApp',
+            title: l10n.ccswitch_importApp,
+            builder: (context, ref) {
+              final prefs = ref.watch(preferencesProvider);
+              final enabled = prefs.ccswitchImportEnabled;
+              final current = prefs.ccswitchImportApp;
+              final l = context.l10n;
+              final theme = Theme.of(context);
+              String label(CcswitchImportApp app) => switch (app) {
+                CcswitchImportApp.claude => l.ccswitch_appClaude,
+                CcswitchImportApp.codex => l.ccswitch_appCodex,
+                CcswitchImportApp.gemini => l.ccswitch_appGemini,
+                CcswitchImportApp.all => l.ccswitch_appAll,
+              };
+              return ListTile(
+                enabled: enabled,
+                leading: Icon(
+                  Symbols.vpn_key_rounded,
+                  color: enabled
+                      ? theme.colorScheme.primary
+                      : theme.disabledColor,
+                ),
+                title: Text(l.ccswitch_importApp),
+                subtitle: Text(label(current)),
+                trailing: const Icon(Symbols.chevron_right_rounded),
+                onTap: enabled
+                    ? () => _showCcswitchImportAppPicker(context, ref, current)
+                    : null,
+              );
+            },
+          ),
         ),
       ],
     ),
@@ -560,3 +612,49 @@ void _showGestureActionPicker(
   });
 }
 
+
+void _showCcswitchImportAppPicker(
+  BuildContext context,
+  WidgetRef ref,
+  CcswitchImportApp current,
+) {
+  final l10n = context.l10n;
+  final options = [
+    (CcswitchImportApp.codex, l10n.ccswitch_appCodex),
+    (CcswitchImportApp.claude, l10n.ccswitch_appClaude),
+    (CcswitchImportApp.gemini, l10n.ccswitch_appGemini),
+    (CcswitchImportApp.all, l10n.ccswitch_appAll),
+  ];
+
+  showDialog<CcswitchImportApp>(
+    context: context,
+    builder: (context) => SimpleDialog(
+      title: Text(l10n.ccswitch_importApp),
+      children: [
+        for (final (app, label) in options)
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(context, app),
+            child: Row(
+              children: [
+                Icon(
+                  app == current
+                      ? Symbols.radio_button_checked_rounded
+                      : Symbols.radio_button_unchecked_rounded,
+                  color: app == current
+                      ? Theme.of(context).colorScheme.primary
+                      : null,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Text(label),
+              ],
+            ),
+          ),
+      ],
+    ),
+  ).then((selected) {
+    if (selected != null) {
+      ref.read(preferencesProvider.notifier).setCcswitchImportApp(selected);
+    }
+  });
+}

--- a/lib/utils/ccswitch/ccswitch_credentials.dart
+++ b/lib/utils/ccswitch/ccswitch_credentials.dart
@@ -1,0 +1,925 @@
+import 'dart:convert';
+
+/// Parsed NewAPI-style provider credentials from free text / HTML.
+class CcswitchCredentials {
+  final String? baseUrl;
+  final String? apiKey;
+  final String? name;
+
+  const CcswitchCredentials({
+    this.baseUrl,
+    this.apiKey,
+    this.name,
+  });
+
+  bool get isComplete =>
+      (baseUrl?.isNotEmpty ?? false) && (apiKey?.isNotEmpty ?? false);
+
+  bool get hasAny =>
+      (baseUrl?.isNotEmpty ?? false) ||
+      (apiKey?.isNotEmpty ?? false) ||
+      (name?.isNotEmpty ?? false);
+
+  CcswitchCredentials copyWith({
+    String? baseUrl,
+    String? apiKey,
+    String? name,
+  }) {
+    return CcswitchCredentials(
+      baseUrl: baseUrl ?? this.baseUrl,
+      apiKey: apiKey ?? this.apiKey,
+      name: name ?? this.name,
+    );
+  }
+
+  CcswitchCredentials merge(CcswitchCredentials other) {
+    return CcswitchCredentials(
+      baseUrl: other.baseUrl?.isNotEmpty == true ? other.baseUrl : baseUrl,
+      apiKey: other.apiKey?.isNotEmpty == true ? other.apiKey : apiKey,
+      name: other.name?.isNotEmpty == true ? other.name : name,
+    );
+  }
+
+  @override
+  String toString() =>
+      'CcswitchCredentials(baseUrl: $baseUrl, apiKey: ${maskApiKey(apiKey)}, name: $name)';
+}
+
+/// Import target app for CC Switch deeplink.
+enum CcswitchImportApp {
+  claude,
+  codex,
+  gemini,
+  all;
+
+  static const List<CcswitchImportApp> storageValues = [
+    claude,
+    codex,
+    gemini,
+    all,
+  ];
+
+  static CcswitchImportApp fromString(String? value) {
+    final mode = (value ?? '').trim().toLowerCase();
+    return CcswitchImportApp.values.firstWhere(
+      (e) => e.name == mode,
+      orElse: () => CcswitchImportApp.codex,
+    );
+  }
+
+  /// Concrete apps to open for this mode.
+  List<CcswitchImportApp> get resolvedApps {
+    if (this == CcswitchImportApp.all) {
+      return const [
+        CcswitchImportApp.claude,
+        CcswitchImportApp.codex,
+        CcswitchImportApp.gemini,
+      ];
+    }
+    return [this];
+  }
+}
+
+const Map<String, Map<String, String>> kCcswitchDefaultModels = {
+  'claude': {
+    'model': 'claude-sonnet-5',
+    'haikuModel': 'claude-haiku-4-5-20251001',
+    'sonnetModel': 'claude-sonnet-5',
+    'opusModel': 'claude-opus-4-8',
+  },
+  'codex': {'model': 'gpt-5.5'},
+  'gemini': {'model': 'gemini-3.5-flash'},
+};
+
+final RegExp _schemeUrlRe = RegExp(r'''https?://[^\s"'`<>]+''', caseSensitive: false);
+final RegExp _bareHostRe = RegExp(
+  r'''\b(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(?:/[^\s"'`<>]*)?(?![A-Za-z-])''',
+);
+final RegExp _skKeyRe = RegExp(r'\b(sk-[A-Za-z0-9._\-]{8,})\b');
+final RegExp _bearerKeyRe =
+    RegExp(r'\bBearer\s+([A-Za-z0-9._\-+=/]{16,})\b', caseSensitive: false);
+final RegExp _skBase64Re = RegExp(r'c2st[A-Za-z0-9+/_-]+={0,2}');
+final RegExp _base64TokenRe = RegExp(r'[A-Za-z0-9+/_-]{20,}={0,2}');
+final RegExp _labeledKeyRe = RegExp(
+  r'''(?:api[_\s-]?key|apikey|\bkey\b|token|auth[_\s-]?token|secret|access[_\s-]?token|密钥|金鑰|金钥|令牌)\s*[:=：]\s*["']?([^\s"'`,;]+)["']?''',
+  caseSensitive: false,
+);
+final RegExp _labeledUrlRe = RegExp(
+  r'''(?:base[_\s-]?url|api[_\s-]?url|\bapi\b|endpoint|host|\burl\b|地址|接口|域名)\s*[:=：]\s*["']?((?:https?://)?[^\s"'`,;]+)["']?''',
+  caseSensitive: false,
+);
+final RegExp _labeledNameRe = RegExp(
+  r'''(?:name|provider|title|名称|名稱)\s*[:=：]\s*["']?([^\n\r"'`,;]+)["']?''',
+  caseSensitive: false,
+);
+final RegExp _queryKeyRe = RegExp(
+  r'''[?&](?:api[_-]?key|apikey|key|token|access[_-]?token)=([^&\s"'`]+)''',
+  caseSensitive: false,
+);
+final RegExp _markdownLinkRe =
+    RegExp(r'\[([^\]]+)\]\((https?://[^)\s]+)\)', caseSensitive: false);
+final RegExp _plainKeyRe = RegExp(r'\b([A-Za-z][A-Za-z0-9._-]{15,127})\b');
+final RegExp _controlCharsRe = RegExp(r'[\u0000-\u0008\u000B\u000C\u000E-\u001F]');
+
+String cleanToken(String? value) {
+  return (value ?? '')
+      .trim()
+      .replaceAll(RegExp(r'''^["'`]+|["'`,;]+$'''), '');
+}
+
+String stripMarkdownWrapper(String value) {
+  final trimmed = cleanToken(value);
+  final md = RegExp(r'^\[([^\]]*)\]\((https?://[^)\s]+)\)$', caseSensitive: false)
+      .firstMatch(trimmed);
+  if (md != null && (md.group(2)?.isNotEmpty ?? false)) {
+    return cleanToken(md.group(2)!);
+  }
+  final bare =
+      RegExp(r'^\[(https?://[^\]]+)\]$', caseSensitive: false).firstMatch(trimmed);
+  if (bare != null && (bare.group(1)?.isNotEmpty ?? false)) {
+    return cleanToken(bare.group(1)!);
+  }
+  return trimmed;
+}
+
+bool looksLikeUrl(String value) {
+  final v = stripMarkdownWrapper(value);
+  if (RegExp(r'^https?://', caseSensitive: false).hasMatch(v)) return true;
+  return RegExp(
+    r'^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}(?::\d{1,5})?(?:/\S*)?$',
+  ).hasMatch(v);
+}
+
+bool looksLikeSkKey(String? value) {
+  return RegExp(r'^sk-[A-Za-z0-9._\-]{8,}$', caseSensitive: false)
+      .hasMatch((value ?? '').trim());
+}
+
+bool looksLikeSecretToken(String value) {
+  final v = cleanToken(value);
+  if (v.length < 16 || v.length > 256) return false;
+  if (looksLikeUrl(v) || looksLikeSkKey(v)) return false;
+  if (RegExp(r'\s').hasMatch(v)) return false;
+  if (!RegExp(r'^[A-Za-z0-9._\-+=/+]+$').hasMatch(v)) return false;
+  final hasLetter = RegExp(r'[A-Za-z]').hasMatch(v);
+  final hasDigit = RegExp(r'\d').hasMatch(v);
+  if (!hasLetter) return false;
+  if (!(hasDigit ||
+      RegExp(r'[_\-+/=]').hasMatch(v) ||
+      (RegExp(r'[A-Z]').hasMatch(v) && RegExp(r'[a-z]').hasMatch(v)))) {
+    return false;
+  }
+  if (RegExp(
+    r'^(https?|baseurl|apikey|endpoint|gateway|proxy|relay|key|token|api)$',
+    caseSensitive: false,
+  ).hasMatch(v)) {
+    return false;
+  }
+  return true;
+}
+
+bool looksLikeBase64Blob(String value) {
+  final cleaned = value.trim().replaceAll(RegExp(r'\s+'), '');
+  if (cleaned.length < 16) return false;
+  if (!RegExp(r'^[A-Za-z0-9+/_-]+={0,2}$').hasMatch(cleaned)) return false;
+  if (looksLikeSkKey(cleaned) || looksLikeUrl(cleaned)) return false;
+  if (cleaned.startsWith('c2st')) return true;
+  if (cleaned.length % 4 != 0) return false;
+  return true;
+}
+
+String? decodeBase64Utf8(String input) {
+  final cleaned = input.replaceAll(RegExp(r'\s+'), '');
+  try {
+    final normalized = base64.normalize(cleaned.replaceAll('-', '+').replaceAll('_', '/'));
+    return utf8.decode(base64.decode(normalized), allowMalformed: true);
+  } catch (_) {
+    try {
+      return utf8.decode(base64.decode(cleaned), allowMalformed: true);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+String? tryDecodeBase64Candidate(String value) {
+  final cleaned = value.trim().replaceAll(RegExp(r'\s+'), '');
+  if (!looksLikeBase64Blob(cleaned)) return null;
+  try {
+    final decoded = decodeBase64Utf8(cleaned);
+    if (decoded == null || decoded.isEmpty) return null;
+    if (decoded == value || decoded == cleaned) return null;
+    if (_controlCharsRe.hasMatch(decoded)) return null;
+    return decoded;
+  } catch (_) {
+    return null;
+  }
+}
+
+List<String> collectSkKeys(String text) {
+  final keys = <String>[];
+  for (final match in _skKeyRe.allMatches(text)) {
+    final g = match.group(1);
+    if (g != null) keys.add(cleanToken(g));
+  }
+  return keys;
+}
+
+bool looksLikePlainApiKey(String value) {
+  final v = cleanToken(value);
+  if (v.length < 16 || v.length > 128) return false;
+  if (looksLikeUrl(v) || looksLikeSkKey(v)) return false;
+  if (RegExp(r'\s').hasMatch(v)) return false;
+  if (!RegExp(r'^[A-Za-z][A-Za-z0-9._-]*$').hasMatch(v)) return false;
+  final hasLetter = RegExp(r'[A-Za-z]').hasMatch(v);
+  final hasDigit = RegExp(r'\d').hasMatch(v);
+  final hasHyphen = v.contains('-') || v.contains('_');
+  if (!hasLetter) return false;
+  if (!(hasDigit || hasHyphen)) return false;
+  if (RegExp(
+    r'^(https?|baseurl|apikey|endpoint|gateway|proxy|relay)$',
+    caseSensitive: false,
+  ).hasMatch(v)) {
+    return false;
+  }
+  if (v.startsWith('c2st')) return false;
+  if (looksLikeBase64Blob(v)) {
+    final decoded = tryDecodeBase64Candidate(v);
+    if (decoded != null &&
+        (looksLikeSkKey(decoded) || collectSkKeys(decoded).isNotEmpty)) {
+      return false;
+    }
+    if (RegExp(r'^[A-Za-z0-9+/]+={0,2}$').hasMatch(v) &&
+        v.length % 4 == 0 &&
+        !hasHyphen) {
+      return false;
+    }
+  }
+  return true;
+}
+
+String decodeSecretLayers(String value) {
+  var current = cleanToken(value);
+  for (var i = 0; i < 2; i++) {
+    if (looksLikeSkKey(current)) return current;
+    final decoded = tryDecodeBase64Candidate(current);
+    if (decoded == null) break;
+    final next = cleanToken(decoded);
+    if (looksLikeSkKey(next)) return next;
+    if (looksLikeSecretToken(next) || looksLikePlainApiKey(next)) {
+      final nested = tryDecodeBase64Candidate(next);
+      if (nested != null &&
+          (looksLikeSkKey(nested) ||
+              looksLikeSecretToken(nested) ||
+              looksLikePlainApiKey(nested))) {
+        current = next;
+        continue;
+      }
+      return next;
+    }
+    final sk = collectSkKeys(next);
+    if (sk.isNotEmpty) return sk.first;
+    current = next;
+  }
+  return current;
+}
+
+String ensureHttps(String url) {
+  final trimmed = stripMarkdownWrapper(url);
+  if (RegExp(r'^https?://', caseSensitive: false).hasMatch(trimmed)) {
+    return trimmed;
+  }
+  if (looksLikeUrl(trimmed)) return 'https://$trimmed';
+  return trimmed;
+}
+
+String normalizeBaseUrl(String raw) {
+  var url = ensureHttps(raw).replaceAll(RegExp(r'[),.;]+$'), '');
+  try {
+    final parsed = Uri.parse(url);
+    final cleanedQuery = Map<String, String>.from(parsed.queryParameters)
+      ..removeWhere(
+        (key, _) => const {
+          'api_key',
+          'apiKey',
+          'apikey',
+          'key',
+          'token',
+          'access_token',
+          'accessToken',
+        }.contains(key),
+      );
+    var href = parsed
+        .replace(queryParameters: cleanedQuery.isEmpty ? null : cleanedQuery, fragment: '')
+        .toString();
+    // Uri.toString may leave trailing ?/# when query/fragment empty; normalize.
+    if (href.endsWith('?')) href = href.substring(0, href.length - 1);
+    // Dart Uri keeps a bare trailing '#' after clearing fragment.
+    if (href.endsWith('#')) href = href.substring(0, href.length - 1);
+    href = href.replaceAll(RegExp(r'#+$'), '');
+    href = href.replaceAll(RegExp(r'\?$'), '');
+    if (href.endsWith('/') && (parsed.path.isEmpty || parsed.path == '/')) {
+      href = href.substring(0, href.length - 1);
+    } else if (href.endsWith('/') && parsed.path.length > 1) {
+      href = href.replaceAll(RegExp(r'/+$'), '');
+    }
+    return href;
+  } catch (_) {
+    return url.replaceAll(RegExp(r'/+$'), '');
+  }
+}
+
+String? firstMatch(RegExp re, String text) {
+  final match = re.firstMatch(text);
+  final g = match?.group(1);
+  return g != null ? cleanToken(g) : null;
+}
+
+List<String> collectUrls(String text) {
+  final urls = <String>[];
+  final seen = <String>{};
+  for (final match in _schemeUrlRe.allMatches(text)) {
+    final value = cleanToken(match.group(0)!).replaceAll(RegExp(r'[),.;]+$'), '');
+    if (looksLikeUrl(value) && seen.add(value)) urls.add(value);
+  }
+  for (final match in _bareHostRe.allMatches(text)) {
+    final value = cleanToken(match.group(0)!).replaceAll(RegExp(r'[),.;]+$'), '');
+    if (!looksLikeUrl(value)) continue;
+    if (looksLikeBase64Blob(value) || looksLikeSkKey(value)) continue;
+    if (!seen.contains(value) && !urls.any((u) => u.contains(value))) {
+      seen.add(value);
+      urls.add(value);
+    }
+  }
+  return urls;
+}
+
+void _pushUnique(List<String> items, Set<String> seen, String value) {
+  final cleaned = cleanToken(value);
+  if (cleaned.isEmpty || !seen.add(cleaned)) return;
+  items.add(cleaned);
+}
+
+List<String> collectPlainKeys(String text) {
+  final keys = <String>[];
+  final seen = <String>{};
+  for (final match in _plainKeyRe.allMatches(text)) {
+    final token = match.group(1) != null ? cleanToken(match.group(1)!) : '';
+    if (token.isEmpty || !looksLikePlainApiKey(token) || looksLikeUrl(token)) {
+      continue;
+    }
+    _pushUnique(keys, seen, token);
+  }
+  return keys;
+}
+
+class _MarkdownLink {
+  final String name;
+  final String url;
+  const _MarkdownLink(this.name, this.url);
+}
+
+List<_MarkdownLink> extractMarkdownLinks(String text) {
+  final links = <_MarkdownLink>[];
+  for (final match in _markdownLinkRe.allMatches(text)) {
+    final name = match.group(1) != null ? cleanToken(match.group(1)!) : '';
+    final url = match.group(2) != null
+        ? cleanToken(match.group(2)!).replaceAll(RegExp(r'[),.;]+$'), '')
+        : '';
+    if (url.isEmpty || !looksLikeUrl(url)) continue;
+    links.add(
+      _MarkdownLink(name.isNotEmpty && !looksLikeUrl(name) ? name : '', url),
+    );
+  }
+  return links;
+}
+
+List<String> collectDecodedBase64Keys(String text) {
+  final keys = <String>[];
+  final seen = <String>{};
+  final candidates = <String>[];
+  for (final match in _skBase64Re.allMatches(text)) {
+    candidates.add(cleanToken(match.group(0)!));
+  }
+  for (final match in _base64TokenRe.allMatches(text)) {
+    final token = cleanToken(match.group(0)!);
+    candidates.add(token);
+    final c2stIdx = token.indexOf('c2st');
+    if (c2stIdx > 0) candidates.add(token.substring(c2stIdx));
+  }
+  for (final candidate in candidates) {
+    final decoded = decodeSecretLayers(candidate);
+    if (looksLikeSkKey(decoded)) {
+      _pushUnique(keys, seen, decoded);
+      continue;
+    }
+    for (final sk in collectSkKeys(decoded)) {
+      _pushUnique(keys, seen, sk);
+    }
+    if (decoded != candidate &&
+        (looksLikeSecretToken(decoded) || looksLikePlainApiKey(decoded))) {
+      _pushUnique(keys, seen, decoded);
+    }
+  }
+  return keys;
+}
+
+String? _pickFrom(Map source, List<String> keys) {
+  for (final key in keys) {
+    final value = source[key];
+    if (value is String && value.trim().isNotEmpty) return cleanToken(value);
+  }
+  final lowerEntries = <String, dynamic>{};
+  source.forEach((k, v) {
+    if (k is String) lowerEntries[k.toLowerCase()] = v;
+  });
+  for (final key in keys) {
+    final value = lowerEntries[key.toLowerCase()];
+    if (value is String && value.trim().isNotEmpty) return cleanToken(value);
+  }
+  return null;
+}
+
+CcswitchCredentials? extractFromRecord(Map record) {
+  final nestedSources = <Map>[record];
+  for (final nestedKey in const ['config', 'env', 'data', 'provider', 'settings']) {
+    final nested = record[nestedKey];
+    if (nested is Map && nested is! List) nestedSources.add(nested);
+  }
+  String? baseUrl;
+  String? apiKey;
+  String? name;
+  for (final source in nestedSources) {
+    baseUrl ??= _pickFrom(source, const [
+      'baseUrl',
+      'base_url',
+      'apiUrl',
+      'api_url',
+      'endpoint',
+      'url',
+      'host',
+      'ANTHROPIC_BASE_URL',
+      'OPENAI_BASE_URL',
+      'GOOGLE_GEMINI_BASE_URL',
+      'GEMINI_BASE_URL',
+    ]);
+    apiKey ??= _pickFrom(source, const [
+      'apiKey',
+      'api_key',
+      'token',
+      'authToken',
+      'auth_token',
+      'accessToken',
+      'access_token',
+      'secret',
+      'key',
+      'ANTHROPIC_AUTH_TOKEN',
+      'ANTHROPIC_API_KEY',
+      'OPENAI_API_KEY',
+      'GEMINI_API_KEY',
+    ]);
+    name ??= _pickFrom(source, const [
+      'name',
+      'title',
+      'provider',
+      'providerName',
+      'provider_name',
+    ]);
+  }
+  if (baseUrl == null && apiKey == null && name == null) return null;
+  return CcswitchCredentials(
+    baseUrl: baseUrl != null ? normalizeBaseUrl(baseUrl) : null,
+    apiKey: apiKey,
+    name: name,
+  );
+}
+
+CcswitchCredentials? tryParseJson(String text) {
+  final trimmed = text.trim();
+  if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return null;
+  try {
+    final parsed = jsonDecode(trimmed);
+    if (parsed is List) {
+      for (final item in parsed) {
+        if (item is Map) {
+          final extracted = extractFromRecord(item);
+          if (extracted != null &&
+              ((extracted.baseUrl?.isNotEmpty ?? false) ||
+                  (extracted.apiKey?.isNotEmpty ?? false))) {
+            return extracted;
+          }
+        }
+      }
+      return null;
+    }
+    if (parsed is Map) return extractFromRecord(parsed);
+  } catch (_) {
+    return null;
+  }
+  return null;
+}
+
+String? extractQueryKey(String url) {
+  try {
+    final parsed = Uri.parse(ensureHttps(url));
+    for (final key in const [
+      'api_key',
+      'apiKey',
+      'apikey',
+      'key',
+      'token',
+      'access_token',
+      'accessToken',
+    ]) {
+      final value = parsed.queryParameters[key];
+      if (value != null && value.isNotEmpty) return cleanToken(value);
+    }
+  } catch (_) {}
+  final match = _queryKeyRe.firstMatch(url);
+  if (match?.group(1) != null) {
+    try {
+      return cleanToken(Uri.decodeComponent(match!.group(1)!));
+    } catch (_) {
+      return cleanToken(match!.group(1)!);
+    }
+  }
+  return null;
+}
+
+String decodeApiKeyIfNeeded(String apiKey) {
+  final trimmed = cleanToken(apiKey);
+  if (looksLikeSkKey(trimmed)) return trimmed;
+  final decoded = decodeSecretLayers(trimmed);
+  if (decoded != trimmed) return decoded;
+  final oneShot = tryDecodeBase64Candidate(trimmed);
+  if (oneShot != null) {
+    if (looksLikeSkKey(oneShot)) return cleanToken(oneShot);
+    final nested = parseNewApiClipboard(oneShot);
+    if (nested?.apiKey != null) return nested!.apiKey!;
+    final sk = collectSkKeys(oneShot);
+    if (sk.isNotEmpty) return sk.first;
+    if (looksLikeSecretToken(oneShot) || looksLikePlainApiKey(oneShot)) {
+      return cleanToken(oneShot);
+    }
+  }
+  return trimmed;
+}
+
+String? guessNameFromFreeText(String text) {
+  var cleaned = text
+      .replaceAllMapped(_markdownLinkRe, (m) => ' ${m.group(1)} ')
+      .replaceAll(_skBase64Re, ' ')
+      .replaceAll(_base64TokenRe, ' ')
+      .replaceAll(_schemeUrlRe, ' ')
+      .replaceAll(_skKeyRe, ' ');
+  cleaned = cleaned.replaceAll(
+    RegExp(
+      r'(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}\d*',
+    ),
+    ' ',
+  );
+  cleaned = cleaned.replaceAll(RegExp(r'\s+'), ' ').trim();
+  final match = RegExp(
+    r'\b([A-Z][A-Za-z0-9._+]{0,40}API)\s*[-–—]\s*([A-Za-z][A-Za-z0-9 ._+]{0,60}?(?:API Gateway|Gateway|Proxy|Relay))\b',
+  ).firstMatch(cleaned);
+  if (match == null) return null;
+  final name = ('${match.group(1)} - ${match.group(2)}')
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .trim();
+  if (name.length < 3 || name.length > 64) return null;
+  return name;
+}
+
+CcswitchCredentials parseOnce(String text) {
+  String? baseUrl;
+  String? apiKey;
+  String? name;
+
+  final jsonPart = tryParseJson(text);
+  if (jsonPart != null) {
+    baseUrl = jsonPart.baseUrl;
+    apiKey = jsonPart.apiKey;
+    name = jsonPart.name;
+  }
+
+  final mdLinks = extractMarkdownLinks(text);
+  if (mdLinks.isNotEmpty) {
+    baseUrl ??= normalizeBaseUrl(mdLinks.first.url);
+    if (mdLinks.first.name.isNotEmpty) name ??= mdLinks.first.name;
+  }
+
+  final labeledUrl = firstMatch(_labeledUrlRe, text);
+  if (labeledUrl != null) {
+    final unwrapped = stripMarkdownWrapper(labeledUrl);
+    if (looksLikeUrl(unwrapped)) baseUrl ??= normalizeBaseUrl(unwrapped);
+  }
+
+  final labeledKey = firstMatch(_labeledKeyRe, text);
+  if (labeledKey != null) apiKey ??= stripMarkdownWrapper(labeledKey);
+
+  final labeledName = firstMatch(_labeledNameRe, text);
+  if (labeledName != null) name ??= labeledName;
+
+  final urls = collectUrls(text);
+  if (baseUrl == null && urls.isNotEmpty) {
+    baseUrl = normalizeBaseUrl(urls.first);
+  }
+
+  if (apiKey == null) {
+    for (final u in urls) {
+      final queryKey = extractQueryKey(u);
+      if (queryKey != null) {
+        apiKey = queryKey;
+        break;
+      }
+    }
+  }
+  if (apiKey == null) {
+    final bearer = firstMatch(_bearerKeyRe, text);
+    if (bearer != null) apiKey = bearer;
+  }
+  if (apiKey == null) {
+    final sk = collectSkKeys(text);
+    if (sk.isNotEmpty) apiKey = sk.first;
+  }
+  if (apiKey == null) {
+    final decodedKey = collectDecodedBase64Keys(text);
+    if (decodedKey.isNotEmpty) apiKey = decodedKey.first;
+  }
+  if (apiKey == null) {
+    final plainKey = collectPlainKeys(text);
+    if (plainKey.isNotEmpty) apiKey = plainKey.first;
+  }
+
+  if (baseUrl == null || apiKey == null) {
+    final lines = text
+        .split(RegExp(r'\r?\n'))
+        .map(cleanToken)
+        .where((line) => line.isNotEmpty);
+    for (final line in lines) {
+      final md = extractMarkdownLinks(line);
+      if (md.isNotEmpty) {
+        baseUrl ??= normalizeBaseUrl(md.first.url);
+        if (name == null && md.first.name.isNotEmpty) name = md.first.name;
+        continue;
+      }
+      final lineUrlLabeled = firstMatch(_labeledUrlRe, line);
+      if (baseUrl == null && lineUrlLabeled != null) {
+        final unwrapped = stripMarkdownWrapper(lineUrlLabeled);
+        if (looksLikeUrl(unwrapped)) {
+          baseUrl = normalizeBaseUrl(unwrapped);
+          continue;
+        }
+      }
+      final lineKeyLabeled = firstMatch(_labeledKeyRe, line);
+      if (apiKey == null && lineKeyLabeled != null) {
+        apiKey = stripMarkdownWrapper(lineKeyLabeled);
+        continue;
+      }
+      if (baseUrl == null && looksLikeUrl(line)) {
+        baseUrl = normalizeBaseUrl(line);
+        continue;
+      }
+      if (apiKey == null && looksLikeSkKey(line)) {
+        apiKey = line;
+        continue;
+      }
+      if (apiKey == null) {
+        final decodedKeys = collectDecodedBase64Keys(line);
+        if (decodedKeys.isNotEmpty) {
+          apiKey = decodedKeys.first;
+          continue;
+        }
+      }
+      if (apiKey == null &&
+          looksLikeBase64Blob(line) &&
+          !looksLikeUrl(line) &&
+          line.length >= 16) {
+        apiKey = line;
+        continue;
+      }
+      if (apiKey == null && looksLikePlainApiKey(line)) {
+        apiKey = line;
+      }
+    }
+  }
+
+  name ??= guessNameFromFreeText(text);
+  return CcswitchCredentials(baseUrl: baseUrl, apiKey: apiKey, name: name);
+}
+
+/// Partial parse: returns credentials if either baseUrl or apiKey is found.
+CcswitchCredentials? parseNewApiClipboardPartial(String? rawText) {
+  if (rawText == null || rawText.trim().isEmpty) return null;
+  final candidates = <String>[rawText.trim()];
+  final wholeDecoded = tryDecodeBase64Candidate(rawText);
+  if (wholeDecoded != null && wholeDecoded != rawText.trim()) {
+    candidates.add(wholeDecoded);
+  }
+  String? baseUrl;
+  String? apiKey;
+  String? name;
+  for (final candidate in candidates) {
+    final parsed = parseOnce(candidate);
+    baseUrl ??= parsed.baseUrl;
+    apiKey ??= parsed.apiKey;
+    name ??= parsed.name;
+    if (baseUrl != null && apiKey != null) break;
+  }
+  if (baseUrl == null && apiKey == null) return null;
+  return CcswitchCredentials(
+    baseUrl: baseUrl != null ? normalizeBaseUrl(baseUrl) : null,
+    apiKey: apiKey != null ? decodeApiKeyIfNeeded(apiKey) : null,
+    name: name?.trim().isNotEmpty == true ? name!.trim() : null,
+  );
+}
+
+/// Full parse: requires both baseUrl and apiKey.
+CcswitchCredentials? parseNewApiClipboard(String? rawText) {
+  final partial = parseNewApiClipboardPartial(rawText);
+  if (partial == null || !partial.isComplete) return null;
+  return CcswitchCredentials(
+    baseUrl: partial.baseUrl,
+    apiKey: partial.apiKey,
+    name: partial.name,
+  );
+}
+
+/// Convert Discourse cooked HTML to plain text for credential scanning.
+String cookedHtmlToCredentialText(String html) {
+  var text = html
+      .replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n')
+      .replaceAll(RegExp(r'<p[^>]*>', caseSensitive: false), '\n')
+      .replaceAll('</p>', '\n')
+      .replaceAll(RegExp(r'<li[^>]*>', caseSensitive: false), '- ')
+      .replaceAll('</li>', '\n')
+      .replaceAll(RegExp(r'<code[^>]*>', caseSensitive: false), '')
+      .replaceAll('</code>', '')
+      .replaceAll(RegExp(r'<pre[^>]*>', caseSensitive: false), '\n')
+      .replaceAll('</pre>', '\n')
+      .replaceAll('&nbsp;', ' ')
+      .replaceAll('&amp;', '&')
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .replaceAll('&quot;', '"')
+      .replaceAll('&#39;', "'");
+  text = text.replaceAll(RegExp(r'<[^>]+>'), '');
+  text = text.replaceAll(RegExp(r'\n{3,}'), '\n\n');
+  return text.trim();
+}
+
+CcswitchCredentials? detectCredentialsFromCooked(String? cookedHtml) {
+  if (cookedHtml == null || cookedHtml.trim().isEmpty) return null;
+  return parseNewApiClipboardPartial(cookedHtmlToCredentialText(cookedHtml));
+}
+
+String maskApiKey(String? key) {
+  if (key == null || key.isEmpty) return '';
+  if (key.length <= 12) return key;
+  return '${key.substring(0, 6)}…${key.substring(key.length - 4)}';
+}
+
+String defaultProviderName(
+  CcswitchCredentials credentials, {
+  DateTime? now,
+}) {
+  final t = now ?? DateTime.now();
+  final stamp =
+      '${t.month}月${t.day}日 ${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+  if (credentials.name != null && credentials.name!.trim().isNotEmpty) {
+    return '$stamp ${credentials.name!.trim()}';
+  }
+  return '$stamp ${credentials.baseUrl ?? ''}';
+}
+
+String utf8ToBase64(String text) {
+  return base64Encode(utf8.encode(text));
+}
+
+Map<String, dynamic>? buildProviderConfig(
+  CcswitchImportApp app,
+  CcswitchCredentials credentials, {
+  String? name,
+}) {
+  final models = kCcswitchDefaultModels[app.name] ?? const <String, String>{};
+  final endpoint = credentials.baseUrl;
+  final apiKey = credentials.apiKey;
+  if (endpoint == null || apiKey == null) return null;
+
+  switch (app) {
+    case CcswitchImportApp.claude:
+      return {
+        'env': {
+          'ANTHROPIC_AUTH_TOKEN': apiKey,
+          'ANTHROPIC_BASE_URL': endpoint,
+          'ANTHROPIC_MODEL': models['model'],
+          'ANTHROPIC_DEFAULT_HAIKU_MODEL': models['haikuModel'],
+          'ANTHROPIC_DEFAULT_SONNET_MODEL': models['sonnetModel'],
+          'ANTHROPIC_DEFAULT_OPUS_MODEL': models['opusModel'],
+        },
+      };
+    case CcswitchImportApp.codex:
+      final providerName =
+          jsonEncode(name ?? defaultProviderName(credentials));
+      final model = jsonEncode(models['model'] ?? 'gpt-5.5');
+      final baseUrl =
+          jsonEncode((endpoint).replaceAll(RegExp(r'/+$'), ''));
+      final configToml = 'model_provider = "custom"\n'
+          'model = $model\n'
+          'model_reasoning_effort = "high"\n'
+          'disable_response_storage = true\n\n'
+          '[model_providers.custom]\n'
+          'name = $providerName\n'
+          'base_url = $baseUrl\n'
+          'wire_api = "responses"\n'
+          'requires_openai_auth = true\n';
+      return {
+        'auth': {'OPENAI_API_KEY': apiKey},
+        'config': configToml,
+      };
+    case CcswitchImportApp.gemini:
+      return {
+        'GEMINI_API_KEY': apiKey,
+        'GOOGLE_GEMINI_BASE_URL': endpoint,
+        'GEMINI_MODEL': models['model'],
+      };
+    case CcswitchImportApp.all:
+      return null;
+  }
+}
+
+/// Build official `ccswitch://v1/import` deeplink for a single app.
+String buildCcswitchDeeplink(
+  CcswitchImportApp app,
+  CcswitchCredentials credentials, {
+  String? name,
+  String? notes = '填入 CC Switch（FluxDO）',
+  bool includeNotes = true,
+  DateTime? now,
+}) {
+  assert(app != CcswitchImportApp.all, 'Use buildCcswitchDeeplinks for all');
+  final targetApp = app;
+  final models = kCcswitchDefaultModels[targetApp.name] ?? const <String, String>{};
+  final providerName =
+      name ?? defaultProviderName(credentials, now: now);
+  final params = <String, String>{
+    'resource': 'provider',
+    'app': targetApp.name,
+    'name': providerName,
+    'endpoint': credentials.baseUrl ?? '',
+    'apiKey': credentials.apiKey ?? '',
+    'homepage': credentials.baseUrl ?? '',
+  };
+  final model = models['model'];
+  if (model != null && model.isNotEmpty) params['model'] = model;
+  if (targetApp == CcswitchImportApp.claude) {
+    final haiku = models['haikuModel'];
+    final sonnet = models['sonnetModel'];
+    final opus = models['opusModel'];
+    if (haiku != null) params['haikuModel'] = haiku;
+    if (sonnet != null) params['sonnetModel'] = sonnet;
+    if (opus != null) params['opusModel'] = opus;
+  }
+  if (includeNotes && notes != null && notes.isNotEmpty) {
+    params['notes'] = notes;
+  }
+  final configObj = buildProviderConfig(
+    targetApp,
+    credentials,
+    name: providerName,
+  );
+  if (configObj != null) {
+    params['configFormat'] = 'json';
+    params['config'] = utf8ToBase64(jsonEncode(configObj));
+  }
+  final query = params.entries
+      .map(
+        (e) =>
+            '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}',
+      )
+      .join('&');
+  return 'ccswitch://v1/import?$query';
+}
+
+/// Build deeplinks for the selected app mode (expands `all`).
+List<String> buildCcswitchDeeplinks(
+  CcswitchImportApp appMode,
+  CcswitchCredentials credentials, {
+  String? name,
+  String? notes = '填入 CC Switch（FluxDO）',
+  bool includeNotes = true,
+  DateTime? now,
+}) {
+  return appMode.resolvedApps
+      .map(
+        (app) => buildCcswitchDeeplink(
+          app,
+          credentials,
+          name: name,
+          notes: notes,
+          includeNotes: includeNotes,
+          now: now,
+        ),
+      )
+      .toList(growable: false);
+}

--- a/lib/utils/ccswitch/ccswitch_launcher.dart
+++ b/lib/utils/ccswitch/ccswitch_launcher.dart
@@ -1,0 +1,230 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:win32_registry/win32_registry.dart';
+
+import '../../services/app_link_service.dart';
+
+/// Launch a `ccswitch://` deeplink as close as possible to browser behavior.
+///
+/// On Windows the protocol may be registered to a debug console build
+/// (`target\debug\cc-switch.exe`, subsystem CUI), which pops a terminal.
+/// Prefer launching the installed GUI executable directly when available.
+Future<bool> launchCcswitchDeeplink(String url) async {
+  if (url.trim().isEmpty) return false;
+
+  if (!kIsWeb && Platform.isWindows) {
+    final exe = resolveCcswitchExecutableWindows();
+    if (exe != null) {
+      try {
+        await Process.start(
+          exe,
+          [url],
+          mode: ProcessStartMode.detached,
+          runInShell: false,
+        );
+        // Best-effort: keep protocol registration pointing at the GUI build so
+        // browser imports behave the same way.
+        maybeHealCcswitchProtocolRegistration(exe);
+        return true;
+      } catch (e) {
+        debugPrint('[CCSwitch] direct launch failed: $e');
+      }
+    }
+  }
+
+  return AppLinkService.launchAppLink(url);
+}
+
+/// Resolve the preferred installed CC Switch executable on Windows.
+///
+/// Preference order:
+/// 1. `%LOCALAPPDATA%\Programs\CC Switch\cc-switch.exe`
+/// 2. Uninstall registry InstallLocation (HKCU/HKLM)
+/// 3. Protocol handler command, if it is not a debug/console build
+@visibleForTesting
+String? resolveCcswitchExecutableWindows({
+  Map<String, String>? environment,
+  bool Function(String path)? fileExists,
+  String? protocolCommand,
+  String? uninstallInstallLocation,
+}) {
+  final env = environment ?? Platform.environment;
+  final exists = fileExists ?? ((path) => File(path).existsSync());
+
+  final candidates = <String>[];
+
+  final localAppData = env['LOCALAPPDATA'];
+  if (localAppData != null && localAppData.isNotEmpty) {
+    candidates.add(
+      _joinWindowsPath(localAppData, const [
+        'Programs',
+        'CC Switch',
+        'cc-switch.exe',
+      ]),
+    );
+  }
+
+  final installLocation =
+      uninstallInstallLocation ?? _readUninstallInstallLocation();
+  if (installLocation != null && installLocation.isNotEmpty) {
+    final trimmed = installLocation.replaceAll(RegExp(r'[\\/]+$'), '');
+    candidates.add(_joinWindowsPath(trimmed, const ['cc-switch.exe']));
+  }
+
+  final command = protocolCommand ?? _readProtocolCommand();
+  final protocolExe = parseProtocolCommandExecutable(command);
+  if (protocolExe != null && !_isLikelyDebugConsoleBuild(protocolExe)) {
+    candidates.add(protocolExe);
+  }
+
+  for (final candidate in candidates) {
+    final normalized = candidate.trim();
+    if (normalized.isEmpty) continue;
+    if (exists(normalized)) return normalized;
+  }
+
+  // Last resort: protocol command even if it looks like a debug build.
+  if (protocolExe != null && exists(protocolExe)) return protocolExe;
+  return null;
+}
+
+@visibleForTesting
+String? parseProtocolCommandExecutable(String? command) {
+  if (command == null) return null;
+  final trimmed = command.trim();
+  if (trimmed.isEmpty) return null;
+
+  // "C:\Path\cc-switch.exe" "%1"
+  final quoted = RegExp(r'^"([^"]+\.exe)"', caseSensitive: false)
+      .firstMatch(trimmed);
+  if (quoted != null) return quoted.group(1);
+
+  // C:\Path\cc-switch.exe "%1"
+  final unquoted = RegExp(r'^([^\s"]+\.exe)\b', caseSensitive: false)
+      .firstMatch(trimmed);
+  return unquoted?.group(1);
+}
+
+@visibleForTesting
+bool isLikelyDebugConsoleBuild(String path) => _isLikelyDebugConsoleBuild(path);
+
+bool _isLikelyDebugConsoleBuild(String path) {
+  final normalized = path.replaceAll('/', r'\').toLowerCase();
+  return normalized.contains(r'\target\debug\') ||
+      normalized.contains(r'\debug\cc-switch.exe');
+}
+
+void maybeHealCcswitchProtocolRegistration(String exePath) {
+  if (kIsWeb || !Platform.isWindows) return;
+  if (_isLikelyDebugConsoleBuild(exePath)) return;
+  try {
+    final current = parseProtocolCommandExecutable(_readProtocolCommand());
+    if (current != null &&
+        !_isLikelyDebugConsoleBuild(current) &&
+        _samePath(current, exePath)) {
+      return;
+    }
+    _writeProtocolCommand(exePath);
+  } catch (e) {
+    debugPrint('[CCSwitch] heal protocol registration failed: $e');
+  }
+}
+
+String? _readProtocolCommand() {
+  try {
+    final key = Registry.openPath(
+      RegistryHive.currentUser,
+      path: r'Software\Classes\ccswitch\shell\open\command',
+    );
+    try {
+      return key.getValueAsString('');
+    } finally {
+      key.close();
+    }
+  } catch (_) {
+    return null;
+  }
+}
+
+void _writeProtocolCommand(String exePath) {
+  final key = Registry.currentUser.createKey(r'Software\Classes\ccswitch');
+  try {
+    key.createValue(
+      const RegistryValue.string('', 'URL:com.ccswitch.desktop protocol'),
+    );
+    key.createValue(const RegistryValue.string('URL Protocol', ''));
+    final cmdKey = key.createKey(r'shell\open\command');
+    try {
+      cmdKey.createValue(RegistryValue.string('', '"$exePath" "%1"'));
+    } finally {
+      cmdKey.close();
+    }
+  } finally {
+    key.close();
+  }
+}
+
+String? _readUninstallInstallLocation() {
+  for (final hive in const [
+    RegistryHive.currentUser,
+    RegistryHive.localMachine,
+  ]) {
+    for (final root in const [
+      r'Software\Microsoft\Windows\CurrentVersion\Uninstall',
+      r'Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+    ]) {
+      try {
+        final parent = Registry.openPath(hive, path: root);
+        try {
+          for (final subName in parent.subkeyNames) {
+            try {
+              final sub = Registry.openPath(
+                hive,
+                path: '$root\\$subName',
+              );
+              try {
+                final displayName = sub.getValueAsString('DisplayName') ?? '';
+                if (!RegExp(r'cc\s*switch', caseSensitive: false)
+                    .hasMatch(displayName)) {
+                  continue;
+                }
+                final location = sub.getValueAsString('InstallLocation');
+                if (location != null && location.isNotEmpty) return location;
+                final icon = sub.getValueAsString('DisplayIcon');
+                final fromIcon = parseProtocolCommandExecutable(icon);
+                if (fromIcon != null) {
+                  return File(fromIcon).parent.path;
+                }
+              } finally {
+                sub.close();
+              }
+            } catch (_) {
+              // keep scanning
+            }
+          }
+        } finally {
+          parent.close();
+        }
+      } catch (_) {
+        // try next root/hive
+      }
+    }
+  }
+  return null;
+}
+
+String _joinWindowsPath(String root, List<String> parts) {
+  final buf = StringBuffer(root.replaceAll('/', r'\'));
+  for (final part in parts) {
+    final current = buf.toString();
+    if (!current.endsWith(r'\')) buf.write(r'\');
+    buf.write(part);
+  }
+  return buf.toString();
+}
+
+bool _samePath(String a, String b) {
+  return a.replaceAll('/', r'\').toLowerCase() ==
+      b.replaceAll('/', r'\').toLowerCase();
+}

--- a/lib/widgets/post/ccswitch/ccswitch_import_bar.dart
+++ b/lib/widgets/post/ccswitch/ccswitch_import_bar.dart
@@ -1,0 +1,372 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:app_icons/app_icons.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../l10n/s.dart';
+import '../../../models/topic.dart';
+import '../../../providers/preferences_provider.dart';
+import '../../../services/toast_service.dart';
+import '../../../utils/ccswitch/ccswitch_credentials.dart';
+import '../../../utils/ccswitch/ccswitch_launcher.dart';
+
+/// Main-post (#1) inline bar: detect BASE URL + API Key and open CC Switch.
+///
+/// Mirrors userscript `ensureMainPostCcswitchImport` placement near the
+/// post date / floor meta area.
+class CcswitchImportBar extends ConsumerStatefulWidget {
+  final Post post;
+
+  /// Optional compact mode for tight header slots.
+  final bool compact;
+
+  const CcswitchImportBar({
+    super.key,
+    required this.post,
+    this.compact = false,
+  });
+
+  @override
+  ConsumerState<CcswitchImportBar> createState() => _CcswitchImportBarState();
+}
+
+class _CcswitchImportBarState extends ConsumerState<CcswitchImportBar> {
+  CcswitchCredentials? _credentials;
+  bool _pickerOpen = false;
+  bool _busy = false;
+  late final TextEditingController _nameController;
+  CcswitchImportApp _pickedApp = CcswitchImportApp.codex;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController();
+    _scanFromPost(silent: true);
+  }
+
+  @override
+  void didUpdateWidget(CcswitchImportBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.post.id != widget.post.id ||
+        oldWidget.post.cooked != widget.post.cooked) {
+      _scanFromPost(silent: true);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _scanFromPost({bool silent = false}) {
+    final found = detectCredentialsFromCooked(widget.post.cooked);
+    setState(() {
+      _credentials = found;
+      if (found?.name != null && found!.name!.isNotEmpty) {
+        _nameController.text = found.name!;
+      }
+    });
+    if (silent) return;
+    if (found == null) {
+      ToastService.showInfo(S.current.ccswitch_notFound);
+      return;
+    }
+    if (found.isComplete) {
+      ToastService.showSuccess(
+        S.current.ccswitch_detected(
+          found.baseUrl ?? '',
+          maskApiKey(found.apiKey),
+        ),
+      );
+    } else {
+      ToastService.showInfo(S.current.ccswitch_partial);
+    }
+  }
+
+  Future<void> _openCcSwitch() async {
+    final creds = _credentials;
+    if (creds == null || !creds.isComplete) {
+      ToastService.showInfo(S.current.ccswitch_needUrlAndKey);
+      return;
+    }
+    final appMode = _pickerOpen
+        ? _pickedApp
+        : ref.read(preferencesProvider).ccswitchImportApp;
+    final name = _nameController.text.trim().isNotEmpty
+        ? _nameController.text.trim()
+        : creds.name;
+    final withName = creds.copyWith(name: name);
+    final links = buildCcswitchDeeplinks(appMode, withName, name: name);
+
+    setState(() => _busy = true);
+    try {
+      var opened = 0;
+      for (var i = 0; i < links.length; i++) {
+        if (i > 0) await Future<void>.delayed(const Duration(milliseconds: 600));
+        final ok = await launchCcswitchDeeplink(links[i]);
+        if (ok) opened += 1;
+      }
+      if (opened == 0) {
+        ToastService.showError(S.current.ccswitch_openFailed);
+      } else {
+        ToastService.showSuccess(S.current.ccswitch_opened(opened));
+        if (mounted) setState(() => _pickerOpen = false);
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _copyDeeplink() async {
+    final creds = _credentials;
+    if (creds == null || !creds.isComplete) {
+      ToastService.showInfo(S.current.ccswitch_needUrlAndKey);
+      return;
+    }
+    final appMode = ref.read(preferencesProvider).ccswitchImportApp;
+    final name = _nameController.text.trim().isNotEmpty
+        ? _nameController.text.trim()
+        : creds.name;
+    final links = buildCcswitchDeeplinks(
+      appMode == CcswitchImportApp.all ? CcswitchImportApp.codex : appMode,
+      creds.copyWith(name: name),
+      name: name,
+    );
+    if (links.isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: links.first));
+    ToastService.showSuccess(S.current.ccswitch_linkCopied);
+  }
+
+  void _openPicker() {
+    final preferred = ref.read(preferencesProvider).ccswitchImportApp;
+    setState(() {
+      _pickedApp = preferred == CcswitchImportApp.all
+          ? CcswitchImportApp.codex
+          : preferred;
+      _pickerOpen = !_pickerOpen;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.post.postNumber != 1) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final ready = _credentials?.isComplete == true;
+    final partial = _credentials != null && !ready;
+
+    final statusColor = ready
+        ? theme.colorScheme.primary
+        : partial
+            ? theme.colorScheme.tertiary
+            : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.7);
+
+    return Material(
+      color: Colors.transparent,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              _ActionChip(
+                label: l10n.ccswitch_fill,
+                primary: true,
+                enabled: !_busy,
+                onTap: ready ? _openPicker : () {
+                  _scanFromPost();
+                  if (_credentials?.isComplete == true) {
+                    _openPicker();
+                  }
+                },
+              ),
+              if (_credentials != null)
+                Text(
+                  ready
+                      ? l10n.ccswitch_statusReady
+                      : l10n.ccswitch_statusPartial,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: statusColor,
+                    fontSize: 11,
+                  ),
+                ),
+              _ActionChip(
+                label: l10n.ccswitch_rescan,
+                onTap: _busy ? null : () => _scanFromPost(),
+              ),
+              _ActionChip(
+                label: l10n.ccswitch_copy,
+                enabled: ready && !_busy,
+                onTap: ready ? _copyDeeplink : null,
+              ),
+            ],
+          ),
+          if (_pickerOpen) ...[
+            const SizedBox(height: 8),
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest
+                    .withValues(alpha: 0.55),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: theme.colorScheme.outlineVariant.withValues(alpha: 0.6),
+                ),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.ccswitch_fill,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    l10n.ccswitch_app,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 8,
+                    children: [
+                      for (final app in const [
+                        CcswitchImportApp.claude,
+                        CcswitchImportApp.codex,
+                        CcswitchImportApp.gemini,
+                      ])
+                        ChoiceChip(
+                          label: Text(_appLabel(l10n, app)),
+                          selected: _pickedApp == app,
+                          onSelected: (_) => setState(() => _pickedApp = app),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    l10n.ccswitch_name,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  TextField(
+                    controller: _nameController,
+                    decoration: InputDecoration(
+                      isDense: true,
+                      hintText: l10n.ccswitch_nameHint,
+                      border: const OutlineInputBorder(),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 8,
+                      ),
+                    ),
+                  ),
+                  if (ready) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      '${_credentials!.baseUrl} / ${maskApiKey(_credentials!.apiKey)}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                  const SizedBox(height: 10),
+                  Row(
+                    children: [
+                      TextButton(
+                        onPressed: _busy
+                            ? null
+                            : () => setState(() => _pickerOpen = false),
+                        child: Text(l10n.common_cancel),
+                      ),
+                      const Spacer(),
+                      FilledButton.icon(
+                        onPressed: _busy ? null : _openCcSwitch,
+                        icon: _busy
+                            ? const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Symbols.open_in_new_rounded, size: 16),
+                        label: Text(l10n.ccswitch_open),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _appLabel(AppLocalizations l10n, CcswitchImportApp app) {
+    return switch (app) {
+      CcswitchImportApp.claude => l10n.ccswitch_appClaude,
+      CcswitchImportApp.codex => l10n.ccswitch_appCodex,
+      CcswitchImportApp.gemini => l10n.ccswitch_appGemini,
+      CcswitchImportApp.all => l10n.ccswitch_appAll,
+    };
+  }
+}
+
+class _ActionChip extends StatelessWidget {
+  final String label;
+  final bool primary;
+  final bool enabled;
+  final VoidCallback? onTap;
+
+  const _ActionChip({
+    required this.label,
+    this.primary = false,
+    this.enabled = true,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final effectiveOnTap = enabled ? onTap : null;
+    if (primary) {
+      return FilledButton.tonal(
+        onPressed: effectiveOnTap,
+        style: FilledButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+          minimumSize: const Size(0, 28),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          textStyle: theme.textTheme.labelSmall?.copyWith(fontSize: 11),
+        ),
+        child: Text(label),
+      );
+    }
+    return OutlinedButton(
+      onPressed: effectiveOnTap,
+      style: OutlinedButton.styleFrom(
+        visualDensity: VisualDensity.compact,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        minimumSize: const Size(0, 28),
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        textStyle: theme.textTheme.labelSmall?.copyWith(fontSize: 11),
+      ),
+      child: Text(label),
+    );
+  }
+}

--- a/lib/widgets/post/post_item/widgets/post_header_section.dart
+++ b/lib/widgets/post/post_item/widgets/post_header_section.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +19,7 @@ import '../../small_action_item.dart';
 import 'post_header.dart';
 import 'post_reply_history.dart';
 import 'post_stamp_painter.dart';
+import '../../ccswitch/ccswitch_import_bar.dart';
 
 class PostHeaderSection extends ConsumerStatefulWidget {
   final Post post;
@@ -330,6 +334,13 @@ class _PostHeaderSectionState extends ConsumerState<PostHeaderSection> {
                   ],
                 ),
               ),
+              if (!kIsWeb &&
+                  (Platform.isWindows || Platform.isMacOS) &&
+                  post.postNumber == 1 &&
+                  ref.watch(preferencesProvider).ccswitchImportEnabled) ...[
+                const SizedBox(height: 8),
+                CcswitchImportBar(post: post),
+              ],
               ValueListenableBuilder<bool>(
                 valueListenable: _showReplyHistoryNotifier,
                 builder: (context, showReplyHistory, _) {

--- a/test/providers/preferences_provider_test.dart
+++ b/test/providers/preferences_provider_test.dart
@@ -55,4 +55,82 @@ void main() {
       BookmarksOpenMode.defaultRoute,
     );
   });
+
+  group('ccswitch import enabled', () {
+    test('defaults to true', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(preferencesProvider).ccswitchImportEnabled,
+        isTrue,
+      );
+    });
+
+    test('setter persists and reloads', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+
+      await container
+          .read(preferencesProvider.notifier)
+          .setCcswitchImportEnabled(false);
+
+      final prefs = container.read(sharedPreferencesProvider);
+      final reloaded = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(reloaded.dispose);
+
+      expect(
+        reloaded.read(preferencesProvider).ccswitchImportEnabled,
+        isFalse,
+      );
+      expect(prefs.getBool('pref_ccswitch_import_enabled'), isFalse);
+    });
+  });
+
+  group('ccswitch import app', () {
+    test('defaults to codex', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(preferencesProvider).ccswitchImportApp,
+        CcswitchImportApp.codex,
+      );
+    });
+
+    test('setter persists and reloads', () async {
+      final container = await _createContainer();
+      addTearDown(container.dispose);
+
+      await container
+          .read(preferencesProvider.notifier)
+          .setCcswitchImportApp(CcswitchImportApp.claude);
+
+      final prefs = container.read(sharedPreferencesProvider);
+      final reloaded = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+      addTearDown(reloaded.dispose);
+
+      expect(
+        reloaded.read(preferencesProvider).ccswitchImportApp,
+        CcswitchImportApp.claude,
+      );
+      expect(prefs.getString('pref_ccswitch_import_app'), 'claude');
+    });
+
+    test('invalid value falls back to codex', () async {
+      final container = await _createContainer(
+        initialValues: {'pref_ccswitch_import_app': 'nope'},
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(preferencesProvider).ccswitchImportApp,
+        CcswitchImportApp.codex,
+      );
+    });
+  });
 }

--- a/test/utils/ccswitch/ccswitch_credentials_test.dart
+++ b/test/utils/ccswitch/ccswitch_credentials_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/utils/ccswitch/ccswitch_credentials.dart';
+
+void main() {
+  group('parseNewApiClipboard', () {
+    test('parses labeled url + sk key', () {
+      const text = '''
+Base URL: https://api.example.com/v1
+API Key: sk-test-key-12345678
+Name: Demo Provider
+''';
+      final creds = parseNewApiClipboard(text);
+      expect(creds, isNotNull);
+      expect(creds!.baseUrl, 'https://api.example.com/v1');
+      expect(creds.apiKey, 'sk-test-key-12345678');
+      expect(creds.name, 'Demo Provider');
+    });
+
+    test('parses free-form url and key lines', () {
+      const text = '''
+https://relay.example.org
+sk-abcdefghi1234567890
+''';
+      final creds = parseNewApiClipboard(text);
+      expect(creds, isNotNull);
+      expect(creds!.baseUrl, 'https://relay.example.org');
+      expect(creds.apiKey, 'sk-abcdefghi1234567890');
+    });
+
+    test('parses JSON env style', () {
+      const text = '''
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://claude.example.com",
+    "ANTHROPIC_AUTH_TOKEN": "sk-json-key-abcdefgh"
+  },
+  "name": "Claude Relay"
+}
+''';
+      final creds = parseNewApiClipboard(text);
+      expect(creds, isNotNull);
+      expect(creds!.baseUrl, 'https://claude.example.com');
+      expect(creds.apiKey, 'sk-json-key-abcdefgh');
+      expect(creds.name, 'Claude Relay');
+    });
+
+    test('decodes base64 sk key', () {
+      // sk-base64demo123 is base64 "c2stYmFzZTY0ZGVtbzEyMw=="
+      const text = '''
+https://api.example.com
+c2stYmFzZTY0ZGVtbzEyMw==
+''';
+      final creds = parseNewApiClipboard(text);
+      expect(creds, isNotNull);
+      expect(creds!.apiKey, 'sk-base64demo123');
+    });
+
+    test('partial when only url', () {
+      final partial = parseNewApiClipboardPartial('https://only-url.example.com');
+      expect(partial, isNotNull);
+      expect(partial!.baseUrl, 'https://only-url.example.com');
+      expect(partial.apiKey, isNull);
+      expect(parseNewApiClipboard('https://only-url.example.com'), isNull);
+    });
+
+    test('detects from cooked HTML', () {
+      const html = '''
+<p>endpoint: https://html.example.com/v1</p>
+<code>sk-htmlkey-12345678</code>
+''';
+      final creds = detectCredentialsFromCooked(html);
+      expect(creds, isNotNull);
+      expect(creds!.isComplete, isTrue);
+      expect(creds.baseUrl, 'https://html.example.com/v1');
+      expect(creds.apiKey, 'sk-htmlkey-12345678');
+    });
+  });
+
+  group('deeplink', () {
+    test('builds ccswitch provider deeplink', () {
+      const creds = CcswitchCredentials(
+        baseUrl: 'https://api.example.com',
+        apiKey: 'sk-test-key-12345678',
+        name: 'Demo',
+      );
+      final link = buildCcswitchDeeplink(
+        CcswitchImportApp.codex,
+        creds,
+        name: 'Demo',
+        now: DateTime(2026, 1, 2, 3, 4),
+      );
+      expect(link.startsWith('ccswitch://v1/import?'), isTrue);
+      expect(link.contains('resource=provider'), isTrue);
+      expect(link.contains('app=codex'), isTrue);
+      expect(link.contains('endpoint='), isTrue);
+      expect(link.contains('apiKey='), isTrue);
+      expect(link.contains('configFormat=json'), isTrue);
+      expect(link.contains('config='), isTrue);
+    });
+
+    test('all mode expands to three apps', () {
+      const creds = CcswitchCredentials(
+        baseUrl: 'https://api.example.com',
+        apiKey: 'sk-test-key-12345678',
+      );
+      final links = buildCcswitchDeeplinks(CcswitchImportApp.all, creds);
+      expect(links, hasLength(3));
+      expect(links[0].contains('app=claude'), isTrue);
+      expect(links[1].contains('app=codex'), isTrue);
+      expect(links[2].contains('app=gemini'), isTrue);
+    });
+
+    test('maskApiKey hides middle', () {
+      expect(maskApiKey('sk-1234567890abcd'), 'sk-123…abcd');
+    });
+  });
+}

--- a/test/utils/ccswitch/ccswitch_launcher_test.dart
+++ b/test/utils/ccswitch/ccswitch_launcher_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/utils/ccswitch/ccswitch_launcher.dart';
+
+void main() {
+  group('parseProtocolCommandExecutable', () {
+    test('parses quoted command', () {
+      expect(
+        parseProtocolCommandExecutable(
+          r'"C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe" "%1"',
+        ),
+        r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+      );
+    });
+
+    test('parses unquoted command', () {
+      expect(
+        parseProtocolCommandExecutable(r'C:\Apps\cc-switch.exe %1'),
+        r'C:\Apps\cc-switch.exe',
+      );
+    });
+
+    test('returns null for empty', () {
+      expect(parseProtocolCommandExecutable(null), isNull);
+      expect(parseProtocolCommandExecutable(''), isNull);
+    });
+  });
+
+  group('isLikelyDebugConsoleBuild', () {
+    test('detects cargo debug target', () {
+      expect(
+        isLikelyDebugConsoleBuild(
+          r'D:\CCSWITCH\src-tauri\target\debug\cc-switch.exe',
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts installed GUI path', () {
+      expect(
+        isLikelyDebugConsoleBuild(
+          r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('resolveCcswitchExecutableWindows', () {
+    test('prefers installed LocalAppData path over debug protocol', () {
+      final resolved = resolveCcswitchExecutableWindows(
+        environment: {
+          'LOCALAPPDATA': r'C:\Users\demo\AppData\Local',
+        },
+        fileExists: (path) =>
+            path ==
+            r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+        protocolCommand:
+            r'"D:\CCSWITCH\src-tauri\target\debug\cc-switch.exe" "%1"',
+      );
+      expect(
+        resolved,
+        r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+      );
+    });
+
+    test('falls back to uninstall install location', () {
+      final resolved = resolveCcswitchExecutableWindows(
+        environment: const {},
+        uninstallInstallLocation:
+            r'C:\Users\demo\AppData\Local\Programs\CC Switch\',
+        fileExists: (path) =>
+            path ==
+            r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+        protocolCommand:
+            r'"D:\CCSWITCH\src-tauri\target\debug\cc-switch.exe" "%1"',
+      );
+      expect(
+        resolved,
+        r'C:\Users\demo\AppData\Local\Programs\CC Switch\cc-switch.exe',
+      );
+    });
+
+    test('uses non-debug protocol command when install missing', () {
+      final resolved = resolveCcswitchExecutableWindows(
+        environment: const {},
+        fileExists: (path) =>
+            path == r'C:\Program Files\CC Switch\cc-switch.exe',
+        protocolCommand: r'"C:\Program Files\CC Switch\cc-switch.exe" "%1"',
+      );
+      expect(resolved, r'C:\Program Files\CC Switch\cc-switch.exe');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Detect BASE URL + API key in the first floor (`postNumber == 1`) and show a **Fill CC Switch** bar under the post header.
- Build official `ccswitch://v1/import` deeplinks for Claude / Codex / Gemini (or all three).
- Add Reading settings (Windows / macOS only):
  - **CC Switch import** master switch (default on)
  - **CC Switch import app** picker (default Codex)
- On Windows, prefer launching the installed GUI `cc-switch.exe` directly so a debug/CUI protocol registration does not flash a terminal.

## Motivation
Many OP posts share API base URLs and keys. This ports the userscript-style one-click fill into FluxDO, while keeping mobile platforms free of the UI.

## Settings
`Settings → Reading`
1. CC Switch import
2. CC Switch import app

## Platform
- UI + settings: **Windows / macOS only**
- Windows launch order: `%LOCALAPPDATA%\Programs\CC Switch\cc-switch.exe` → uninstall InstallLocation → non-debug protocol handler → protocol fallback
- macOS: protocol launch

## Test plan
- [x] `flutter test test/utils/ccswitch/ccswitch_credentials_test.dart test/utils/ccswitch/ccswitch_launcher_test.dart test/providers/preferences_provider_test.dart`
- [ ] Open an OP post with BASE URL + API key on Windows; confirm import bar appears
- [ ] Toggle off **CC Switch import** in Reading settings; bar disappears
- [ ] Open / copy deeplink; Windows should start installed GUI without a terminal flash
- [ ] macOS protocol open (if available)

## Notes
- API keys are masked in the UI.
- Does not change the CC Switch app itself; only consumes the public deeplink contract.