### PR TITLE
fix:内容与媒体功能

### DIFF
--- a/lib/l10n/modules/ai/ai_en.arb
+++ b/lib/l10n/modules/ai/ai_en.arb
@@ -221,6 +221,8 @@
   "ai_translationModelNotSelected": "Not selected (default text model will be used)",
   "ai_translationEnabled": "AI translation",
   "ai_translationEnabledDesc": "Show a Translate entry in the post menu, translating post content with the selected AI model",
+  "ai_translationTruncated": "Content is too long; only the beginning was translated",
+  "ai_translationStopped": "Translation stopped",
   "ai_tokenUsage": "Input {prompt} · Output {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_en.arb
+++ b/lib/l10n/modules/ai/ai_en.arb
@@ -209,6 +209,18 @@
   "ai_quickPromptsManageSubtitle": "Manage the quick prompts at the bottom of the AI assistant — add, edit, pin, reorder",
   "ai_quickPromptsValidateNameRequired": "Please enter a name",
   "ai_quickPromptsValidateTemplateRequired": "Please enter a prompt template",
+  "ai_translationTitle": "AI Translation",
+  "ai_translationMenuLabel": "Translate",
+  "ai_translationNoModel": "No AI model available. Configure a provider in AI settings first",
+  "ai_translationNoApiKey": "Failed to read the API key for this AI provider. Please reconfigure it",
+  "ai_translationEmptyContent": "Nothing to translate",
+  "ai_translationFailed": "Translation failed. Please try again later",
+  "ai_translationTargetLanguage": "Target language",
+  "ai_translationTargetLanguageFollowApp": "Follow app language",
+  "ai_translationModel": "Translation model",
+  "ai_translationModelNotSelected": "Not selected (default text model will be used)",
+  "ai_translationEnabled": "AI translation",
+  "ai_translationEnabledDesc": "Show a Translate entry in the post menu, translating post content with the selected AI model",
   "ai_tokenUsage": "Input {prompt} · Output {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh.arb
+++ b/lib/l10n/modules/ai/ai_zh.arb
@@ -230,6 +230,18 @@
   "ai_quickPromptsManageSubtitle": "管理 AI 助手底部的快捷词，可增删改、Pin、调顺序",
   "ai_quickPromptsValidateNameRequired": "请输入名称",
   "ai_quickPromptsValidateTemplateRequired": "请输入 prompt 模板",
+  "ai_translationTitle": "AI 翻译",
+  "ai_translationMenuLabel": "翻译",
+  "ai_translationNoModel": "没有可用的 AI 模型，请先在 AI 设置中配置提供商",
+  "ai_translationNoApiKey": "无法读取该 AI 提供商的 API Key，请重新配置",
+  "ai_translationEmptyContent": "没有可翻译的内容",
+  "ai_translationFailed": "翻译失败，请稍后重试",
+  "ai_translationTargetLanguage": "翻译目标语言",
+  "ai_translationTargetLanguageFollowApp": "跟随应用语言",
+  "ai_translationModel": "翻译模型",
+  "ai_translationModelNotSelected": "未选择（将使用默认文本模型）",
+  "ai_translationEnabled": "AI 翻译",
+  "ai_translationEnabledDesc": "在帖子菜单中显示「翻译」入口，使用所选 AI 模型翻译帖子内容",
   "ai_tokenUsage": "输入 {prompt} · 输出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh.arb
+++ b/lib/l10n/modules/ai/ai_zh.arb
@@ -242,6 +242,8 @@
   "ai_translationModelNotSelected": "未选择（将使用默认文本模型）",
   "ai_translationEnabled": "AI 翻译",
   "ai_translationEnabledDesc": "在帖子菜单中显示「翻译」入口，使用所选 AI 模型翻译帖子内容",
+  "ai_translationTruncated": "内容过长，仅翻译开头部分",
+  "ai_translationStopped": "已停止翻译",
   "ai_tokenUsage": "输入 {prompt} · 输出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh_HK.arb
+++ b/lib/l10n/modules/ai/ai_zh_HK.arb
@@ -242,6 +242,8 @@
   "ai_translationModelNotSelected": "未選擇（將使用默認文本模型）",
   "ai_translationEnabled": "AI 翻譯",
   "ai_translationEnabledDesc": "在帖子菜單中顯示「翻譯」入口，使用所選 AI 模型翻譯帖子內容",
+  "ai_translationTruncated": "內容過長，僅翻譯開頭部分",
+  "ai_translationStopped": "已停止翻譯",
   "ai_tokenUsage": "輸入 {prompt} · 輸出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh_HK.arb
+++ b/lib/l10n/modules/ai/ai_zh_HK.arb
@@ -230,6 +230,18 @@
   "ai_quickPromptsManageSubtitle": "管理 AI 助手底部的快捷詞，可增刪改、Pin、調順序",
   "ai_quickPromptsValidateNameRequired": "請輸入名稱",
   "ai_quickPromptsValidateTemplateRequired": "請輸入 prompt 模板",
+  "ai_translationTitle": "AI 翻譯",
+  "ai_translationMenuLabel": "翻譯",
+  "ai_translationNoModel": "沒有可用的 AI 模型，請先在 AI 設置中配置提供商",
+  "ai_translationNoApiKey": "無法讀取該 AI 提供商的 API Key，請重新配置",
+  "ai_translationEmptyContent": "沒有可翻譯的內容",
+  "ai_translationFailed": "翻譯失敗，請稍後重試",
+  "ai_translationTargetLanguage": "翻譯目標語言",
+  "ai_translationTargetLanguageFollowApp": "跟隨應用語言",
+  "ai_translationModel": "翻譯模型",
+  "ai_translationModelNotSelected": "未選擇（將使用默認文本模型）",
+  "ai_translationEnabled": "AI 翻譯",
+  "ai_translationEnabledDesc": "在帖子菜單中顯示「翻譯」入口，使用所選 AI 模型翻譯帖子內容",
   "ai_tokenUsage": "輸入 {prompt} · 輸出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh_TW.arb
+++ b/lib/l10n/modules/ai/ai_zh_TW.arb
@@ -230,6 +230,18 @@
   "ai_quickPromptsManageSubtitle": "管理 AI 助手底部的快捷詞，可增刪改、Pin、調順序",
   "ai_quickPromptsValidateNameRequired": "請輸入名稱",
   "ai_quickPromptsValidateTemplateRequired": "請輸入 prompt 範本",
+  "ai_translationTitle": "AI 翻譯",
+  "ai_translationMenuLabel": "翻譯",
+  "ai_translationNoModel": "沒有可用的 AI 模型，請先在 AI 設定中設定提供者",
+  "ai_translationNoApiKey": "無法讀取該 AI 提供者的 API Key，請重新設定",
+  "ai_translationEmptyContent": "沒有可翻譯的內容",
+  "ai_translationFailed": "翻譯失敗，請稍後再試",
+  "ai_translationTargetLanguage": "翻譯目標語言",
+  "ai_translationTargetLanguageFollowApp": "跟隨應用程式語言",
+  "ai_translationModel": "翻譯模型",
+  "ai_translationModelNotSelected": "未選擇（將使用預設文字模型）",
+  "ai_translationEnabled": "AI 翻譯",
+  "ai_translationEnabledDesc": "在貼文選單中顯示「翻譯」入口，使用所選 AI 模型翻譯貼文內容",
   "ai_tokenUsage": "輸入 {prompt} · 輸出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/ai/ai_zh_TW.arb
+++ b/lib/l10n/modules/ai/ai_zh_TW.arb
@@ -242,6 +242,8 @@
   "ai_translationModelNotSelected": "未選擇（將使用預設文字模型）",
   "ai_translationEnabled": "AI 翻譯",
   "ai_translationEnabledDesc": "在貼文選單中顯示「翻譯」入口，使用所選 AI 模型翻譯貼文內容",
+  "ai_translationTruncated": "內容過長，僅翻譯開頭部分",
+  "ai_translationStopped": "已停止翻譯",
   "ai_tokenUsage": "輸入 {prompt} · 輸出 {response}",
   "@ai_tokenUsage": {
     "placeholders": {

--- a/lib/l10n/modules/appearance/appearance_en.arb
+++ b/lib/l10n/modules/appearance/appearance_en.arb
@@ -87,6 +87,8 @@
   "reading_boostDanmakuDesc": "Overlay Boosts on top of post content as scrolling danmaku. Pauses on touch.",
   "reading_expandRelatedLinks": "Expand related links by default",
   "reading_expandRelatedLinksDesc": "Show related links expanded in posts",
+  "reading_adaptiveSignatureFrameRate": "Adaptive signature frame rate",
+  "reading_adaptiveSignatureFrameRateDesc": "Dynamically reduce animated SVG frame rate while scrolling or under load to prevent stutter",
   "reading_showSignatures": "Show user signatures",
   "reading_showSignaturesDesc": "Display user signatures below post content",
   "reading_title": "Reading Settings",

--- a/lib/l10n/modules/appearance/appearance_zh.arb
+++ b/lib/l10n/modules/appearance/appearance_zh.arb
@@ -87,6 +87,8 @@
   "reading_boostDanmakuDesc": "把 Boost 以弹幕形式叠加在帖子内容上方滚动，触摸暂停",
   "reading_expandRelatedLinks": "默认展开相关链接",
   "reading_expandRelatedLinksDesc": "帖子中的相关链接区域默认展开显示",
+  "reading_adaptiveSignatureFrameRate": "小尾巴自适应帧率",
+  "reading_adaptiveSignatureFrameRateDesc": "根据滚动和设备负载动态降低动画 SVG 帧率，减少卡顿",
   "reading_showSignatures": "显示用户签名",
   "reading_showSignaturesDesc": "在帖子内容下方显示用户签名",
   "reading_title": "阅读设置",

--- a/lib/l10n/modules/appearance/appearance_zh_HK.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_HK.arb
@@ -87,6 +87,8 @@
   "reading_boostDanmakuDesc": "把 Boost 以彈幕形式疊加喺帖子內容上方滾動，觸碰暫停",
   "reading_expandRelatedLinks": "預設展開相關鏈接",
   "reading_expandRelatedLinksDesc": "帖子中的相關鏈接區域預設展開顯示",
+  "reading_adaptiveSignatureFrameRate": "小尾巴自適應幀率",
+  "reading_adaptiveSignatureFrameRateDesc": "根據滾動和裝置負載動態降低動畫 SVG 幀率，減少卡頓",
   "reading_showSignatures": "顯示用户簽名",
   "reading_showSignaturesDesc": "在帖子內容下方顯示用户簽名",
   "reading_title": "閱讀設定",

--- a/lib/l10n/modules/appearance/appearance_zh_TW.arb
+++ b/lib/l10n/modules/appearance/appearance_zh_TW.arb
@@ -87,6 +87,8 @@
   "reading_boostDanmakuDesc": "把 Boost 以彈幕形式疊加在帖子內容上方滾動，觸控暫停",
   "reading_expandRelatedLinks": "預設展開相關連結",
   "reading_expandRelatedLinksDesc": "帖子中的相關連結區域預設展開顯示",
+  "reading_adaptiveSignatureFrameRate": "小尾巴自適應幀率",
+  "reading_adaptiveSignatureFrameRateDesc": "依滾動和裝置負載動態降低動畫 SVG 幀率，減少卡頓",
   "reading_showSignatures": "顯示使用者簽名",
   "reading_showSignaturesDesc": "在帖子內容下方顯示使用者簽名",
   "reading_title": "閱讀設定",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -86,6 +86,7 @@ import 'providers/preferences_provider.dart';
 import 'providers/theme_provider.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:just_audio_media_kit/just_audio_media_kit.dart';
+import 'services/audio/just_audio_gst.dart';
 import 'widgets/preheat_gate.dart';
 import 'widgets/onboarding_gate.dart';
 import 'widgets/layout/adaptive_scaffold.dart';
@@ -143,9 +144,16 @@ Future<void> main() async {
   // 见 image_decode_gate.dart)。
   FluxdoWidgetsBinding.ensureInitialized();
 
-  // just_audio 不自带 Windows/Linux 实现。必须在创建 AudioPlayer 前注册
-  // MediaKit 后端，否则会落回不存在的 MethodChannel 实现。
-  JustAudioMediaKit.ensureInitialized();
+  // just_audio 不自带 Windows/Linux 实现,必须在创建 AudioPlayer 前注册
+  // 后端,否则会落回不存在的 MethodChannel 实现。两平台后端不同:
+  // - Windows: MediaKit(libmpv-2.dll 随 media_kit_libs_windows_audio 打包);
+  // - Linux: GStreamer 桥(见 just_audio_gst.dart 注释,flatpak 禁网沙箱
+  //   与 GNOME runtime 均不容纳 mpv 方案)。
+  if (!kIsWeb && Platform.isLinux) {
+    JustAudioGst.registerWith();
+  } else {
+    JustAudioMediaKit.ensureInitialized(linux: false);
+  }
 
   // Rust 动图管线的首帧(挂载瞬态的裸 RGBA 上传,不经 binding)注入
   // 同一个闸门,与标准路径统一错峰;播放中的后续帧不过闸。

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,6 +85,7 @@ import 'services/network/adapters/platform_adapter.dart';
 import 'providers/preferences_provider.dart';
 import 'providers/theme_provider.dart';
 import 'package:dynamic_color/dynamic_color.dart';
+import 'package:just_audio_media_kit/just_audio_media_kit.dart';
 import 'widgets/preheat_gate.dart';
 import 'widgets/onboarding_gate.dart';
 import 'widgets/layout/adaptive_scaffold.dart';
@@ -141,6 +142,10 @@ Future<void> main() async {
   // Impeller 纹理上传并发,图密话题快滚 raster 尖峰的对症闸门,
   // 见 image_decode_gate.dart)。
   FluxdoWidgetsBinding.ensureInitialized();
+
+  // just_audio 不自带 Windows/Linux 实现。必须在创建 AudioPlayer 前注册
+  // MediaKit 后端，否则会落回不存在的 MethodChannel 实现。
+  JustAudioMediaKit.ensureInitialized();
 
   // Rust 动图管线的首帧(挂载瞬态的裸 RGBA 上传,不经 binding)注入
   // 同一个闸门,与标准路径统一错峰;播放中的后续帧不过闸。

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -522,6 +522,11 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       return;
     }
     if (widget.embeddedMode) {
+      // 嵌入模式只有书签页移动端 chrome 会传 onEmbeddedBack;桌面双栏
+      // 下它是 null,此时 Esc 落到这里是刻意的空操作:scope 回调没有
+      // 「未处理」语义(分发端 containsKey 即消费),又不能不注册 ——
+      // 上面退搜索/回正文正是嵌入模式需要的。也不能落到 maybePop:
+      // 嵌入面板不是独立路由,pop 的会是宿主页面(如整个书签页)。
       widget.onEmbeddedBack?.call();
       return;
     }

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -6,6 +6,7 @@ import '../../services/notion/notion_bookmark_auto_sync.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderSliver, RenderViewport;
 import 'package:flutter/scheduler.dart' show SchedulerBinding, Priority;
+import 'package:flutter/services.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
@@ -195,7 +196,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   bool _defaultNestedViewApplied = false; // 默认嵌套视图配置是否已应用（依赖 detail 加载后判定）
   // 搜索相关
   final TextEditingController _searchController = TextEditingController();
-  final FocusNode _searchFocusNode = FocusNode();
+  late final FocusNode _searchFocusNode;
   late final AnimationController _expandController;
   late final Animation<Offset> _animation;
   Set<int> _lastReadPostNumbers = {};
@@ -259,6 +260,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     WidgetsBinding.instance.addObserver(this);
     _isParentActive = widget.parentActive;
     _providerPostNumber = widget.scrollToPostNumber;
+    _searchFocusNode = FocusNode(onKeyEvent: _handleSearchKeyEvent);
 
     _expandController = AnimationController(
       vsync: this,
@@ -488,15 +490,51 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         unawaited(_handleDeletePost(post));
       },
     };
-    final registeredShortcuts = widget.embeddedMode
-        ? shortcuts
-        : {
-            ...shortcuts,
-            ShortcutAction.closeOverlay: () {
-              if (mounted) Navigator.of(context).maybePop();
-            },
-          };
+    // Esc 优先退出页内搜索/AI，再按当前布局执行嵌入返回或路由返回。
+    final registeredShortcuts = {
+      ...shortcuts,
+      ShortcutAction.closeOverlay: _handleCloseShortcut,
+    };
     _shortcutScopeBinding.register(context, registeredShortcuts);
+  }
+
+  void _exitSearchMode() {
+    _searchController.clear();
+    ref.read(topicSearchProvider(widget.topicId).notifier).exitSearchMode();
+  }
+
+  void _returnFromAiPage() {
+    _pageController.animateToPage(
+      0,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  void _handleCloseShortcut() {
+    if (!mounted) return;
+    if (ref.read(topicSearchProvider(widget.topicId)).isSearchMode) {
+      _exitSearchMode();
+      return;
+    }
+    if (_currentPageNotifier.value != 0) {
+      _returnFromAiPage();
+      return;
+    }
+    if (widget.embeddedMode) {
+      widget.onEmbeddedBack?.call();
+      return;
+    }
+    Navigator.of(context).maybePop();
+  }
+
+  KeyEventResult _handleSearchKeyEvent(FocusNode _, KeyEvent event) {
+    if (event is! KeyDownEvent ||
+        event.logicalKey != LogicalKeyboardKey.escape) {
+      return KeyEventResult.ignored;
+    }
+    _exitSearchMode();
+    return KeyEventResult.handled;
   }
 
   void _schedulePostShortcutRegistration() {
@@ -840,12 +878,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         actions: [
           IconButton(
             icon: const Icon(Symbols.close_rounded),
-            onPressed: () {
-              _searchController.clear();
-              ref
-                  .read(topicSearchProvider(widget.topicId).notifier)
-                  .exitSearchMode();
-            },
+            onPressed: _exitSearchMode,
           ),
         ],
       );
@@ -1888,10 +1921,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           canPop: !isSearchMode,
           onPopInvokedWithResult: (bool didPop, dynamic result) {
             if (!didPop) {
-              _searchController.clear();
-              ref
-                  .read(topicSearchProvider(widget.topicId).notifier)
-                  .exitSearchMode();
+              _exitSearchMode();
             }
           },
           child: topicScaffold,
@@ -1910,16 +1940,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
             onPopInvokedWithResult: (bool didPop, dynamic result) {
               if (!didPop) {
                 if (isOnAiPage) {
-                  _pageController.animateToPage(
-                    0,
-                    duration: const Duration(milliseconds: 300),
-                    curve: Curves.easeOutCubic,
-                  );
+                  _returnFromAiPage();
                 } else {
-                  _searchController.clear();
-                  ref
-                      .read(topicSearchProvider(widget.topicId).notifier)
-                      .exitSearchMode();
+                  _exitSearchMode();
                 }
               }
             },
@@ -1946,6 +1969,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
                         topicId: widget.topicId,
                         detail: detail,
                         embedded: true,
+                        onEscape: _returnFromAiPage,
                         onReplyToTopic: detail == null
                             ? null
                             : (imageMarkdown) {

--- a/lib/pages/topic_detail_page/widgets/ai_chat_input.dart
+++ b/lib/pages/topic_detail_page/widgets/ai_chat_input.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:ai_model_manager/ai_model_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:image_picker/image_picker.dart';
 import '../../../l10n/s.dart';
@@ -21,6 +22,7 @@ class AiChatInput extends StatefulWidget {
   final bool isGenerating;
   final AiChatInputSend onSend;
   final VoidCallback onStop;
+  final VoidCallback? onEscape;
 
   /// 是否启用图片附件功能（取决于当前模型是否支持多模态）
   ///
@@ -47,6 +49,7 @@ class AiChatInput extends StatefulWidget {
     required this.isGenerating,
     required this.onSend,
     required this.onStop,
+    this.onEscape,
     this.allowAttachments = true,
     this.isImageMode = false,
     this.canEnterImageMode = false,
@@ -61,7 +64,7 @@ class AiChatInput extends StatefulWidget {
 
 class _AiChatInputState extends State<AiChatInput> {
   final _controller = TextEditingController();
-  final _focusNode = FocusNode();
+  late final FocusNode _focusNode;
   final _picker = ImagePicker();
 
   final List<AiChatAttachment> _pendingAttachments = [];
@@ -71,6 +74,22 @@ class _AiChatInputState extends State<AiChatInput> {
 
   bool get _canSend =>
       _controller.text.trim().isNotEmpty || _pendingAttachments.isNotEmpty;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(onKeyEvent: _handleKeyEvent);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode _, KeyEvent event) {
+    if (event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.escape &&
+        widget.onEscape != null) {
+      widget.onEscape!();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
 
   @override
   void dispose() {

--- a/lib/pages/topic_detail_page/widgets/ai_chat_page.dart
+++ b/lib/pages/topic_detail_page/widgets/ai_chat_page.dart
@@ -47,6 +47,9 @@ class AiChatPage extends ConsumerStatefulWidget {
   /// 回复话题回调（将 AI 回复内容预填到回复框）
   final void Function(String content)? onReplyToTopic;
 
+  /// 嵌入话题页时按 Escape 返回话题正文
+  final VoidCallback? onEscape;
+
   const AiChatPage({
     super.key,
     required this.topicId,
@@ -54,6 +57,7 @@ class AiChatPage extends ConsumerStatefulWidget {
     this.embedded = false,
     this.detail,
     this.onReplyToTopic,
+    this.onEscape,
   });
 
   @override
@@ -838,6 +842,7 @@ class _AiChatPageState extends ConsumerState<AiChatPage> {
                 );
               },
               onStop: chatNotifier.stopGeneration,
+              onEscape: widget.onEscape,
               modelButton: currentModel == null
                   ? null
                   : _ModelLogoButton(

--- a/lib/providers/ai_post_review_provider.dart
+++ b/lib/providers/ai_post_review_provider.dart
@@ -15,30 +15,40 @@ final aiPostReviewAvailableModelsProvider =
           .toList(growable: false);
     });
 
+/// 解析「providerId:modelId」偏好并回退到默认文本模型的公共逻辑。
+/// AI 审核与 AI 翻译共用,仅偏好 key 不同:显式选择优先,失效(模型被
+/// 删除等)时依次回退到默认文本模型、首个可用文本模型。
+({AiProvider provider, AiModel model})? resolveSelectedTextAiModel(
+  Ref ref,
+  String? selectedKey,
+) {
+  final available = ref.watch(aiPostReviewAvailableModelsProvider);
+  if (available.isEmpty) return null;
+
+  final parsed = parseAiModelKey(selectedKey);
+  if (parsed != null) {
+    final selected = available.firstWhereOrNull(
+      (item) =>
+          item.provider.id == parsed.providerId &&
+          item.model.id == parsed.modelId,
+    );
+    if (selected != null) return selected;
+  }
+
+  final defaultTextModel = ref.watch(defaultTextAiModelProvider);
+  if (defaultTextModel != null &&
+      defaultTextModel.model.output.contains(Modality.text)) {
+    return defaultTextModel;
+  }
+  return available.first;
+}
+
 final aiPostReviewSelectedModelProvider =
     Provider<({AiProvider provider, AiModel model})?>((ref) {
       final selectedKey = ref.watch(
         preferencesProvider.select((prefs) => prefs.aiPostReviewModelKey),
       );
-      final available = ref.watch(aiPostReviewAvailableModelsProvider);
-      if (available.isEmpty) return null;
-
-      final parsed = parseAiModelKey(selectedKey);
-      if (parsed != null) {
-        final selected = available.firstWhereOrNull(
-          (item) =>
-              item.provider.id == parsed.providerId &&
-              item.model.id == parsed.modelId,
-        );
-        if (selected != null) return selected;
-      }
-
-      final defaultTextModel = ref.watch(defaultTextAiModelProvider);
-      if (defaultTextModel != null &&
-          defaultTextModel.model.output.contains(Modality.text)) {
-        return defaultTextModel;
-      }
-      return available.first;
+      return resolveSelectedTextAiModel(ref, selectedKey);
     });
 
 final aiPostReviewServiceProvider = Provider<AiPostReviewService>((ref) {

--- a/lib/providers/ai_translation_provider.dart
+++ b/lib/providers/ai_translation_provider.dart
@@ -1,0 +1,73 @@
+import 'package:ai_model_manager/ai_model_manager.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/ai_translation_service.dart';
+import 'ai_post_review_provider.dart';
+import 'locale_provider.dart';
+import 'preferences_provider.dart';
+
+/// 可选目标语言（代码 → 本语言显示名）。
+const aiTranslationLanguages = <String, String>{
+  'zh-CN': '简体中文',
+  'zh-TW': '繁體中文',
+  'en': 'English',
+  'ja': '日本語',
+  'ko': '한국어',
+  'fr': 'Français',
+  'de': 'Deutsch',
+  'es': 'Español',
+  'ru': 'Русский',
+};
+
+/// 偏好优先；未设置时跟随应用语言。
+final aiTranslationTargetLanguageProvider = Provider<String>((ref) {
+  final preferred = ref.watch(
+    preferencesProvider.select((p) => p.aiTranslationTargetLanguage),
+  );
+  if (preferred != null && preferred.isNotEmpty) return preferred;
+  final locale = ref.watch(localeProvider);
+  final tag = locale?.toLanguageTag() ?? 'zh-CN';
+  if (tag.startsWith('zh')) {
+    return tag.contains('TW') || tag.contains('HK') || tag.contains('Hant')
+        ? 'zh-TW'
+        : 'zh-CN';
+  }
+  final short = tag.split('-').first;
+  return aiTranslationLanguages.containsKey(short) ? short : 'en';
+});
+
+String aiTranslationLanguageLabel(String code) =>
+    aiTranslationLanguages[code] ?? code;
+
+/// 偏好指定模型优先，否则使用默认文本模型或首个可用文本模型。
+final aiTranslationSelectedModelProvider =
+    Provider<({AiProvider provider, AiModel model})?>((ref) {
+      final selectedKey = ref.watch(
+        preferencesProvider.select((prefs) => prefs.aiTranslationModelKey),
+      );
+      final available = ref.watch(aiPostReviewAvailableModelsProvider);
+      if (available.isEmpty) return null;
+
+      final parsed = parseAiModelKey(selectedKey);
+      if (parsed != null) {
+        final selected = available.firstWhereOrNull(
+          (item) =>
+              item.provider.id == parsed.providerId &&
+              item.model.id == parsed.modelId,
+        );
+        if (selected != null) return selected;
+      }
+
+      final defaultTextModel = ref.watch(defaultTextAiModelProvider);
+      if (defaultTextModel != null &&
+          defaultTextModel.model.output.contains(Modality.text)) {
+        return defaultTextModel;
+      }
+      return available.first;
+    });
+
+final aiTranslationServiceProvider = Provider<AiTranslationService>((ref) {
+  final chatService = ref.watch(aiChatServiceProvider);
+  return AiTranslationService(chatService: chatService);
+});

--- a/lib/providers/ai_translation_provider.dart
+++ b/lib/providers/ai_translation_provider.dart
@@ -1,5 +1,4 @@
 import 'package:ai_model_manager/ai_model_manager.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../services/ai_translation_service.dart';
@@ -40,31 +39,14 @@ final aiTranslationTargetLanguageProvider = Provider<String>((ref) {
 String aiTranslationLanguageLabel(String code) =>
     aiTranslationLanguages[code] ?? code;
 
-/// 偏好指定模型优先，否则使用默认文本模型或首个可用文本模型。
+/// 偏好指定模型优先，否则使用默认文本模型或首个可用文本模型
+/// （回退逻辑与 AI 审核共用 [resolveSelectedTextAiModel]）。
 final aiTranslationSelectedModelProvider =
     Provider<({AiProvider provider, AiModel model})?>((ref) {
       final selectedKey = ref.watch(
         preferencesProvider.select((prefs) => prefs.aiTranslationModelKey),
       );
-      final available = ref.watch(aiPostReviewAvailableModelsProvider);
-      if (available.isEmpty) return null;
-
-      final parsed = parseAiModelKey(selectedKey);
-      if (parsed != null) {
-        final selected = available.firstWhereOrNull(
-          (item) =>
-              item.provider.id == parsed.providerId &&
-              item.model.id == parsed.modelId,
-        );
-        if (selected != null) return selected;
-      }
-
-      final defaultTextModel = ref.watch(defaultTextAiModelProvider);
-      if (defaultTextModel != null &&
-          defaultTextModel.model.output.contains(Modality.text)) {
-        return defaultTextModel;
-      }
-      return available.first;
+      return resolveSelectedTextAiModel(ref, selectedKey);
     });
 
 final aiTranslationServiceProvider = Provider<AiTranslationService>((ref) {

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -168,6 +168,9 @@ class AppPreferences {
   /// 且第三方签名图成本高、良莠不齐,默认关对齐网页更稳妥。
   final bool showSignatures;
 
+  /// 小尾巴动画 SVG 自适应帧率
+  final bool adaptiveSignatureFrameRate;
+
   /// Boost 弹幕化（默认关闭）
   final bool boostDanmaku;
 
@@ -251,6 +254,7 @@ class AppPreferences {
     this.hcaptchaCreateEndpoint,
     required this.dialogBlur,
     this.showSignatures = false,
+    this.adaptiveSignatureFrameRate = true,
     this.boostDanmaku = false,
     this.defaultNestedView = false,
     this.nestedLineStyle = NestedLineStyle.auto,
@@ -298,6 +302,7 @@ class AppPreferences {
     Object? hcaptchaCreateEndpoint = _unset,
     bool? dialogBlur,
     bool? showSignatures,
+    bool? adaptiveSignatureFrameRate,
     bool? boostDanmaku,
     bool? defaultNestedView,
     NestedLineStyle? nestedLineStyle,
@@ -350,6 +355,8 @@ class AppPreferences {
           : hcaptchaCreateEndpoint as String?,
       dialogBlur: dialogBlur ?? this.dialogBlur,
       showSignatures: showSignatures ?? this.showSignatures,
+      adaptiveSignatureFrameRate:
+          adaptiveSignatureFrameRate ?? this.adaptiveSignatureFrameRate,
       boostDanmaku: boostDanmaku ?? this.boostDanmaku,
       defaultNestedView: defaultNestedView ?? this.defaultNestedView,
       nestedLineStyle: nestedLineStyle ?? this.nestedLineStyle,
@@ -412,6 +419,8 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
       'pref_hcaptcha_create_endpoint';
   static const String _dialogBlurKey = 'pref_dialog_blur';
   static const String _showSignaturesKey = 'pref_show_signatures';
+  static const String _adaptiveSignatureFrameRateKey =
+      'pref_adaptive_signature_frame_rate';
   static const String _boostDanmakuKey = 'pref_boost_danmaku';
   static const String _defaultNestedViewKey = 'pref_default_nested_view';
   static const String _nestedLineStyleKey = 'pref_nested_line_style';
@@ -478,6 +487,8 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           hcaptchaCreateEndpoint: _prefs.getString(_hcaptchaCreateEndpointKey),
           dialogBlur: _prefs.getBool(_dialogBlurKey) ?? true,
           showSignatures: _prefs.getBool(_showSignaturesKey) ?? false,
+          adaptiveSignatureFrameRate:
+              _prefs.getBool(_adaptiveSignatureFrameRateKey) ?? true,
           boostDanmaku: _prefs.getBool(_boostDanmakuKey) ?? false,
           defaultNestedView: _prefs.getBool(_defaultNestedViewKey) ?? false,
           nestedLineStyle: NestedLineStyle.fromString(
@@ -702,6 +713,11 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   Future<void> setShowSignatures(bool enabled) async {
     state = state.copyWith(showSignatures: enabled);
     await _prefs.setBool(_showSignaturesKey, enabled);
+  }
+
+  Future<void> setAdaptiveSignatureFrameRate(bool enabled) async {
+    state = state.copyWith(adaptiveSignatureFrameRate: enabled);
+    await _prefs.setBool(_adaptiveSignatureFrameRateKey, enabled);
   }
 
   Future<void> setBoostDanmaku(bool enabled) async {

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -155,6 +155,15 @@ class AppPreferences {
   /// 发帖前 AI 审核使用的模型 key（providerId:modelId）
   final String? aiPostReviewModelKey;
 
+  /// AI 翻译功能开关。关闭时帖子菜单不显示翻译入口。
+  final bool aiTranslationEnabled;
+
+  /// AI 翻译目标语言。null 表示跟随应用语言。
+  final String? aiTranslationTargetLanguage;
+
+  /// AI 翻译使用的模型 key（providerId:modelId）。
+  final String? aiTranslationModelKey;
+
   /// hcaptcha 验证 POST endpoint 覆盖。null = 用内置 fallback 列表 (尝试
   /// `/captcha/hcaptcha/create.json` → `/hcaptcha/create.json`)。
   /// 站长改 mount path 时不发版即可改这里。
@@ -251,6 +260,9 @@ class AppPreferences {
     this.useRichComposer = false,
     this.aiPostReviewEnabled = false,
     this.aiPostReviewModelKey,
+    this.aiTranslationEnabled = false,
+    this.aiTranslationTargetLanguage,
+    this.aiTranslationModelKey,
     this.hcaptchaCreateEndpoint,
     required this.dialogBlur,
     this.showSignatures = false,
@@ -299,6 +311,9 @@ class AppPreferences {
     bool? useRichComposer,
     bool? aiPostReviewEnabled,
     Object? aiPostReviewModelKey = _unset,
+    bool? aiTranslationEnabled,
+    Object? aiTranslationTargetLanguage = _unset,
+    Object? aiTranslationModelKey = _unset,
     Object? hcaptchaCreateEndpoint = _unset,
     bool? dialogBlur,
     bool? showSignatures,
@@ -350,6 +365,15 @@ class AppPreferences {
       aiPostReviewModelKey: identical(aiPostReviewModelKey, _unset)
           ? this.aiPostReviewModelKey
           : aiPostReviewModelKey as String?,
+      aiTranslationEnabled:
+          aiTranslationEnabled ?? this.aiTranslationEnabled,
+      aiTranslationTargetLanguage:
+          identical(aiTranslationTargetLanguage, _unset)
+          ? this.aiTranslationTargetLanguage
+          : aiTranslationTargetLanguage as String?,
+      aiTranslationModelKey: identical(aiTranslationModelKey, _unset)
+          ? this.aiTranslationModelKey
+          : aiTranslationModelKey as String?,
       hcaptchaCreateEndpoint: identical(hcaptchaCreateEndpoint, _unset)
           ? this.hcaptchaCreateEndpoint
           : hcaptchaCreateEndpoint as String?,
@@ -415,6 +439,10 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _useRichComposerKey = 'pref_use_rich_composer';
   static const String _aiPostReviewEnabledKey = 'pref_ai_post_review_enabled';
   static const String _aiPostReviewModelPrefKey = 'pref_ai_post_review_model';
+  static const String _aiTranslationEnabledKey = 'pref_ai_translation_enabled';
+  static const String _aiTranslationTargetLanguageKey =
+      'pref_ai_translation_target_language';
+  static const String _aiTranslationModelPrefKey = 'pref_ai_translation_model';
   static const String _hcaptchaCreateEndpointKey =
       'pref_hcaptcha_create_endpoint';
   static const String _dialogBlurKey = 'pref_dialog_blur';
@@ -484,6 +512,12 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           useRichComposer: _prefs.getBool(_useRichComposerKey) ?? false,
           aiPostReviewEnabled: _prefs.getBool(_aiPostReviewEnabledKey) ?? false,
           aiPostReviewModelKey: _prefs.getString(_aiPostReviewModelPrefKey),
+          aiTranslationEnabled:
+              _prefs.getBool(_aiTranslationEnabledKey) ?? false,
+          aiTranslationTargetLanguage: _prefs.getString(
+            _aiTranslationTargetLanguageKey,
+          ),
+          aiTranslationModelKey: _prefs.getString(_aiTranslationModelPrefKey),
           hcaptchaCreateEndpoint: _prefs.getString(_hcaptchaCreateEndpointKey),
           dialogBlur: _prefs.getBool(_dialogBlurKey) ?? true,
           showSignatures: _prefs.getBool(_showSignaturesKey) ?? false,
@@ -692,6 +726,32 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
       await _prefs.remove(_aiPostReviewModelPrefKey);
     } else {
       await _prefs.setString(_aiPostReviewModelPrefKey, key);
+    }
+  }
+
+  Future<void> setAiTranslationEnabled(bool enabled) async {
+    if (state.aiTranslationEnabled == enabled) return;
+    state = state.copyWith(aiTranslationEnabled: enabled);
+    await _prefs.setBool(_aiTranslationEnabledKey, enabled);
+  }
+
+  Future<void> setAiTranslationTargetLanguage(String? language) async {
+    if (state.aiTranslationTargetLanguage == language) return;
+    state = state.copyWith(aiTranslationTargetLanguage: language);
+    if (language == null || language.isEmpty) {
+      await _prefs.remove(_aiTranslationTargetLanguageKey);
+    } else {
+      await _prefs.setString(_aiTranslationTargetLanguageKey, language);
+    }
+  }
+
+  Future<void> setAiTranslationModelKey(String? key) async {
+    if (state.aiTranslationModelKey == key) return;
+    state = state.copyWith(aiTranslationModelKey: key);
+    if (key == null || key.isEmpty) {
+      await _prefs.remove(_aiTranslationModelPrefKey);
+    } else {
+      await _prefs.setString(_aiTranslationModelPrefKey, key);
     }
   }
 

--- a/lib/services/ai_translation_service.dart
+++ b/lib/services/ai_translation_service.dart
@@ -1,0 +1,68 @@
+import 'package:ai_model_manager/ai_model_manager.dart';
+import 'package:html/parser.dart' as html_parser;
+
+/// 帖子内容 AI 翻译服务。
+class AiTranslationService {
+  AiTranslationService({required AiChatService chatService})
+    : _chatService = chatService;
+
+  final AiChatService _chatService;
+
+  /// 流式翻译 [text] 到 [targetLanguage]，每个事件是一段增量文本。
+  Stream<String> translateStream({
+    required AiProvider provider,
+    required AiModel model,
+    required String apiKey,
+    required String text,
+    required String targetLanguage,
+  }) async* {
+    final stream = _chatService.sendChatStream(
+      provider: provider,
+      model: model.id,
+      apiKey: apiKey,
+      systemPrompt: buildSystemPrompt(targetLanguage),
+      messages: [
+        AiChatMessage(
+          id: 'translate-request',
+          role: ChatRole.user,
+          content: text,
+          createdAt: DateTime.now(),
+        ),
+      ],
+      thinkingConfig: const ThinkingConfig(),
+    );
+    await for (final chunk in stream) {
+      if (chunk is TextDelta) yield chunk.text;
+    }
+  }
+
+  static String buildSystemPrompt(String targetLanguage) {
+    return '''
+你是一名专业翻译。把用户发来的论坛帖子内容完整翻译成目标语言：$targetLanguage。
+
+要求：
+1. 只输出译文本身，不要任何前言、解释或“以下是翻译”之类的话。
+2. 保留原文的段落结构与列表结构。
+3. 代码块、命令、URL、@用户名、专有名词（软件名/型号等）保持原样不翻译。
+4. 语气与原文一致（口语保持口语，技术表达保持准确）。
+5. 如果原文已经是目标语言，原样输出并在末尾另起一行注明「（原文即目标语言）」。
+''';
+  }
+
+  /// cooked HTML 转为供翻译的纯文本。
+  static String extractPlainText(String cookedHtml) {
+    final document = html_parser.parse(cookedHtml);
+    for (final img in document.querySelectorAll('img')) {
+      final alt = img.attributes['alt'];
+      img.replaceWith(
+        html_parser.parseFragment(alt != null && alt.isNotEmpty ? alt : ''),
+      );
+    }
+    final text = document.body?.text ?? cookedHtml;
+    return text
+        .replaceAll(RegExp(r'\r\n?'), '\n')
+        .replaceAll(RegExp(r'[ \t]+'), ' ')
+        .replaceAll(RegExp(r'\n{3,}'), '\n\n')
+        .trim();
+  }
+}

--- a/lib/services/ai_translation_service.dart
+++ b/lib/services/ai_translation_service.dart
@@ -49,6 +49,21 @@ class AiTranslationService {
 ''';
   }
 
+  /// 单次送翻的字符上限。超长帖(转录、日志贴)整篇塞给模型会超出上下文
+  /// 或烧掉大量 token(用的是用户自己的 API Key),超限截到段落边界,
+  /// UI 侧注明只翻译了开头部分。
+  static const int maxTranslateChars = 16000;
+
+  /// 超过 [maxTranslateChars] 时截断,尽量截在换行处避免劈开句子。
+  static ({String text, bool truncated}) clampForTranslation(String text) {
+    if (text.length <= maxTranslateChars) {
+      return (text: text, truncated: false);
+    }
+    var cut = text.lastIndexOf('\n', maxTranslateChars);
+    if (cut < maxTranslateChars ~/ 2) cut = maxTranslateChars;
+    return (text: text.substring(0, cut).trimRight(), truncated: true);
+  }
+
   /// cooked HTML 转为供翻译的纯文本。
   static String extractPlainText(String cookedHtml) {
     final document = html_parser.parse(cookedHtml);

--- a/lib/services/audio/just_audio_gst.dart
+++ b/lib/services/audio/just_audio_gst.dart
@@ -1,0 +1,244 @@
+import 'dart:async';
+
+import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
+import 'package:flutter/services.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+
+/// Linux 的 just_audio 后端:桥接到 audioplayers_linux(GStreamer)。
+///
+/// 为什么不用 media_kit(Windows 同款):media_kit_libs_linux 不打包
+/// libmpv(指望系统已装),且其 CMake 会在 configure 期联网下载 mimalloc,
+/// 在 flatpak 禁网沙箱里是 FATAL_ERROR;运行时 GNOME runtime 也没有
+/// libmpv,dlopen 直接抛异常。而 GStreamer(core/base/good + gst-libav,
+/// 覆盖 AAC/MP3/Opus)本来就在 GNOME runtime 里 —— wpe-layer 的 WebKit
+/// 播媒体用的就是它,audioplayers_linux 的 CMake 只 pkg-config 查系统
+/// GStreamer、零构建期下载,禁网沙箱天然可编。
+///
+/// 只实现本项目用到的子集(单曲 URL:load/play/pause/seek/音量/倍速)。
+/// 播放列表、ClippingAudioSource 等 just_audio 高级音源不支持 —— 帖内
+/// 音频条与语音评论预览都是单文件播放。
+class JustAudioGst extends JustAudioPlatform {
+  final _players = <String, _GstAudioPlayer>{};
+
+  /// 在 main() 里于创建任何 AudioPlayer 之前调用(仅 Linux)。
+  static void registerWith() {
+    JustAudioPlatform.instance = JustAudioGst();
+  }
+
+  @override
+  Future<AudioPlayerPlatform> init(InitRequest request) async {
+    if (_players.containsKey(request.id)) {
+      throw PlatformException(
+        code: 'error',
+        message: 'Player ${request.id} already exists',
+      );
+    }
+    final player = _GstAudioPlayer(request.id);
+    await player._create();
+    _players[request.id] = player;
+    return player;
+  }
+
+  @override
+  Future<DisposePlayerResponse> disposePlayer(
+    DisposePlayerRequest request,
+  ) async {
+    await _players.remove(request.id)?._dispose();
+    return DisposePlayerResponse();
+  }
+
+  @override
+  Future<DisposeAllPlayersResponse> disposeAllPlayers(
+    DisposeAllPlayersRequest request,
+  ) async {
+    final players = _players.values.toList(growable: false);
+    _players.clear();
+    for (final player in players) {
+      await player._dispose();
+    }
+    return DisposeAllPlayersResponse();
+  }
+}
+
+class _GstAudioPlayer extends AudioPlayerPlatform {
+  _GstAudioPlayer(super.id);
+
+  static AudioplayersPlatformInterface get _api =>
+      AudioplayersPlatformInterface.instance;
+
+  final _events = StreamController<PlaybackEventMessage>.broadcast();
+  StreamSubscription<AudioEvent>? _eventSub;
+
+  var _processingState = ProcessingStateMessage.idle;
+  Duration? _duration;
+
+  /// 最后一次确知的播放位置。just_audio 前端按
+  /// `updatePosition + (now - updateTime)` 自行插值,platform 侧无需轮询,
+  /// 只要在状态转换点(load/play/pause/seek/completed)上报准确锚点。
+  var _position = Duration.zero;
+  var _playing = false;
+  var _disposed = false;
+  Completer<void>? _prepared;
+
+  Future<void> _create() async {
+    await _api.create(id);
+    // 对齐 just_audio 语义:播完停在 completed、可 seek 回去重播。
+    // audioplayers 默认 release 会把已加载的源一并释放。
+    await _api.setReleaseMode(id, ReleaseMode.stop);
+    _eventSub = _api.getEventStream(id).listen(_onEvent, onError: _onError);
+  }
+
+  Future<void> _dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _eventSub?.cancel();
+    await _events.close();
+    await _api.dispose(id);
+  }
+
+  void _onEvent(AudioEvent event) {
+    if (_disposed) return;
+    switch (event.eventType) {
+      case AudioEventType.prepared:
+        if (event.isPrepared ?? false) {
+          _prepared?.complete();
+          _prepared = null;
+        }
+      case AudioEventType.duration:
+        _duration = event.duration;
+        if (_processingState == ProcessingStateMessage.ready) {
+          _broadcast();
+        }
+      case AudioEventType.complete:
+        _processingState = ProcessingStateMessage.completed;
+        _playing = false;
+        _position = _duration ?? _position;
+        _broadcast();
+      case AudioEventType.seekComplete:
+        // seek() 已乐观上报目标位置;GStreamer 落到关键帧后校准一次。
+        unawaited(_refreshPosition());
+      case AudioEventType.log:
+        break;
+    }
+  }
+
+  void _onError(Object error) {
+    if (_disposed) return;
+    final prepared = _prepared;
+    if (prepared != null && !prepared.isCompleted) {
+      _prepared = null;
+      prepared.completeError(
+        PlatformException(code: 'load_failed', message: '$error'),
+      );
+      return;
+    }
+    _events.addError(error);
+  }
+
+  Future<void> _refreshPosition() async {
+    final positionMs = await _api.getCurrentPosition(id);
+    if (_disposed || positionMs == null) return;
+    _position = Duration(milliseconds: positionMs);
+    _broadcast();
+  }
+
+  void _broadcast() {
+    if (_disposed) return;
+    _events.add(
+      PlaybackEventMessage(
+        processingState: _processingState,
+        updateTime: DateTime.now(),
+        updatePosition: _position,
+        // GStreamer 侧无缓冲进度事件,用当前位置兜底(进度条不画缓冲带)。
+        bufferedPosition: _position,
+        duration: _duration,
+        icyMetadata: null,
+        currentIndex: 0,
+        androidAudioSessionId: null,
+      ),
+    );
+  }
+
+  @override
+  Stream<PlaybackEventMessage> get playbackEventMessageStream => _events.stream;
+
+  @override
+  Future<LoadResponse> load(LoadRequest request) async {
+    final source = request.audioSourceMessage;
+    if (source is! UriAudioSourceMessage) {
+      throw PlatformException(
+        code: 'unsupported',
+        message: 'JustAudioGst 仅支持 URL 音源(setUrl/setFilePath)',
+      );
+    }
+    _processingState = ProcessingStateMessage.loading;
+    _duration = null;
+    _position = Duration.zero;
+    _broadcast();
+
+    final prepared = _prepared = Completer<void>();
+    final uri = Uri.parse(source.uri);
+    await _api.setSourceUrl(
+      id,
+      source.uri,
+      isLocal: uri.scheme.isEmpty || uri.scheme == 'file',
+    );
+    // setSourceUrl 返回不代表就绪,等 prepared 事件;失败经 _onError 抛出。
+    await prepared.future;
+
+    final durationMs = await _api.getDuration(id);
+    if (durationMs != null && durationMs > 0) {
+      _duration = Duration(milliseconds: durationMs);
+    }
+    if (request.initialPosition != null &&
+        request.initialPosition! > Duration.zero) {
+      _position = request.initialPosition!;
+      await _api.seek(id, _position);
+    }
+    _processingState = ProcessingStateMessage.ready;
+    _broadcast();
+    return LoadResponse(duration: _duration);
+  }
+
+  @override
+  Future<PlayResponse> play(PlayRequest request) async {
+    if (_playing) return PlayResponse();
+    _playing = true;
+    await _api.resume(id);
+    _broadcast();
+    return PlayResponse();
+  }
+
+  @override
+  Future<PauseResponse> pause(PauseRequest request) async {
+    if (!_playing) return PauseResponse();
+    _playing = false;
+    await _api.pause(id);
+    // 暂停后取真实位置作为新锚点,消除插值累计误差。
+    await _refreshPosition();
+    return PauseResponse();
+  }
+
+  @override
+  Future<SeekResponse> seek(SeekRequest request) async {
+    _position = request.position ?? Duration.zero;
+    if (_processingState == ProcessingStateMessage.completed) {
+      _processingState = ProcessingStateMessage.ready;
+    }
+    await _api.seek(id, _position);
+    _broadcast();
+    return SeekResponse();
+  }
+
+  @override
+  Future<SetVolumeResponse> setVolume(SetVolumeRequest request) async {
+    await _api.setVolume(id, request.volume);
+    return SetVolumeResponse();
+  }
+
+  @override
+  Future<SetSpeedResponse> setSpeed(SetSpeedRequest request) async {
+    await _api.setPlaybackRate(id, request.speed);
+    return SetSpeedResponse();
+  }
+}

--- a/lib/services/discourse/_search.dart
+++ b/lib/services/discourse/_search.dart
@@ -107,11 +107,16 @@ mixin _SearchMixin on _DiscourseServiceBase {
       }
 
       // 逐字触发的自动补全请求:被 CF 挑战时只做后台静默过盾,
-      // 不能每敲一个字就弹前台验证页(私信 @ 疯狂过盾问题)
+      // 不能每敲一个字就弹前台验证页(私信 @ 疯狂过盾问题)。
+      //
+      // priority 必须显式给 normal:调度器对 isSilent 一律推断成 low
+      // (request_scheduler_interceptor._inferPriority),而队列是按优先级
+      // 排序的堆、没有 aging —— 后到的 normal 会不断反超已排队的 low。
+      // 每 host 只有 3 个并发槽,边加载楼层边打字时补全会被饿死。
       final response = await _dio.get(
         '/u/search/users',
         queryParameters: queryParams,
-        options: Options(extra: {'isSilent': true}),
+        options: Options(extra: {'isSilent': true, 'priority': 'normal'}),
       );
       return MentionSearchResult.fromJson(response.data as Map<String, dynamic>);
     } catch (e) {
@@ -131,8 +136,9 @@ mixin _SearchMixin on _DiscourseServiceBase {
         queryParameters: {
           'names[]': names,
         },
-        // 编辑器内自动触发的校验请求,同样不应弹前台验证
-        options: Options(extra: {'isSilent': true}),
+        // 编辑器内自动触发的校验请求,同样不应弹前台验证;
+        // 同样显式声明 normal,避免被调度器按 isSilent 降级排队。
+        options: Options(extra: {'isSilent': true, 'priority': 'normal'}),
       );
       return MentionCheckResult.fromJson(response.data as Map<String, dynamic>);
     } catch (e) {

--- a/lib/services/discourse/_search.dart
+++ b/lib/services/discourse/_search.dart
@@ -99,11 +99,20 @@ mixin _SearchMixin on _DiscourseServiceBase {
       if (topicId != null) {
         queryParams['topic_id'] = topicId;
       }
-      if (categoryId != null) {
+      // 私信没有分类,TopicDetail 会把 category_id 兜底成 0;
+      // 带 category_id=0 请求会被 Discourse 以 404 拒绝(分类不存在),
+      // 导致私信里 @ 搜不到人。0 及负值一律不发。
+      if (categoryId != null && categoryId > 0) {
         queryParams['category_id'] = categoryId;
       }
 
-      final response = await _dio.get('/u/search/users', queryParameters: queryParams);
+      // 逐字触发的自动补全请求:被 CF 挑战时只做后台静默过盾,
+      // 不能每敲一个字就弹前台验证页(私信 @ 疯狂过盾问题)
+      final response = await _dio.get(
+        '/u/search/users',
+        queryParameters: queryParams,
+        options: Options(extra: {'isSilent': true}),
+      );
       return MentionSearchResult.fromJson(response.data as Map<String, dynamic>);
     } catch (e) {
       debugPrint('[DiscourseService] searchUsers failed: $e');
@@ -122,6 +131,8 @@ mixin _SearchMixin on _DiscourseServiceBase {
         queryParameters: {
           'names[]': names,
         },
+        // 编辑器内自动触发的校验请求,同样不应弹前台验证
+        options: Options(extra: {'isSilent': true}),
       );
       return MentionCheckResult.fromJson(response.data as Map<String, dynamic>);
     } catch (e) {

--- a/lib/services/signature_frame_scheduler.dart
+++ b/lib/services/signature_frame_scheduler.dart
@@ -9,12 +9,20 @@ import '../utils/scroll_busy_signal.dart';
 /// 调度器只决定“多久采样一次动画”，时间轴仍按真实经过时间推进，因此降帧
 /// 不会让动画变慢。全部签名共用一个单次 Timer；当前实现虽然只允许一个
 /// SVG 同时播放，但共享设计可以避免以后放宽并发时产生多个独立定时器。
+///
+/// 每次派发会推进**所有**订阅者一帧（而非轮转），这样放宽并发后每个 SVG
+/// 拿到的仍然是 [effectiveFps]，不会被订阅数摊薄；总成本随订阅数线性上升，
+/// 由负载学习降档兜底。
 class SignatureFrameScheduler {
   SignatureFrameScheduler._();
 
   static final instance = SignatureFrameScheduler._();
 
-  static const _fpsTiers = <int>[24, 12, 6];
+  /// 帧率档位。顶档必须 ≤ AnimatedSvgView 关闭自适应时的固定帧率
+  /// (`_playbackFps = 15`)，否则打开这个以「降低帧率减少卡顿」为名、
+  /// 且默认开启的开关，反而会比关掉它更费 —— 每 tick 是两趟 SVG 全树
+  /// 遍历加一次重绘，帧率上浮的成本相当可观。
+  static const _fpsTiers = <int>[15, 8, 4];
   static const _pressureThreshold = 2;
   static const _healthyThreshold = 120;
 
@@ -22,11 +30,11 @@ class SignatureFrameScheduler {
   final Stopwatch _clock = Stopwatch()..start();
 
   Timer? _timer;
-  Object? _lastOwner;
   bool _dispatching = false;
   bool _timingsAttached = false;
   int _tierIndex = 0;
   int _pressureStreak = 0;
+  int _wakeLagStreak = 0;
   int _healthyStreak = 0;
   int _scheduledAtMicros = 0;
   int _scheduledDelayMicros = 0;
@@ -49,7 +57,6 @@ class SignatureFrameScheduler {
 
   void unsubscribe(Object owner) {
     if (_subscribers.remove(owner) == null) return;
-    if (identical(_lastOwner, owner)) _lastOwner = null;
     if (_subscribers.isEmpty) {
       _timer?.cancel();
       _timer = null;
@@ -94,16 +101,10 @@ class SignatureFrameScheduler {
     final dispatchWatch = Stopwatch()..start();
     _dispatching = true;
     try {
-      final owners = _subscribers.keys.toList(growable: false);
-      var index = 0;
-      final lastOwner = _lastOwner;
-      if (lastOwner != null) {
-        final lastIndex = owners.indexOf(lastOwner);
-        if (lastIndex >= 0) index = (lastIndex + 1) % owners.length;
+      // 复制一份再遍历:回调里可能触发 unsubscribe(如订阅者已 unmount)。
+      for (final onFrame in _subscribers.values.toList(growable: false)) {
+        onFrame(wakeMicros);
       }
-      final owner = owners[index];
-      _lastOwner = owner;
-      _subscribers[owner]?.call(wakeMicros);
     } finally {
       dispatchWatch.stop();
       _dispatching = false;
@@ -121,15 +122,33 @@ class SignatureFrameScheduler {
         workMicros:
             timing.buildDuration.inMicroseconds +
             timing.rasterDuration.inMicroseconds,
-        wakeLagMicros: 0,
       );
     }
   }
 
-  void _recordLoad({required int workMicros, required int wakeLagMicros}) {
+  /// [wakeLagMicros] 只有调度器自身的派发样本才携带(UI 帧样本传 null)。
+  void _recordLoad({required int workMicros, int? wakeLagMicros}) {
+    // 唤醒延迟走独立 streak:派发样本最高 15Hz,UI 帧样本 60-120Hz,
+    // 若共用一条 streak,两个派发样本之间必然夹着几十个 UI 帧样本,
+    // 任何一个健康帧都会清零连击,唤醒延迟信号永远凑不齐阈值(死通路)。
+    if (wakeLagMicros != null) {
+      if (wakeLagMicros >= 8000) {
+        _healthyStreak = 0;
+        _wakeLagStreak++;
+        if (_wakeLagStreak >= _pressureThreshold &&
+            _tierIndex < _fpsTiers.length - 1) {
+          _wakeLagStreak = 0;
+          _tierIndex++;
+          _reschedule();
+          return;
+        }
+      } else {
+        _wakeLagStreak = 0;
+      }
+    }
+
     final expensive = workMicros >= 12000;
-    final pumpDelayed = wakeLagMicros >= 8000;
-    if (expensive || pumpDelayed) {
+    if (expensive) {
       _healthyStreak = 0;
       _pressureStreak++;
       if (_pressureStreak >= _pressureThreshold &&
@@ -142,7 +161,9 @@ class SignatureFrameScheduler {
     }
 
     _pressureStreak = 0;
-    if (workMicros <= 6000 && wakeLagMicros < 3000 && _tierIndex > 0) {
+    if (workMicros <= 6000 &&
+        (wakeLagMicros == null || wakeLagMicros < 3000) &&
+        _tierIndex > 0) {
       _healthyStreak++;
       if (_healthyStreak >= _healthyThreshold) {
         _healthyStreak = 0;
@@ -160,7 +181,8 @@ class SignatureFrameScheduler {
   }
 
   /// 单元测试使用：喂入确定性负载样本。
-  void debugRecordLoad({required int workMicros, int wakeLagMicros = 0}) {
+  /// [wakeLagMicros] 非 null 表示派发样本,null 表示 UI 帧样本。
+  void debugRecordLoad({required int workMicros, int? wakeLagMicros}) {
     _recordLoad(workMicros: workMicros, wakeLagMicros: wakeLagMicros);
   }
 
@@ -169,11 +191,11 @@ class SignatureFrameScheduler {
     _timer?.cancel();
     _timer = null;
     _subscribers.clear();
-    _lastOwner = null;
     _dispatching = false;
     _detachTimings();
     _tierIndex = 0;
     _pressureStreak = 0;
+    _wakeLagStreak = 0;
     _healthyStreak = 0;
     _scheduledAtMicros = 0;
     _scheduledDelayMicros = 0;

--- a/lib/services/signature_frame_scheduler.dart
+++ b/lib/services/signature_frame_scheduler.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+
+import 'package:flutter/scheduler.dart';
+
+import '../utils/scroll_busy_signal.dart';
+
+/// 小尾巴动画共享自适应帧调度器。
+///
+/// 调度器只决定“多久采样一次动画”，时间轴仍按真实经过时间推进，因此降帧
+/// 不会让动画变慢。全部签名共用一个单次 Timer；当前实现虽然只允许一个
+/// SVG 同时播放，但共享设计可以避免以后放宽并发时产生多个独立定时器。
+class SignatureFrameScheduler {
+  SignatureFrameScheduler._();
+
+  static final instance = SignatureFrameScheduler._();
+
+  static const _fpsTiers = <int>[24, 12, 6];
+  static const _pressureThreshold = 2;
+  static const _healthyThreshold = 120;
+
+  final Map<Object, void Function(int nowMicros)> _subscribers = {};
+  final Stopwatch _clock = Stopwatch()..start();
+
+  Timer? _timer;
+  Object? _lastOwner;
+  bool _dispatching = false;
+  bool _timingsAttached = false;
+  int _tierIndex = 0;
+  int _pressureStreak = 0;
+  int _healthyStreak = 0;
+  int _scheduledAtMicros = 0;
+  int _scheduledDelayMicros = 0;
+
+  int get targetFps => _fpsTiers[_tierIndex];
+
+  /// 滚动时固定使用最低档；滚动结束后恢复到负载学习得到的档位。
+  int get effectiveFps => ScrollBusySignal.isBusy ? _fpsTiers.last : targetFps;
+
+  int get debugSubscriberCount => _subscribers.length;
+
+  void subscribe({
+    required Object owner,
+    required void Function(int nowMicros) onFrame,
+  }) {
+    _subscribers[owner] = onFrame;
+    _attachTimings();
+    _scheduleNext();
+  }
+
+  void unsubscribe(Object owner) {
+    if (_subscribers.remove(owner) == null) return;
+    if (identical(_lastOwner, owner)) _lastOwner = null;
+    if (_subscribers.isEmpty) {
+      _timer?.cancel();
+      _timer = null;
+      _detachTimings();
+    } else if (!_dispatching) {
+      _scheduleNext();
+    }
+  }
+
+  void _attachTimings() {
+    if (_timingsAttached) return;
+    _timingsAttached = true;
+    SchedulerBinding.instance.addTimingsCallback(_onFrameTimings);
+  }
+
+  void _detachTimings() {
+    if (!_timingsAttached) return;
+    _timingsAttached = false;
+    SchedulerBinding.instance.removeTimingsCallback(_onFrameTimings);
+  }
+
+  Duration get _interval => Duration(
+    microseconds: (Duration.microsecondsPerSecond / effectiveFps).ceil(),
+  );
+
+  void _scheduleNext() {
+    if (_dispatching || _subscribers.isEmpty) return;
+    _timer?.cancel();
+    final delay = _interval;
+    _scheduledAtMicros = _clock.elapsedMicroseconds;
+    _scheduledDelayMicros = delay.inMicroseconds;
+    _timer = Timer(delay, _dispatch);
+  }
+
+  void _dispatch() {
+    _timer = null;
+    if (_subscribers.isEmpty) return;
+
+    final wakeMicros = _clock.elapsedMicroseconds;
+    final wakeLagMicros =
+        wakeMicros - _scheduledAtMicros - _scheduledDelayMicros;
+    final dispatchWatch = Stopwatch()..start();
+    _dispatching = true;
+    try {
+      final owners = _subscribers.keys.toList(growable: false);
+      var index = 0;
+      final lastOwner = _lastOwner;
+      if (lastOwner != null) {
+        final lastIndex = owners.indexOf(lastOwner);
+        if (lastIndex >= 0) index = (lastIndex + 1) % owners.length;
+      }
+      final owner = owners[index];
+      _lastOwner = owner;
+      _subscribers[owner]?.call(wakeMicros);
+    } finally {
+      dispatchWatch.stop();
+      _dispatching = false;
+      _recordLoad(
+        workMicros: dispatchWatch.elapsedMicroseconds,
+        wakeLagMicros: wakeLagMicros,
+      );
+      _scheduleNext();
+    }
+  }
+
+  void _onFrameTimings(List<FrameTiming> timings) {
+    for (final timing in timings) {
+      _recordLoad(
+        workMicros:
+            timing.buildDuration.inMicroseconds +
+            timing.rasterDuration.inMicroseconds,
+        wakeLagMicros: 0,
+      );
+    }
+  }
+
+  void _recordLoad({required int workMicros, required int wakeLagMicros}) {
+    final expensive = workMicros >= 12000;
+    final pumpDelayed = wakeLagMicros >= 8000;
+    if (expensive || pumpDelayed) {
+      _healthyStreak = 0;
+      _pressureStreak++;
+      if (_pressureStreak >= _pressureThreshold &&
+          _tierIndex < _fpsTiers.length - 1) {
+        _pressureStreak = 0;
+        _tierIndex++;
+        _reschedule();
+      }
+      return;
+    }
+
+    _pressureStreak = 0;
+    if (workMicros <= 6000 && wakeLagMicros < 3000 && _tierIndex > 0) {
+      _healthyStreak++;
+      if (_healthyStreak >= _healthyThreshold) {
+        _healthyStreak = 0;
+        _tierIndex--;
+        _reschedule();
+      }
+    } else {
+      _healthyStreak = 0;
+    }
+  }
+
+  void _reschedule() {
+    if (_dispatching || _subscribers.isEmpty) return;
+    _scheduleNext();
+  }
+
+  /// 单元测试使用：喂入确定性负载样本。
+  void debugRecordLoad({required int workMicros, int wakeLagMicros = 0}) {
+    _recordLoad(workMicros: workMicros, wakeLagMicros: wakeLagMicros);
+  }
+
+  /// 单元测试使用：清理单例状态。
+  void debugReset() {
+    _timer?.cancel();
+    _timer = null;
+    _subscribers.clear();
+    _lastOwner = null;
+    _dispatching = false;
+    _detachTimings();
+    _tierIndex = 0;
+    _pressureStreak = 0;
+    _healthyStreak = 0;
+    _scheduledAtMicros = 0;
+    _scheduledDelayMicros = 0;
+  }
+}

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/s.dart';
 import '../../providers/ai_post_review_provider.dart';
+import '../../providers/ai_translation_provider.dart';
 import '../../providers/preferences_provider.dart';
 import '../../services/toast_service.dart';
 import '../../utils/dialog_utils.dart';
@@ -152,6 +153,58 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
           },
           onTap: (context, ref) => _showAiPostReviewModelSheet(context, ref),
         ),
+        SwitchModel(
+          id: 'aiTranslation',
+          title: l10n.ai_translationEnabled,
+          subtitle: l10n.ai_translationEnabledDesc,
+          icon: Symbols.translate_rounded,
+          getValue: (ref) =>
+              ref.watch(preferencesProvider).aiTranslationEnabled,
+          onChanged: (ref, v) async {
+            final notifier = ref.read(preferencesProvider.notifier);
+            await notifier.setAiTranslationEnabled(v);
+            if (!v) return;
+            final prefs = ref.read(preferencesProvider);
+            if (prefs.aiTranslationModelKey != null) return;
+            final selected = ref.read(aiTranslationSelectedModelProvider);
+            if (selected == null) return;
+            await notifier.setAiTranslationModelKey(
+              buildAiModelKey(selected.provider.id, selected.model.id),
+            );
+          },
+        ),
+        ActionModel(
+          id: 'aiTranslationTargetLanguage',
+          title: l10n.ai_translationTargetLanguage,
+          icon: Symbols.translate_rounded,
+          getDynamicSubtitle: (ref) {
+            final preferred = ref.watch(
+              preferencesProvider.select(
+                (preferences) => preferences.aiTranslationTargetLanguage,
+              ),
+            );
+            if (preferred == null || preferred.isEmpty) {
+              return l10n.ai_translationTargetLanguageFollowApp;
+            }
+            return aiTranslationLanguageLabel(preferred);
+          },
+          onTap: (context, ref) =>
+              _showAiTranslationLanguagePicker(context, ref),
+        ),
+        ActionModel(
+          id: 'aiTranslationModel',
+          title: l10n.ai_translationModel,
+          icon: Symbols.psychology_alt_rounded,
+          getDynamicSubtitle: (ref) {
+            final selected = ref.watch(aiTranslationSelectedModelProvider);
+            if (selected == null) {
+              return l10n.ai_translationModelNotSelected;
+            }
+            final modelName = selected.model.name ?? selected.model.id;
+            return '${selected.provider.name} / $modelName';
+          },
+          onTap: (context, ref) => _showAiTranslationModelSheet(context, ref),
+        ),
         ActionModel(
           id: 'stickerSource',
           title: l10n.preferences_stickerSource,
@@ -209,6 +262,93 @@ Future<void> _showAiPostReviewModelSheet(
   await ref
       .read(preferencesProvider.notifier)
       .setAiPostReviewModelKey(
+        buildAiModelKey(selected.provider.id, selected.model.id),
+      );
+}
+
+void _showAiTranslationLanguagePicker(BuildContext context, WidgetRef ref) {
+  final l10n = context.l10n;
+  final current = ref.read(preferencesProvider).aiTranslationTargetLanguage;
+  showAppDialog<String?>(
+    context: context,
+    builder: (dialogContext) => SimpleDialog(
+      title: Text(l10n.ai_translationTargetLanguage),
+      children: [
+        SimpleDialogOption(
+          onPressed: () => Navigator.pop(dialogContext, ''),
+          child: Row(
+            children: [
+              Icon(
+                current == null || current.isEmpty
+                    ? Symbols.radio_button_checked_rounded
+                    : Symbols.radio_button_unchecked_rounded,
+                color: current == null || current.isEmpty
+                    ? Theme.of(dialogContext).colorScheme.primary
+                    : null,
+                size: 20,
+              ),
+              const SizedBox(width: 12),
+              Text(l10n.ai_translationTargetLanguageFollowApp),
+            ],
+          ),
+        ),
+        for (final entry in aiTranslationLanguages.entries)
+          SimpleDialogOption(
+            onPressed: () => Navigator.pop(dialogContext, entry.key),
+            child: Row(
+              children: [
+                Icon(
+                  entry.key == current
+                      ? Symbols.radio_button_checked_rounded
+                      : Symbols.radio_button_unchecked_rounded,
+                  color: entry.key == current
+                      ? Theme.of(dialogContext).colorScheme.primary
+                      : null,
+                  size: 20,
+                ),
+                const SizedBox(width: 12),
+                Text(entry.value),
+              ],
+            ),
+          ),
+      ],
+    ),
+  ).then((selected) {
+    if (selected == null) return;
+    ref
+        .read(preferencesProvider.notifier)
+        .setAiTranslationTargetLanguage(selected.isEmpty ? null : selected);
+  });
+}
+
+Future<void> _showAiTranslationModelSheet(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final allModels = ref.read(aiPostReviewAvailableModelsProvider);
+  if (allModels.isEmpty) {
+    ToastService.showInfo(context.l10n.aiPostReview_noAvailableModel);
+    return;
+  }
+
+  final current =
+      ref.read(aiTranslationSelectedModelProvider) ?? allModels.first;
+  final selected = await showAiModelSelectSheet(
+    context: context,
+    allModels: allModels,
+    current: current,
+    mode: PromptType.text,
+  );
+  if (!context.mounted || selected == null) return;
+
+  if (!selected.model.output.contains(Modality.text)) {
+    ToastService.showInfo(context.l10n.aiPostReview_chooseTextModel);
+    return;
+  }
+
+  await ref
+      .read(preferencesProvider.notifier)
+      .setAiTranslationModelKey(
         buildAiModelKey(selected.provider.id, selected.model.id),
       );
 }

--- a/lib/settings/definitions/reading_defs.dart
+++ b/lib/settings/definitions/reading_defs.dart
@@ -107,6 +107,18 @@ List<SettingsGroup> buildReadingGroups(BuildContext context) {
             onChanged: (ref, v) =>
                 ref.read(preferencesProvider.notifier).setShowSignatures(v),
           ),
+        if (PreloadedDataService().signaturesEnabled)
+          SwitchModel(
+            id: 'adaptiveSignatureFrameRate',
+            title: l10n.reading_adaptiveSignatureFrameRate,
+            subtitle: l10n.reading_adaptiveSignatureFrameRateDesc,
+            icon: Symbols.speed_rounded,
+            getValue: (ref) =>
+                ref.watch(preferencesProvider).adaptiveSignatureFrameRate,
+            onChanged: (ref, v) => ref
+                .read(preferencesProvider.notifier)
+                .setAdaptiveSignatureFrameRate(v),
+          ),
         CustomModel(
           id: 'bookmarksOpenMode',
           title: l10n.reading_bookmarksOpenMode,
@@ -559,4 +571,3 @@ void _showGestureActionPicker(
     if (selected != null) onPicked(selected);
   });
 }
-

--- a/lib/widgets/ai/ai_translation_sheet.dart
+++ b/lib/widgets/ai/ai_translation_sheet.dart
@@ -1,0 +1,273 @@
+import 'dart:async';
+
+import 'package:ai_model_manager/ai_model_manager.dart';
+import 'package:app_icons/app_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../l10n/s.dart';
+import '../../providers/ai_translation_provider.dart';
+import '../../services/ai_translation_service.dart';
+import '../../services/toast_service.dart';
+import '../../utils/dialog_utils.dart';
+import '../common/app_bottom_sheet.dart';
+
+/// 打开帖子 AI 翻译弹层。弹层独立于楼层树，避免破坏帖子实例缓存。
+void showAiTranslationSheet(
+  BuildContext context, {
+  required String cookedHtml,
+}) {
+  showAppBottomSheet(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (ctx) => AppSheetScaffold(
+      maxHeightFactor: 0.85,
+      child: _AiTranslationSheetBody(cookedHtml: cookedHtml),
+    ),
+  );
+}
+
+class _AiTranslationSheetBody extends ConsumerStatefulWidget {
+  const _AiTranslationSheetBody({required this.cookedHtml});
+
+  final String cookedHtml;
+
+  @override
+  ConsumerState<_AiTranslationSheetBody> createState() =>
+      _AiTranslationSheetBodyState();
+}
+
+class _AiTranslationSheetBodyState
+    extends ConsumerState<_AiTranslationSheetBody> {
+  final StringBuffer _result = StringBuffer();
+  StreamSubscription<String>? _subscription;
+  Timer? _flushTimer;
+  bool _dirty = false;
+  bool _firstDeltaShown = false;
+  bool _streaming = false;
+  String? _error;
+
+  /// 高频 token 合并为约 12 FPS 的 UI 更新，避免长译文逐 token 重建。
+  static const _flushInterval = Duration(milliseconds: 80);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _start());
+  }
+
+  @override
+  void dispose() {
+    _flushTimer?.cancel();
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  void _markDirty() {
+    if (!_firstDeltaShown) {
+      _firstDeltaShown = true;
+      _dirty = false;
+      setState(() {});
+      return;
+    }
+    _dirty = true;
+    _flushTimer ??= Timer(_flushInterval, () {
+      _flushTimer = null;
+      if (!mounted || !_dirty) return;
+      _dirty = false;
+      setState(() {});
+    });
+  }
+
+  Future<void> _start() async {
+    if (!mounted) return;
+    await _subscription?.cancel();
+    setState(() {
+      _result.clear();
+      _error = null;
+      _firstDeltaShown = false;
+      _streaming = true;
+    });
+
+    final selected = ref.read(aiTranslationSelectedModelProvider);
+    if (selected == null) {
+      setState(() {
+        _streaming = false;
+        _error = S.current.ai_translationNoModel;
+      });
+      return;
+    }
+    final apiKey = await AiProviderListNotifier.getApiKey(selected.provider.id);
+    if (!mounted) return;
+    if (apiKey == null || apiKey.trim().isEmpty) {
+      setState(() {
+        _streaming = false;
+        _error = S.current.ai_translationNoApiKey;
+      });
+      return;
+    }
+
+    final text = AiTranslationService.extractPlainText(widget.cookedHtml);
+    if (text.isEmpty) {
+      setState(() {
+        _streaming = false;
+        _error = S.current.ai_translationEmptyContent;
+      });
+      return;
+    }
+
+    final target = ref.read(aiTranslationTargetLanguageProvider);
+    final service = ref.read(aiTranslationServiceProvider);
+    _subscription = service
+        .translateStream(
+          provider: selected.provider,
+          model: selected.model,
+          apiKey: apiKey.trim(),
+          text: text,
+          targetLanguage: aiTranslationLanguageLabel(target),
+        )
+        .listen(
+          (delta) {
+            if (!mounted) return;
+            _result.write(delta);
+            _markDirty();
+          },
+          onError: (Object error) {
+            if (!mounted) return;
+            _flushTimer?.cancel();
+            _flushTimer = null;
+            _dirty = false;
+            setState(() {
+              _streaming = false;
+              _error = S.current.ai_translationFailed;
+            });
+            debugPrint('[AiTranslation] 翻译失败: $error');
+          },
+          onDone: () {
+            if (!mounted) return;
+            _flushTimer?.cancel();
+            _flushTimer = null;
+            _dirty = false;
+            setState(() => _streaming = false);
+          },
+        );
+  }
+
+  Future<void> _copy() async {
+    await Clipboard.setData(ClipboardData(text: _result.toString()));
+    if (mounted) ToastService.showSuccess(S.current.common_copiedToClipboard);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final target = ref.watch(aiTranslationTargetLanguageProvider);
+    final selected = ref.watch(aiTranslationSelectedModelProvider);
+    final l10n = context.l10n;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Icon(
+              Symbols.translate_rounded,
+              size: 20,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              l10n.ai_translationTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const Spacer(),
+            Text(
+              aiTranslationLanguageLabel(target),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+        if (selected != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              '${selected.provider.name} / ${selected.model.name ?? selected.model.id}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        const SizedBox(height: 12),
+        Flexible(
+          child: SingleChildScrollView(
+            child: _error != null
+                ? Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 24),
+                    child: Column(
+                      children: [
+                        Text(
+                          _error!,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        FilledButton.tonal(
+                          onPressed: _start,
+                          child: Text(l10n.common_retry),
+                        ),
+                      ],
+                    ),
+                  )
+                : _result.isEmpty
+                ? const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 32),
+                    child: Center(
+                      child: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2.5),
+                      ),
+                    ),
+                  )
+                : SelectableText(
+                    _result.toString(),
+                    style: theme.textTheme.bodyMedium?.copyWith(height: 1.55),
+                  ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (_streaming)
+              Padding(
+                padding: const EdgeInsets.only(right: 12),
+                child: SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+            TextButton.icon(
+              onPressed: _result.isEmpty ? null : _copy,
+              icon: const Icon(Symbols.content_copy_rounded, size: 18),
+              label: Text(l10n.common_copy),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/ai/ai_translation_sheet.dart
+++ b/lib/widgets/ai/ai_translation_sheet.dart
@@ -47,6 +47,7 @@ class _AiTranslationSheetBodyState
   bool _dirty = false;
   bool _firstDeltaShown = false;
   bool _streaming = false;
+  bool _truncated = false;
   String? _error;
 
   /// 高频 token 合并为约 12 FPS 的 UI 更新，避免长译文逐 token 重建。
@@ -88,6 +89,7 @@ class _AiTranslationSheetBodyState
       _result.clear();
       _error = null;
       _firstDeltaShown = false;
+      _truncated = false;
       _streaming = true;
     });
 
@@ -117,6 +119,10 @@ class _AiTranslationSheetBodyState
       });
       return;
     }
+    final clamped = AiTranslationService.clampForTranslation(text);
+    if (clamped.truncated) {
+      setState(() => _truncated = true);
+    }
 
     final target = ref.read(aiTranslationTargetLanguageProvider);
     final service = ref.read(aiTranslationServiceProvider);
@@ -125,7 +131,7 @@ class _AiTranslationSheetBodyState
           provider: selected.provider,
           model: selected.model,
           apiKey: apiKey.trim(),
-          text: text,
+          text: clamped.text,
           targetLanguage: aiTranslationLanguageLabel(target),
         )
         .listen(
@@ -150,9 +156,31 @@ class _AiTranslationSheetBodyState
             _flushTimer?.cancel();
             _flushTimer = null;
             _dirty = false;
-            setState(() => _streaming = false);
+            setState(() {
+              _streaming = false;
+              // 流正常结束却一个 TextDelta 都没有:推理模型把预算烧在
+              // thinking 上导致正文被截断、内容策略拦截、provider 返回空
+              // SSE body 都会走到这里。不置错误的话 build 会落进
+              // `_result.isEmpty` 的 spinner 分支且永不退出 —— 既没有提示
+              // 也没有重试入口。对齐 AiPostReviewService 的空结果保护。
+              if (_result.isEmpty) _error = S.current.ai_translationFailed;
+            });
           },
         );
+  }
+
+  /// 中途停止:保留已生成的部分译文;一个字都没出时落进错误分支
+  /// 给出「已停止」+ 重试,避免停在永久 spinner。
+  void _stop() {
+    _subscription?.cancel();
+    _subscription = null;
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    _dirty = false;
+    setState(() {
+      _streaming = false;
+      if (_result.isEmpty) _error = S.current.ai_translationStopped;
+    });
   }
 
   Future<void> _copy() async {
@@ -204,6 +232,16 @@ class _AiTranslationSheetBodyState
               ),
             ),
           ),
+        if (_truncated)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(
+              l10n.ai_translationTruncated,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.tertiary,
+              ),
+            ),
+          ),
         const SizedBox(height: 12),
         Flexible(
           child: SingleChildScrollView(
@@ -248,7 +286,7 @@ class _AiTranslationSheetBodyState
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            if (_streaming)
+            if (_streaming) ...[
               Padding(
                 padding: const EdgeInsets.only(right: 12),
                 child: SizedBox(
@@ -260,6 +298,12 @@ class _AiTranslationSheetBodyState
                   ),
                 ),
               ),
+              TextButton.icon(
+                onPressed: _stop,
+                icon: const Icon(Symbols.stop_rounded, size: 18),
+                label: Text(l10n.ai_stopGenerate),
+              ),
+            ],
             TextButton.icon(
               onPressed: _result.isEmpty ? null : _copy,
               icon: const Icon(Symbols.content_copy_rounded, size: 18),

--- a/lib/widgets/content/animated_svg_view.dart
+++ b/lib/widgets/content/animated_svg_view.dart
@@ -25,7 +25,9 @@ import 'package:full_svg_flutter/src/animation/svg_theme_apply.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
+import '../../services/signature_frame_scheduler.dart';
 import '../../utils/svg_utils.dart';
+import 'signature_animation_scope.dart';
 
 /// 动画 SVG 视图（CSS @keyframes / SMIL / filter 等 jovial_svg 不支持的特性）。
 ///
@@ -227,6 +229,7 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
   static const int _bigSourceBytes = 256 << 10;
 
   final Object _token = Object();
+  final Object _adaptiveFrameOwner = Object();
   final GlobalKey _boundaryKey = GlobalKey();
 
   late int _cacheKey; // 原始源码会话内 hash(不等 strip)
@@ -249,6 +252,7 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
   int _captureRetries = 0;
   AnimatedSvgController? _controller;
   _BumpNotifier? _waitNotifier;
+  bool _adaptiveFrameRate = false;
 
   // ---- 自持播放器(见"播放控制"注释) ----
   SvgDocument? _playerDoc;
@@ -265,6 +269,20 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
   void initState() {
     super.initState();
     _initSource();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final adaptive =
+        !widget.autoPlay &&
+        SignatureAnimationScope.adaptiveFrameRateOf(context);
+    if (_adaptiveFrameRate == adaptive) return;
+    _adaptiveFrameRate = adaptive;
+    if (_isPlaying) {
+      _stopPlaybackClock();
+      _startPlaybackClock();
+    }
   }
 
   void _initSource() {
@@ -405,6 +423,7 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
   }
 
   void _teardownSource() {
+    _stopAdaptivePlayback();
     _SvgFirstFrameCache.resign(_cacheKey, _token);
     _waitNotifier?.removeListener(_onCacheBump);
     _waitNotifier = null;
@@ -585,6 +604,12 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
 
   void _startPlaybackClock() {
     _playTimer?.cancel();
+    _stopAdaptivePlayback();
+    _playClock.start();
+    if (_adaptiveFrameRate) {
+      _startAdaptivePlayback();
+      return;
+    }
     _playTimer = Timer.periodic(
       Duration(milliseconds: (1000 / _playbackFps).round()),
       (_) {
@@ -594,12 +619,12 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
         _tickPlayer();
       },
     );
-    _playClock.start();
   }
 
   void _stopPlaybackClock() {
     _playTimer?.cancel();
     _playTimer = null;
+    _stopAdaptivePlayback();
     _playClock.stop();
   }
 
@@ -697,6 +722,27 @@ class _AnimatedSvgViewState extends State<AnimatedSvgView> {
     } else {
       _isPlaying = false;
     }
+  }
+
+  void _startAdaptivePlayback() {
+    SignatureFrameScheduler.instance.subscribe(
+      owner: _adaptiveFrameOwner,
+      onFrame: _onAdaptiveFrame,
+    );
+  }
+
+  void _stopAdaptivePlayback() {
+    SignatureFrameScheduler.instance.unsubscribe(_adaptiveFrameOwner);
+  }
+
+  void _onAdaptiveFrame(int _) {
+    if (!mounted || !_isPlaying || !_adaptiveFrameRate) {
+      _stopAdaptivePlayback();
+      return;
+    }
+    // 调度器只控制采样频率，时间轴仍由共享的真实时间时钟推进。
+    if (Scrollable.recommendDeferredLoadingForContext(context)) return;
+    _tickPlayer();
   }
 
   // ---- build ----

--- a/lib/widgets/content/signature_animation_scope.dart
+++ b/lib/widgets/content/signature_animation_scope.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+/// 将小尾巴专属的动画策略传给签名 HTML/图片内部的 SVG 渲染器。
+///
+/// 使用作用域而不是修改通用图片回调，advanced HTML 中的内联 SVG 与普通
+/// URL SVG 都能自动继承，同时正文和全屏查看器不会受到影响。
+class SignatureAnimationScope extends InheritedWidget {
+  const SignatureAnimationScope({
+    super.key,
+    required this.adaptiveFrameRate,
+    required super.child,
+  });
+
+  final bool adaptiveFrameRate;
+
+  static bool adaptiveFrameRateOf(BuildContext context) {
+    return context
+            .dependOnInheritedWidgetOfExactType<SignatureAnimationScope>()
+            ?.adaptiveFrameRate ??
+        false;
+  }
+
+  @override
+  bool updateShouldNotify(SignatureAnimationScope oldWidget) {
+    return adaptiveFrameRate != oldWidget.adaptiveFrameRate;
+  }
+}

--- a/lib/widgets/mention/mention_autocomplete.dart
+++ b/lib/widgets/mention/mention_autocomplete.dart
@@ -335,8 +335,13 @@ class _MentionAutocompleteState extends State<MentionAutocomplete> {
           showWhenUnlinked: false,
           offset: Offset(0, anchorY + (showAbove ? -4 : 4)), // 根据光标位置偏移
           followerAnchor: showAbove ? Alignment.bottomLeft : Alignment.topLeft,
-          targetAnchor: Alignment.topLeft, 
-          child: Container(
+          targetAnchor: Alignment.topLeft,
+          // 桌面端 TextField 默认"点击区域外即失焦":点弹窗的瞬间输入框
+          // 失焦 → overlay 被移除 → 点击落空。把弹窗并入 EditableText 的
+          // TapRegion 分组,点选就不再触发失焦。
+          child: TapRegion(
+            groupId: EditableText,
+            child: Container(
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainerHigh,
               borderRadius: BorderRadius.circular(8),
@@ -348,11 +353,12 @@ class _MentionAutocompleteState extends State<MentionAutocomplete> {
                 ),
               ],
             ),
-            child: Material(
-              color: Colors.transparent,
-              child: ConstrainedBox(
-                constraints: BoxConstraints(maxHeight: effectiveMaxHeight),
-                child: _buildContent(theme),
+              child: Material(
+                color: Colors.transparent,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxHeight: effectiveMaxHeight),
+                  child: _buildContent(theme),
+                ),
               ),
             ),
           ),

--- a/lib/widgets/mention/mention_autocomplete.dart
+++ b/lib/widgets/mention/mention_autocomplete.dart
@@ -342,17 +342,17 @@ class _MentionAutocompleteState extends State<MentionAutocomplete> {
           child: TapRegion(
             groupId: EditableText,
             child: Container(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerHigh,
-              borderRadius: BorderRadius.circular(8),
-              boxShadow: [
-                BoxShadow(
-                  color: Colors.black.withValues(alpha: 0.15),
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ],
-            ),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHigh,
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.15),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
               child: Material(
                 color: Colors.transparent,
                 child: ConstrainedBox(

--- a/lib/widgets/post/post_item/widgets/post_footer_section/actions/menu_actions.dart
+++ b/lib/widgets/post/post_item/widgets/post_footer_section/actions/menu_actions.dart
@@ -106,6 +106,23 @@ extension _PostFooterMenuActions on _PostFooterSectionState {
                     widget.onEdit!();
                   },
                 ),
+              // 菜单点击后才构建，用 read 避免给楼层常驻树增加监听。
+              if (ref.read(preferencesProvider).aiTranslationEnabled &&
+                  ref.read(aiTranslationSelectedModelProvider) != null)
+                ListTile(
+                  leading: Icon(
+                    Symbols.translate_rounded,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                  title: Text(context.l10n.ai_translationMenuLabel),
+                  onTap: () {
+                    Navigator.pop(ctx);
+                    showAiTranslationSheet(
+                      context,
+                      cookedHtml: widget.post.cooked,
+                    );
+                  },
+                ),
               ListTile(
                 leading: Icon(
                   Symbols.share_rounded,

--- a/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
+++ b/lib/widgets/post/post_item/widgets/post_footer_section/post_footer_section.dart
@@ -10,6 +10,7 @@ import '../../../../../constants.dart';
 import '../../../../../models/topic.dart';
 import '../../../../../modules/ldc_reward/ldc_reward.dart';
 import '../../../../../providers/discourse_providers.dart';
+import '../../../../../providers/ai_translation_provider.dart';
 import '../../../../../providers/preferences_provider.dart';
 import '../../../../../utils/blocked_user_filter.dart';
 import '../../../../../utils/frame_jank_monitor.dart';
@@ -35,6 +36,7 @@ import '../../../../post/post_replies_sheet.dart';
 import '../../../../user/user_card.dart';
 import '../../../../../utils/dialog_utils.dart';
 import '../../../../common/app_bottom_sheet.dart';
+import '../../../../ai/ai_translation_sheet.dart';
 
 part 'actions/bookmark_actions.dart';
 part 'actions/manage_actions.dart';

--- a/lib/widgets/post/post_signature_block.dart
+++ b/lib/widgets/post/post_signature_block.dart
@@ -6,6 +6,7 @@ import '../../providers/preferences_provider.dart';
 import '../../services/preloaded_data_service.dart';
 import '../../utils/fluxdo_render_callbacks.dart';
 import '../content/discourse_image.dart';
+import '../content/signature_animation_scope.dart';
 
 /// 帖子底部的用户签名区块（discourse-signatures 插件）。
 ///
@@ -100,6 +101,11 @@ class _PostSignatureBlockState extends ConsumerState<PostSignatureBlock> {
 
     final theme = Theme.of(context);
     final preloaded = PreloadedDataService();
+    final adaptiveFrameRate = ref.watch(
+      preferencesProvider.select(
+        (preferences) => preferences.adaptiveSignatureFrameRate,
+      ),
+    );
 
     // URL 模式:user_signature 是图片地址(advanced 关)。合法性已由
     // shouldRender 把关;此处兜底——非法地址(历史脏数据可为任意
@@ -156,7 +162,10 @@ class _PostSignatureBlockState extends ConsumerState<PostSignatureBlock> {
             ),
           ),
         ),
-        child: content,
+        child: SignatureAnimationScope(
+          adaptiveFrameRate: adaptiveFrameRate,
+          child: content,
+        ),
       ),
     );
   }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <audioplayers_linux/audioplayers_linux_plugin.h>
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_acrylic/flutter_acrylic_plugin.h>
@@ -16,7 +17,6 @@
 #include <flutter_timezone/flutter_timezone_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <irondash_engine_context/irondash_engine_context_plugin.h>
-#include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <quickjs_engine/quickjs_engine_plugin.h>
 #include <record_linux/record_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -25,6 +25,9 @@
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) audioplayers_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "AudioplayersLinuxPlugin");
+  audioplayers_linux_plugin_register_with_registrar(audioplayers_linux_registrar);
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
@@ -55,9 +58,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
   irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
-  g_autoptr(FlPluginRegistrar) media_kit_libs_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitLibsLinuxPlugin");
-  media_kit_libs_linux_plugin_register_with_registrar(media_kit_libs_linux_registrar);
   g_autoptr(FlPluginRegistrar) quickjs_engine_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "QuickjsEnginePlugin");
   quickjs_engine_plugin_register_with_registrar(quickjs_engine_registrar);

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -16,6 +16,7 @@
 #include <flutter_timezone/flutter_timezone_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <irondash_engine_context/irondash_engine_context_plugin.h>
+#include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <quickjs_engine/quickjs_engine_plugin.h>
 #include <record_linux/record_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -54,6 +55,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) irondash_engine_context_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "IrondashEngineContextPlugin");
   irondash_engine_context_plugin_register_with_registrar(irondash_engine_context_registrar);
+  g_autoptr(FlPluginRegistrar) media_kit_libs_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "MediaKitLibsLinuxPlugin");
+  media_kit_libs_linux_plugin_register_with_registrar(media_kit_libs_linux_registrar);
   g_autoptr(FlPluginRegistrar) quickjs_engine_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "QuickjsEnginePlugin");
   quickjs_engine_plugin_register_with_registrar(quickjs_engine_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  audioplayers_linux
   dynamic_color
   file_selector_linux
   flutter_acrylic
@@ -13,7 +14,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_timezone
   gtk
   irondash_engine_context
-  media_kit_libs_linux
   quickjs_engine
   record_linux
   screen_retriever_linux

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -13,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_timezone
   gtk
   irondash_engine_context
+  media_kit_libs_linux
   quickjs_engine
   record_linux
   screen_retriever_linux

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
+  audioplayers_linux:
+    dependency: "direct main"
+    description:
+      name: audioplayers_linux
+      sha256: "15178b726b7cdee5364d0463c8d445630c4e0fb7d26612b73c767e7d25de9417"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  audioplayers_platform_interface:
+    dependency: "direct main"
+    description:
+      name: audioplayers_platform_interface
+      sha256: "765f6f0e6dca55cb471c9483fc77700564b3484d19198aca4ebb5147c6c85acb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -1285,7 +1301,7 @@ packages:
     source: hosted
     version: "2.1.0"
   just_audio_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: just_audio_platform_interface
       sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
@@ -1404,14 +1420,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.6"
-  media_kit_libs_linux:
-    dependency: "direct main"
-    description:
-      name: media_kit_libs_linux
-      sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   media_kit_libs_windows_audio:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1276,6 +1276,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.6"
+  just_audio_media_kit:
+    dependency: "direct main"
+    description:
+      name: just_audio_media_kit
+      sha256: f3cf04c3a50339709e87e90b4e841eef4364ab4be2bdbac0c54cc48679f84d23
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   just_audio_platform_interface:
     dependency: transitive
     description:
@@ -1388,6 +1396,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2951.0"
+  media_kit:
+    dependency: transitive
+    description:
+      name: media_kit
+      sha256: ae9e79597500c7ad6083a3c7b7b7544ddabfceacce7ae5c9709b0ec16a5d6643
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
+  media_kit_libs_linux:
+    dependency: "direct main"
+    description:
+      name: media_kit_libs_linux
+      sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  media_kit_libs_windows_audio:
+    dependency: "direct main"
+    description:
+      name: media_kit_libs_windows_audio
+      sha256: c2fd558cc87b9d89a801141fcdffe02e338a3b21a41a18fbd63d5b221a1b8e53
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.9"
   melos:
     dependency: "direct dev"
     description:
@@ -1885,6 +1917,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  safe_local_storage:
+    dependency: transitive
+    description:
+      name: safe_local_storage
+      sha256: "7483b3d5e8976f0bd263647c03b96131ee8e43f48b56fa8a8ec459e8515d74b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   screen_retriever:
     dependency: "direct main"
     description:
@@ -2298,6 +2338,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   unorm_dart:
     dependency: transitive
     description:
@@ -2306,6 +2354,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2"
+  uri_parser:
+    dependency: transitive
+    description:
+      name: uri_parser
+      sha256: "051c62e5f693de98ca9f130ee707f8916e2266945565926be3ff20659f7853ce"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   url_launcher:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -161,10 +161,19 @@ dependencies:
   chewie: any
   video_player: any
   just_audio: ^0.10.6 # 原生上传音频播放(FluxdoRender audioBuilder)
-  # just_audio 本身不包含 Windows/Linux 实现；桌面端使用 media_kit 后端。
+  # just_audio 本身不包含 Windows/Linux 实现。
+  # - Windows: media_kit 后端(自带 libmpv-2.dll)。
+  # - Linux: 自写 GStreamer 桥(services/audio/just_audio_gst.dart),经
+  #   audioplayers_linux 走 GNOME runtime 自带的 GStreamer。不用 media_kit:
+  #   media_kit_libs_linux 不打包 libmpv(指望系统已装),且其 CMake 会在
+  #   configure 期联网下载 mimalloc —— flatpak 禁网沙箱里直接 FATAL_ERROR。
+  #   只依赖 audioplayers_linux + platform_interface,不拉 audioplayers 主包,
+  #   避免给 Android/iOS 等平台塞进用不到的实现插件。
   just_audio_media_kit: ^2.1.0
   media_kit_libs_windows_audio: ^1.0.9
-  media_kit_libs_linux: ^1.2.1
+  just_audio_platform_interface: ^4.6.0 # JustAudioGst 实现平台接口
+  audioplayers_linux: ^4.3.0
+  audioplayers_platform_interface: ^7.2.0
   rhttp:
     git:
       url: https://github.com/Lingyan000/rhttp_plus.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -161,6 +161,10 @@ dependencies:
   chewie: any
   video_player: any
   just_audio: ^0.10.6 # 原生上传音频播放(FluxdoRender audioBuilder)
+  # just_audio 本身不包含 Windows/Linux 实现；桌面端使用 media_kit 后端。
+  just_audio_media_kit: ^2.1.0
+  media_kit_libs_windows_audio: ^1.0.9
+  media_kit_libs_linux: ^1.2.1
   rhttp:
     git:
       url: https://github.com/Lingyan000/rhttp_plus.git

--- a/test/pages/topic_detail_page/ai_chat_input_shortcut_test.dart
+++ b/test/pages/topic_detail_page/ai_chat_input_shortcut_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/l10n/s.dart';
+import 'package:fluxdo/pages/topic_detail_page/widgets/ai_chat_input.dart';
+
+void main() {
+  testWidgets('AI 输入框聚焦时 Esc 只触发页内返回', (tester) async {
+    var escapeCalls = 0;
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          localizationsDelegates: const [
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocaleUtils.supportedLocales,
+          home: Scaffold(
+            body: AiChatInput(
+              isGenerating: false,
+              onSend: (_, _) {},
+              onStop: () {},
+              onEscape: () => escapeCalls++,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(escapeCalls, 1);
+  });
+}

--- a/test/providers/preferences_provider_test.dart
+++ b/test/providers/preferences_provider_test.dart
@@ -55,4 +55,25 @@ void main() {
       BookmarksOpenMode.defaultRoute,
     );
   });
+
+  test('AI 翻译偏好可以持久化并恢复', () async {
+    final container = await _createContainer();
+    addTearDown(container.dispose);
+
+    final notifier = container.read(preferencesProvider.notifier);
+    await notifier.setAiTranslationEnabled(true);
+    await notifier.setAiTranslationTargetLanguage('ja');
+    await notifier.setAiTranslationModelKey('provider:model');
+
+    final prefs = container.read(sharedPreferencesProvider);
+    final reloaded = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(reloaded.dispose);
+
+    final state = reloaded.read(preferencesProvider);
+    expect(state.aiTranslationEnabled, isTrue);
+    expect(state.aiTranslationTargetLanguage, 'ja');
+    expect(state.aiTranslationModelKey, 'provider:model');
+  });
 }

--- a/test/services/ai_translation_service_test.dart
+++ b/test/services/ai_translation_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/ai_translation_service.dart';
+
+void main() {
+  test('从 cooked HTML 提取可翻译文本并保留图片 alt', () {
+    final text = AiTranslationService.extractPlainText(
+      '<p>Hello <strong>world</strong></p><p><img alt=":wave:"></p>',
+    );
+
+    expect(text, contains('Hello world'));
+    expect(text, contains(':wave:'));
+  });
+
+  test('系统提示包含目标语言和只输出译文约束', () {
+    final prompt = AiTranslationService.buildSystemPrompt('日本語');
+
+    expect(prompt, contains('日本語'));
+    expect(prompt, contains('只输出译文本身'));
+  });
+}

--- a/test/services/ai_translation_service_test.dart
+++ b/test/services/ai_translation_service_test.dart
@@ -11,6 +11,28 @@ void main() {
     expect(text, contains(':wave:'));
   });
 
+  test('超长内容截断到段落边界并标记 truncated', () {
+    final paragraph = '${'字' * 799}\n';
+    final long = paragraph * 25; // 20000 字符,超过 16000 上限
+
+    final clamped = AiTranslationService.clampForTranslation(long);
+
+    expect(clamped.truncated, isTrue);
+    expect(
+      clamped.text.length,
+      lessThanOrEqualTo(AiTranslationService.maxTranslateChars),
+    );
+    // 截在换行处,不劈开句子
+    expect(clamped.text, endsWith('字'));
+    expect(long.substring(clamped.text.length, clamped.text.length + 1), '\n');
+  });
+
+  test('未超限内容原样返回', () {
+    final clamped = AiTranslationService.clampForTranslation('短内容');
+    expect(clamped.truncated, isFalse);
+    expect(clamped.text, '短内容');
+  });
+
   test('系统提示包含目标语言和只输出译文约束', () {
     final prompt = AiTranslationService.buildSystemPrompt('日本語');
 

--- a/test/services/just_audio_gst_test.dart
+++ b/test/services/just_audio_gst_test.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:audioplayers_platform_interface/audioplayers_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/audio/just_audio_gst.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+
+/// 记录调用并允许测试手动喂事件的 audioplayers 假实现。
+class _FakeAudioplayers extends AudioplayersPlatformInterface {
+  final calls = <String>[];
+  final events = StreamController<AudioEvent>.broadcast(sync: true);
+  int? durationMs = 5000;
+  int? positionMs = 0;
+
+  @override
+  Future<void> create(String playerId) async => calls.add('create');
+
+  @override
+  Future<void> dispose(String playerId) async => calls.add('dispose');
+
+  @override
+  Future<void> pause(String playerId) async => calls.add('pause');
+
+  @override
+  Future<void> stop(String playerId) async => calls.add('stop');
+
+  @override
+  Future<void> resume(String playerId) async => calls.add('resume');
+
+  @override
+  Future<void> release(String playerId) async => calls.add('release');
+
+  @override
+  Future<void> seek(String playerId, Duration position) async =>
+      calls.add('seek:${position.inMilliseconds}');
+
+  @override
+  Future<void> setBalance(String playerId, double balance) async {}
+
+  @override
+  Future<void> setVolume(String playerId, double volume) async =>
+      calls.add('setVolume:$volume');
+
+  @override
+  Future<void> setReleaseMode(String playerId, ReleaseMode releaseMode) async =>
+      calls.add('setReleaseMode:${releaseMode.name}');
+
+  @override
+  Future<void> setPlaybackRate(String playerId, double playbackRate) async =>
+      calls.add('setPlaybackRate:$playbackRate');
+
+  @override
+  Future<void> setSourceUrl(
+    String playerId,
+    String url, {
+    bool? isLocal,
+    String? mimeType,
+  }) async => calls.add('setSourceUrl:$url');
+
+  @override
+  Future<void> setSourceBytes(
+    String playerId,
+    Uint8List bytes, {
+    String? mimeType,
+  }) async {}
+
+  @override
+  Future<void> setAudioContext(
+    String playerId,
+    AudioContext audioContext,
+  ) async {}
+
+  @override
+  Future<void> setPlayerMode(String playerId, PlayerMode playerMode) async {}
+
+  @override
+  Future<int?> getDuration(String playerId) async => durationMs;
+
+  @override
+  Future<int?> getCurrentPosition(String playerId) async => positionMs;
+
+  @override
+  Future<void> emitLog(String playerId, String message) async {}
+
+  @override
+  Future<void> emitError(String playerId, String code, String message) async {}
+
+  @override
+  Stream<AudioEvent> getEventStream(String playerId) => events.stream;
+}
+
+void main() {
+  late _FakeAudioplayers fake;
+  late JustAudioGst platform;
+
+  setUp(() {
+    fake = _FakeAudioplayers();
+    AudioplayersPlatformInterface.instance = fake;
+    platform = JustAudioGst();
+  });
+
+  Future<AudioPlayerPlatform> initPlayer() =>
+      platform.init(InitRequest(id: 'p1'));
+
+  LoadRequest urlRequest([String url = 'https://example.com/a.mp3']) =>
+      LoadRequest(
+        audioSourceMessage: ProgressiveAudioSourceMessage(
+          id: 's1',
+          uri: url,
+          headers: null,
+          tag: null,
+        ),
+      );
+
+  test('init 创建播放器并设置 stop 释放模式(对齐 just_audio 播完语义)', () async {
+    await initPlayer();
+    expect(fake.calls, contains('create'));
+    expect(fake.calls, contains('setReleaseMode:stop'));
+  });
+
+  test('load 等待 prepared 事件后返回时长', () async {
+    final player = await initPlayer();
+    final loading = player.load(urlRequest());
+
+    // prepared 事件到达前 load 不应完成
+    var done = false;
+    unawaited(loading.then((_) => done = true));
+    await Future<void>.delayed(Duration.zero);
+    expect(done, isFalse);
+
+    fake.events.add(
+      const AudioEvent(eventType: AudioEventType.prepared, isPrepared: true),
+    );
+    final response = await loading;
+    expect(response.duration, const Duration(seconds: 5));
+  });
+
+  test('complete 事件映射为 completed 且位置钉在末尾', () async {
+    final player = await initPlayer();
+    final loading = player.load(urlRequest());
+    fake.events.add(
+      const AudioEvent(eventType: AudioEventType.prepared, isPrepared: true),
+    );
+    await loading;
+
+    final completed = player.playbackEventMessageStream.firstWhere(
+      (e) => e.processingState == ProcessingStateMessage.completed,
+    );
+    fake.events.add(const AudioEvent(eventType: AudioEventType.complete));
+    final event = await completed;
+    expect(event.updatePosition, const Duration(seconds: 5));
+  });
+
+  test('completed 后 seek 回 ready,可重新播放', () async {
+    final player = await initPlayer();
+    final loading = player.load(urlRequest());
+    fake.events.add(
+      const AudioEvent(eventType: AudioEventType.prepared, isPrepared: true),
+    );
+    await loading;
+    fake.events.add(const AudioEvent(eventType: AudioEventType.complete));
+
+    final ready = player.playbackEventMessageStream.firstWhere(
+      (e) => e.processingState == ProcessingStateMessage.ready,
+    );
+    await player.seek(SeekRequest(position: Duration.zero));
+    final event = await ready;
+    expect(event.updatePosition, Duration.zero);
+    expect(fake.calls, contains('seek:0'));
+  });
+
+  test('加载失败经事件流错误抛出,而不是永久挂起', () async {
+    final player = await initPlayer();
+    final loading = player.load(urlRequest());
+    fake.events.addError(Exception('gst error'));
+    await expectLater(loading, throwsA(isA<Exception>()));
+  });
+
+  test('不支持的音源类型直接拒绝', () async {
+    final player = await initPlayer();
+    await expectLater(
+      player.load(
+        LoadRequest(
+          audioSourceMessage: ConcatenatingAudioSourceMessage(
+            id: 'list',
+            children: const [],
+            useLazyPreparation: false,
+            shuffleOrder: const [],
+          ),
+        ),
+      ),
+      throwsA(isA<Exception>()),
+    );
+  });
+
+  test('disposePlayer 释放底层播放器,重复 id 可再创建', () async {
+    await initPlayer();
+    await platform.disposePlayer(DisposePlayerRequest(id: 'p1'));
+    expect(fake.calls, contains('dispose'));
+    // 释放后同 id 重新 init 不应抛"already exists"
+    await initPlayer();
+  });
+}

--- a/test/services/signature_frame_scheduler_test.dart
+++ b/test/services/signature_frame_scheduler_test.dart
@@ -6,30 +6,65 @@ void main() {
 
   tearDown(scheduler.debugReset);
 
-  test('连续高负载快速从 24 FPS 降到 12/6 FPS', () {
-    expect(scheduler.targetFps, 24);
+  test('顶档不高于关闭自适应时的固定帧率', () {
+    // AnimatedSvgView 关闭自适应时是固定 15 FPS。顶档一旦超过它，
+    // 这个默认开启的「降帧减卡顿」开关就会变成加帧开关。
+    expect(scheduler.targetFps, lessThanOrEqualTo(15));
+  });
+
+  test('连续高负载快速从 15 FPS 降到 8/4 FPS', () {
+    expect(scheduler.targetFps, 15);
     for (var i = 0; i < 2; i++) {
       scheduler.debugRecordLoad(workMicros: 16000);
     }
-    expect(scheduler.targetFps, 12);
+    expect(scheduler.targetFps, 8);
     for (var i = 0; i < 2; i++) {
       scheduler.debugRecordLoad(workMicros: 16000);
     }
-    expect(scheduler.targetFps, 6);
+    expect(scheduler.targetFps, 4);
+  });
+
+  test('唤醒延迟连击不被穿插的健康 UI 帧清零', () {
+    // 两个派发样本(15Hz)之间必然夹着大量健康 UI 帧样本(60-120Hz)。
+    // 唤醒延迟若与帧耗时共用一条 streak,连击会被清零、信号永远失效。
+    scheduler.debugRecordLoad(workMicros: 1000, wakeLagMicros: 10000);
+    for (var i = 0; i < 8; i++) {
+      scheduler.debugRecordLoad(workMicros: 3000); // 健康 UI 帧
+    }
+    expect(scheduler.targetFps, 15);
+    scheduler.debugRecordLoad(workMicros: 1000, wakeLagMicros: 10000);
+    expect(scheduler.targetFps, 8);
   });
 
   test('健康帧持续一段时间后缓慢恢复帧率', () {
     for (var i = 0; i < 4; i++) {
       scheduler.debugRecordLoad(workMicros: 16000);
     }
-    expect(scheduler.targetFps, 6);
+    expect(scheduler.targetFps, 4);
 
     for (var i = 0; i < 119; i++) {
       scheduler.debugRecordLoad(workMicros: 3000);
     }
-    expect(scheduler.targetFps, 6);
+    expect(scheduler.targetFps, 4);
     scheduler.debugRecordLoad(workMicros: 3000);
-    expect(scheduler.targetFps, 12);
+    expect(scheduler.targetFps, 8);
+  });
+
+  testWidgets('多订阅者每人每 tick 都推进一帧,不被摊薄', (tester) async {
+    final a = Object();
+    final b = Object();
+    var callsA = 0;
+    var callsB = 0;
+    scheduler.subscribe(owner: a, onFrame: (_) => callsA++);
+    scheduler.subscribe(owner: b, onFrame: (_) => callsB++);
+
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(callsA, greaterThan(0));
+    expect(callsA, callsB);
+
+    scheduler.unsubscribe(a);
+    scheduler.unsubscribe(b);
   });
 
   testWidgets('取消订阅后停止共享调度', (tester) async {

--- a/test/services/signature_frame_scheduler_test.dart
+++ b/test/services/signature_frame_scheduler_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/signature_frame_scheduler.dart';
+
+void main() {
+  final scheduler = SignatureFrameScheduler.instance;
+
+  tearDown(scheduler.debugReset);
+
+  test('连续高负载快速从 24 FPS 降到 12/6 FPS', () {
+    expect(scheduler.targetFps, 24);
+    for (var i = 0; i < 2; i++) {
+      scheduler.debugRecordLoad(workMicros: 16000);
+    }
+    expect(scheduler.targetFps, 12);
+    for (var i = 0; i < 2; i++) {
+      scheduler.debugRecordLoad(workMicros: 16000);
+    }
+    expect(scheduler.targetFps, 6);
+  });
+
+  test('健康帧持续一段时间后缓慢恢复帧率', () {
+    for (var i = 0; i < 4; i++) {
+      scheduler.debugRecordLoad(workMicros: 16000);
+    }
+    expect(scheduler.targetFps, 6);
+
+    for (var i = 0; i < 119; i++) {
+      scheduler.debugRecordLoad(workMicros: 3000);
+    }
+    expect(scheduler.targetFps, 6);
+    scheduler.debugRecordLoad(workMicros: 3000);
+    expect(scheduler.targetFps, 12);
+  });
+
+  testWidgets('取消订阅后停止共享调度', (tester) async {
+    final owner = Object();
+    var calls = 0;
+    scheduler.subscribe(owner: owner, onFrame: (_) => calls++);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(calls, greaterThan(0));
+
+    scheduler.unsubscribe(owner);
+    final stoppedAt = calls;
+    await tester.pump(const Duration(milliseconds: 200));
+    expect(calls, stoppedAt);
+    expect(scheduler.debugSubscriberCount, 0);
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -18,6 +18,7 @@
 #include <flutter_timezone/flutter_timezone_plugin_c_api.h>
 #include <gal/gal_plugin_c_api.h>
 #include <irondash_engine_context/irondash_engine_context_plugin_c_api.h>
+#include <media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h>
 #include <quickjs_engine/quickjs_engine_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
@@ -51,6 +52,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("GalPluginCApi"));
   IrondashEngineContextPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IrondashEngineContextPluginCApi"));
+  MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MediaKitLibsWindowsAudioPluginCApi"));
   QuickjsEnginePluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("QuickjsEnginePlugin"));
   RecordWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   flutter_timezone
   gal
   irondash_engine_context
+  media_kit_libs_windows_audio
   quickjs_engine
   record_windows
   screen_retriever_windows


### PR DESCRIPTION
从 #336 拆出的内容与媒体提交。包含小尾巴动画 SVG 自适应帧率、AI 流式翻译、私信 @ 搜索修复、桌面端 @ 点选、Windows/Linux 音频后端和话题搜索/AI 页 Esc 返回。fluxdo_render 更新因 dev 已指向同一提交而作为空提交跳过。
验证：定向测试 10 项通过；改动文件定向分析无错误（仅 1 条基线 lint info）；git diff --check 通过。