### PR TITLE
feat:平行视界与追觅功能

### DIFF
--- a/lib/l10n/modules/search/search_en.arb
+++ b/lib/l10n/modules/search/search_en.arb
@@ -23,6 +23,7 @@
   "search_noLimit": "No limit",
   "search_noPopularTags": "No popular tags",
   "search_noResults": "No results found",
+  "search_selectResultHint": "Select a search result to view its details here",
   "search_popularTags": "Popular tags",
   "search_recentSearches": "Recent searches",
   "search_replyCount": "{count} replies",

--- a/lib/l10n/modules/search/search_zh.arb
+++ b/lib/l10n/modules/search/search_zh.arb
@@ -51,6 +51,7 @@
   "search_noLimit": "不限",
   "search_noPopularTags": "暂无热门标签",
   "search_noResults": "没有找到相关结果",
+  "search_selectResultHint": "选择一个搜索结果，在此处查看详情",
   "search_popularTags": "热门标签",
   "search_recentSearches": "最近搜索",
   "search_replyCount": "{count} 条回复",

--- a/lib/l10n/modules/search/search_zh_HK.arb
+++ b/lib/l10n/modules/search/search_zh_HK.arb
@@ -51,6 +51,7 @@
   "search_noLimit": "不限",
   "search_noPopularTags": "暫無熱門標籤",
   "search_noResults": "沒有找到相關結果",
+  "search_selectResultHint": "選擇一個搜索結果，在此處查看詳情",
   "search_popularTags": "熱門標籤",
   "search_recentSearches": "最近搜索",
   "search_replyCount": "{count} 條回覆",

--- a/lib/l10n/modules/search/search_zh_TW.arb
+++ b/lib/l10n/modules/search/search_zh_TW.arb
@@ -51,6 +51,7 @@
   "search_noLimit": "不限",
   "search_noPopularTags": "暫無熱門標籤",
   "search_noResults": "沒有找到相關結果",
+  "search_selectResultHint": "選擇一個搜尋結果，在此處查看詳情",
   "search_popularTags": "熱門標籤",
   "search_recentSearches": "最近搜尋",
   "search_replyCount": "{count} 條回覆",

--- a/lib/l10n/modules/seeking/seeking_en.arb
+++ b/lib/l10n/modules/seeking/seeking_en.arb
@@ -1,0 +1,40 @@
+{
+  "seeking_title": "Seeking",
+  "seeking_addUser": "Add user",
+  "seeking_addUserHint": "Enter username",
+  "seeking_removeUser": "Stop watching",
+  "seeking_userExists": "This user is already being watched",
+  "seeking_userLimit": "Watch limit is {max} users",
+  "@seeking_userLimit": {
+    "placeholders": {
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollow": "Sync following",
+  "seeking_syncFollowDone": "Imported {count} followed users",
+  "@seeking_syncFollowDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollowFailed": "Failed to sync following. Please try again later",
+  "seeking_userNotFound": "User not found",
+  "seeking_addUserFailed": "Failed to add user. Please try again later",
+  "seeking_paceTitle": "Request rate",
+  "seeking_paceHigh": "High",
+  "seeking_paceMedium": "Medium",
+  "seeking_paceLow": "Low",
+  "seeking_emptyHint": "Add users whose activity you want to watch.\nOnce enabled, their posts / replies / likes / reactions / boosts are polled automatically",
+  "seeking_waitingData": "Waiting for the first round of data…",
+  "seeking_disabledHint": "Watching is off. Toggle the switch in the top right to start",
+  "seeking_rateLimited": "Rate limited. Paused until the next minute, then resumes automatically",
+  "seeking_typePost": "posted",
+  "seeking_typeReply": "replied to",
+  "seeking_typeLike": "liked",
+  "seeking_typeReaction": "reacted to",
+  "seeking_typeBoost": "boosted"
+}

--- a/lib/l10n/modules/seeking/seeking_zh.arb
+++ b/lib/l10n/modules/seeking/seeking_zh.arb
@@ -1,0 +1,40 @@
+{
+  "seeking_title": "追觅",
+  "seeking_addUser": "添加用户",
+  "seeking_addUserHint": "输入用户名",
+  "seeking_removeUser": "移除监控",
+  "seeking_userExists": "该用户已在监控列表中",
+  "seeking_userLimit": "监控上限 {max} 人",
+  "@seeking_userLimit": {
+    "placeholders": {
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollow": "同步关注",
+  "seeking_syncFollowDone": "已导入 {count} 位关注用户",
+  "@seeking_syncFollowDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollowFailed": "同步关注失败，请稍后重试",
+  "seeking_userNotFound": "未找到该用户",
+  "seeking_addUserFailed": "添加用户失败，请稍后重试",
+  "seeking_paceTitle": "请求频率",
+  "seeking_paceHigh": "高",
+  "seeking_paceMedium": "中",
+  "seeking_paceLow": "低",
+  "seeking_emptyHint": "添加想要关注动态的用户，\n开启开关后将自动轮询其发帖 / 回复 / 点赞 / 回应 / Boost",
+  "seeking_waitingData": "等待第一轮数据…",
+  "seeking_disabledHint": "监控已关闭，打开右上角开关开始追觅",
+  "seeking_rateLimited": "触发限流，已暂停到下一分钟自动恢复",
+  "seeking_typePost": "发布了话题",
+  "seeking_typeReply": "回复了",
+  "seeking_typeLike": "点赞了",
+  "seeking_typeReaction": "回应了",
+  "seeking_typeBoost": "Boost 了"
+}

--- a/lib/l10n/modules/seeking/seeking_zh_HK.arb
+++ b/lib/l10n/modules/seeking/seeking_zh_HK.arb
@@ -1,0 +1,40 @@
+{
+  "seeking_title": "追覓",
+  "seeking_addUser": "添加用戶",
+  "seeking_addUserHint": "輸入用戶名",
+  "seeking_removeUser": "移除監控",
+  "seeking_userExists": "該用戶已在監控列表中",
+  "seeking_userLimit": "監控上限 {max} 人",
+  "@seeking_userLimit": {
+    "placeholders": {
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollow": "同步關注",
+  "seeking_syncFollowDone": "已導入 {count} 位關注用戶",
+  "@seeking_syncFollowDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollowFailed": "同步關注失敗，請稍後重試",
+  "seeking_userNotFound": "未找到該用戶",
+  "seeking_addUserFailed": "添加用戶失敗，請稍後重試",
+  "seeking_paceTitle": "請求頻率",
+  "seeking_paceHigh": "高",
+  "seeking_paceMedium": "中",
+  "seeking_paceLow": "低",
+  "seeking_emptyHint": "添加想要關注動態的用戶，\n開啟開關後將自動輪詢其發帖 / 回覆 / 點讚 / 回應 / Boost",
+  "seeking_waitingData": "等待第一輪數據…",
+  "seeking_disabledHint": "監控已關閉，打開右上角開關開始追覓",
+  "seeking_rateLimited": "觸發限流，已暫停到下一分鐘自動恢復",
+  "seeking_typePost": "發佈了話題",
+  "seeking_typeReply": "回覆了",
+  "seeking_typeLike": "點讚了",
+  "seeking_typeReaction": "回應了",
+  "seeking_typeBoost": "Boost 了"
+}

--- a/lib/l10n/modules/seeking/seeking_zh_TW.arb
+++ b/lib/l10n/modules/seeking/seeking_zh_TW.arb
@@ -1,0 +1,40 @@
+{
+  "seeking_title": "追覓",
+  "seeking_addUser": "新增使用者",
+  "seeking_addUserHint": "輸入使用者名稱",
+  "seeking_removeUser": "移除監控",
+  "seeking_userExists": "該使用者已在監控清單中",
+  "seeking_userLimit": "監控上限 {max} 人",
+  "@seeking_userLimit": {
+    "placeholders": {
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollow": "同步關注",
+  "seeking_syncFollowDone": "已匯入 {count} 位關注使用者",
+  "@seeking_syncFollowDone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "seeking_syncFollowFailed": "同步關注失敗，請稍後再試",
+  "seeking_userNotFound": "找不到該使用者",
+  "seeking_addUserFailed": "新增使用者失敗，請稍後再試",
+  "seeking_paceTitle": "請求頻率",
+  "seeking_paceHigh": "高",
+  "seeking_paceMedium": "中",
+  "seeking_paceLow": "低",
+  "seeking_emptyHint": "新增想要關注動態的使用者，\n開啟開關後將自動輪詢其發文 / 回覆 / 按讚 / 回應 / Boost",
+  "seeking_waitingData": "等待第一輪資料…",
+  "seeking_disabledHint": "監控已關閉，打開右上角開關開始追覓",
+  "seeking_rateLimited": "觸發限流，已暫停到下一分鐘自動恢復",
+  "seeking_typePost": "發佈了話題",
+  "seeking_typeReply": "回覆了",
+  "seeking_typeLike": "按讚了",
+  "seeking_typeReaction": "回應了",
+  "seeking_typeBoost": "Boost 了"
+}

--- a/lib/l10n/modules/settings/settings_en.arb
+++ b/lib/l10n/modules/settings/settings_en.arb
@@ -101,6 +101,7 @@
   "settings_searchHint": "Search settings...",
   "settings_shortcuts": "Keyboard Shortcuts",
   "settings_title": "App Settings",
+  "settings_selectHint": "Select a setting on the left to configure it here",
   "shortcuts_closeOverlay": "Close Overlay",
   "shortcuts_composer": "Composer",
   "shortcuts_composerSubmit": "Submit (send/publish)",

--- a/lib/l10n/modules/settings/settings_zh.arb
+++ b/lib/l10n/modules/settings/settings_zh.arb
@@ -118,6 +118,7 @@
   "settings_searchHint": "搜索设置项...",
   "settings_shortcuts": "快捷键",
   "settings_title": "应用设置",
+  "settings_selectHint": "选择左侧设置项，在此处进行配置",
   "shortcuts_closeOverlay": "关闭浮层",
   "shortcuts_composer": "撰写",
   "shortcuts_composerSubmit": "提交（发送/发布）",

--- a/lib/l10n/modules/settings/settings_zh_HK.arb
+++ b/lib/l10n/modules/settings/settings_zh_HK.arb
@@ -101,6 +101,7 @@
   "settings_searchHint": "搜尋設定項...",
   "settings_shortcuts": "快捷鍵",
   "settings_title": "應用設定",
+  "settings_selectHint": "選擇左側設定項，在此處進行配置",
   "shortcuts_closeOverlay": "關閉浮層",
   "shortcuts_composer": "撰寫",
   "shortcuts_composerSubmit": "提交（傳送/發佈）",

--- a/lib/l10n/modules/settings/settings_zh_TW.arb
+++ b/lib/l10n/modules/settings/settings_zh_TW.arb
@@ -101,6 +101,7 @@
   "settings_searchHint": "搜尋設定項...",
   "settings_shortcuts": "快捷鍵",
   "settings_title": "應用設定",
+  "settings_selectHint": "選擇左側設定項，在此處進行設定",
   "shortcuts_closeOverlay": "關閉浮層",
   "shortcuts_composer": "撰寫",
   "shortcuts_composerSubmit": "提交（傳送/發佈）",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1462,7 +1462,16 @@ class _MainPageState extends ConsumerState<MainPage>
             for (int i = 0; i < pageEntries.length; i++)
               KeyedSubtree(
                 key: ValueKey('nav-entry-${pageEntries[i].id}'),
-                child: pageEntries[i].pageBuilder!(context, safePageIndex == i),
+                child: TickerMode(
+                  enabled: safePageIndex == i,
+                  child: ExcludeFocus(
+                    excluding: safePageIndex != i,
+                    child: pageEntries[i].pageBuilder!(
+                      context,
+                      safePageIndex == i,
+                    ),
+                  ),
+                ),
               ),
           ],
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -106,6 +106,7 @@ import 'providers/read_later_provider.dart';
 import 'providers/shortcut_provider.dart';
 import 'widgets/keyboard_shortcut_handler.dart';
 import 'utils/platform_utils.dart';
+import 'utils/discourse_url_parser.dart';
 
 /// 初始化 rhttp Rust runtime
 Future<bool> _initRhttp() async {
@@ -1232,7 +1233,25 @@ class _MainPageState extends ConsumerState<MainPage>
         context.l10n.preferences_clipboardTopicLink_detected,
         duration: const Duration(seconds: 8),
         actionLabel: context.l10n.preferences_clipboardTopicLink_open,
-        onAction: () => DeepLinkService.instance.handleUri(candidate.uri),
+        // 能解析成话题链接就进首页平行视界（选中 + 切 tab），解析不了
+        // 再退回深链通道
+        onAction: () {
+          final topic = DiscourseUrlParser.parseTopic(
+            candidate.uri.toString(),
+          );
+          if (topic != null) {
+            ref
+                .read(selectedTopicProvider.notifier)
+                .select(
+                  topicId: topic.topicId,
+                  initialTitle: topic.slug,
+                  scrollToPostNumber: topic.postNumber,
+                );
+            ref.requestNavDestination(NavEntryIds.home);
+          } else {
+            DeepLinkService.instance.handleUri(candidate.uri);
+          }
+        },
       );
     } finally {
       _clipboardCheckInFlight = false;
@@ -1359,6 +1378,18 @@ class _MainPageState extends ConsumerState<MainPage>
         ref.read(barVisibilityProvider.notifier).state = 1.0;
         setState(() => _currentIndex = index);
       }
+    });
+
+    // 通知、深链等外部入口按稳定 id 切换工作区，避免用户重排底栏后
+    // 数字下标指向错误页面。
+    ref.listen(navDestinationRequestProvider, (_, request) {
+      if (request == null) return;
+      final index = pageEntries.indexWhere(
+        (entry) => entry.id == request.targetId,
+      );
+      if (index < 0 || index == _currentIndex) return;
+      ref.read(barVisibilityProvider.notifier).state = 1.0;
+      setState(() => _currentIndex = index);
     });
 
     final destinations = [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,6 +96,7 @@ import 'widgets/preheat_gate.dart';
 import 'widgets/onboarding_gate.dart';
 import 'widgets/layout/adaptive_scaffold.dart';
 import 'widgets/layout/adaptive_navigation.dart';
+import 'widgets/layout/master_detail_layout.dart';
 import 'widgets/notification/notification_quick_panel.dart';
 import 'widgets/topic/category_drawer.dart' show CategoryDrawerHost;
 import 'widgets/read_later/read_later_bubble.dart';
@@ -1233,13 +1234,15 @@ class _MainPageState extends ConsumerState<MainPage>
         context.l10n.preferences_clipboardTopicLink_detected,
         duration: const Duration(seconds: 8),
         actionLabel: context.l10n.preferences_clipboardTopicLink_open,
-        // 能解析成话题链接就进首页平行视界（选中 + 切 tab），解析不了
-        // 再退回深链通道
+        // 宽屏且能解析成话题链接就进首页平行视界（选中 + 切 tab）；
+        // 窄屏没有「写栈 → 推详情」的桥（同通知入口的窄屏问题），
+        // 和解析失败一样退回深链通道全屏打开
         onAction: () {
           final topic = DiscourseUrlParser.parseTopic(
             candidate.uri.toString(),
           );
-          if (topic != null) {
+          if (topic != null &&
+              MasterDetailLayout.canShowBothPanesFor(context)) {
             ref
                 .read(selectedTopicProvider.notifier)
                 .select(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:flutter_acrylic/flutter_acrylic.dart' as acrylic;
 import 'pages/topics_page.dart';
 import 'pages/data_management_page.dart';
 import 'providers/discourse_providers.dart';
+import 'providers/selected_topic_provider.dart';
 import 'providers/locale_provider.dart';
 import 'widgets/ai/builtin_presets_factory.dart';
 import 'providers/message_bus_providers.dart';
@@ -1382,6 +1383,14 @@ class _MainPageState extends ConsumerState<MainPage>
     final hasNotificationEntry = entries.any(
       (e) => e.id == NavEntryIds.notifications,
     );
+    final activeEntryId = pageEntries[safePageIndex].id;
+    final topicParallelStacked = ref.watch(selectedTopicProvider).isStacked;
+    final messageParallelStacked = ref.watch(selectedMessageProvider).isStacked;
+    final seekingParallelStacked = ref.watch(selectedSeekingProvider).isStacked;
+    final hideNavigationRail =
+        (activeEntryId == NavEntryIds.home && topicParallelStacked) ||
+        (activeEntryId == NavEntryIds.messages && messageParallelStacked) ||
+        (activeEntryId == NavEntryIds.seeking && seekingParallelStacked);
 
     // 首页的 FAB 由 TopicsScreen 内部处理，避免切换时闪烁
     Widget page = PopScope(
@@ -1415,6 +1424,7 @@ class _MainPageState extends ConsumerState<MainPage>
         railBottomLeading: (user != null && !hasNotificationEntry)
             ? const NotificationIconButton()
             : null,
+        hideNavigationRail: hideNavigationRail,
         body: IndexedStack(
           index: safePageIndex,
           children: [

--- a/lib/models/draft.dart
+++ b/lib/models/draft.dart
@@ -135,6 +135,15 @@ class Draft {
   final String? avatarTemplate; // 头像模板
   final int? topicId; // 话题 ID
 
+  /// 目标话题的原型（`regular` / `private_message`），来自列表 API 的
+  /// **顶层** `archetype` 字段。
+  ///
+  /// **别用 [DraftData.archetypeId] 判私信**：那是 composer 自己的原型，
+  /// 回复一个已有私信时它照样是 `"regular"`（实测 `/drafts.json`
+  /// 返回 `data.archetypeId="regular"` 而顶层 `archetype="private_message"`）。
+  /// 只有顶层这个字段描述的是**话题**本身。
+  final String? archetype;
+
   const Draft({
     required this.draftKey,
     required this.data,
@@ -145,7 +154,13 @@ class Draft {
     this.username,
     this.avatarTemplate,
     this.topicId,
+    this.archetype,
   });
+
+  /// 这条草稿对应的是不是私信。
+  bool get isPrivateMessage =>
+      archetype == DraftAction.privateMessage.value ||
+      isNewPrivateMessageKey(draftKey);
 
   /// 从 API 响应解析
   factory Draft.fromJson(Map<String, dynamic> json) {
@@ -183,6 +198,7 @@ class Draft {
       username: json['username'] as String?,
       avatarTemplate: json['avatar_template'] as String?,
       topicId: topicId,
+      archetype: json['archetype'] as String?,
     );
   }
 
@@ -213,6 +229,7 @@ class Draft {
     String? username,
     String? avatarTemplate,
     int? topicId,
+    String? archetype,
   }) {
     return Draft(
       draftKey: draftKey ?? this.draftKey,
@@ -224,6 +241,7 @@ class Draft {
       username: username ?? this.username,
       avatarTemplate: avatarTemplate ?? this.avatarTemplate,
       topicId: topicId ?? this.topicId,
+      archetype: archetype ?? this.archetype,
     );
   }
 

--- a/lib/models/seeking.dart
+++ b/lib/models/seeking.dart
@@ -97,4 +97,16 @@ class SeekingUserProfile {
     if (template == null || template.isEmpty) return '';
     return template.replaceAll('{size}', '$size');
   }
+
+  /// 值相等：provider 靠它判断「资料没变就不重建状态」，
+  /// 避免每个轮询节拍都触发整页重建。
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SeekingUserProfile &&
+          other.lastSeenAt == lastSeenAt &&
+          other.avatarTemplate == avatarTemplate;
+
+  @override
+  int get hashCode => Object.hash(lastSeenAt, avatarTemplate);
 }

--- a/lib/models/seeking.dart
+++ b/lib/models/seeking.dart
@@ -1,0 +1,100 @@
+import 'user_action.dart';
+
+/// 追觅动态类型
+enum SeekingActivityType { post, reply, like, reaction, boost }
+
+/// 追觅（监控用户动态）的统一动态条目。
+///
+/// 由 /user_actions.json（发帖/回复/点赞）、discourse-reactions、
+/// discourse-boosts 三路数据归一化而来，按 createdAt 倒序合并。
+class SeekingActivity {
+  const SeekingActivity({
+    required this.uid,
+    required this.username,
+    required this.type,
+    required this.topicId,
+    this.postNumber,
+    required this.title,
+    this.excerpt,
+    this.reactionValue,
+    this.createdAt,
+  });
+
+  /// 全局唯一 id（新增检测用）：action 用 topicId_postNumber，
+  /// reaction/boost 用各自插件的自增 id。
+  final String uid;
+
+  /// 被监控用户名（动态的主体）
+  final String username;
+
+  final SeekingActivityType type;
+  final int topicId;
+  final int? postNumber;
+  final String title;
+  final String? excerpt;
+
+  /// reaction 的表情值（如 heart / tieba_087）
+  final String? reactionValue;
+
+  final DateTime? createdAt;
+
+  factory SeekingActivity.fromUserAction(String username, UserAction action) {
+    final type = switch (action.actionType) {
+      UserActionType.newTopic => SeekingActivityType.post,
+      UserActionType.like => SeekingActivityType.like,
+      _ => SeekingActivityType.reply,
+    };
+    return SeekingActivity(
+      uid: '${action.topicId}_${action.postNumber ?? 1}_${action.actionType}',
+      username: username,
+      type: type,
+      topicId: action.topicId,
+      postNumber: action.postNumber,
+      title: action.title,
+      excerpt: action.excerpt,
+      createdAt: action.actingAt,
+    );
+  }
+
+  factory SeekingActivity.fromReaction(String username, UserReaction reaction) {
+    return SeekingActivity(
+      uid: 'reaction_${reaction.id}',
+      username: username,
+      type: SeekingActivityType.reaction,
+      topicId: reaction.topicId,
+      postNumber: reaction.postNumber,
+      title: reaction.topicTitle ?? '',
+      excerpt: reaction.excerpt,
+      reactionValue: reaction.reactionValue,
+      createdAt: reaction.createdAt,
+    );
+  }
+
+  factory SeekingActivity.fromBoost(String username, UserBoost boost) {
+    return SeekingActivity(
+      uid: 'boost_${boost.id}',
+      username: username,
+      type: SeekingActivityType.boost,
+      topicId: boost.topicId,
+      // boost 链接可能没有楼层段（只 boost 话题本身），回退首楼
+      postNumber: boost.postNumber ?? 1,
+      title: boost.topicTitle ?? '',
+      excerpt: boost.excerpt ?? boost.cooked,
+      createdAt: boost.createdAt,
+    );
+  }
+}
+
+/// 被监控用户的轻量资料（两段式省请求的比较基准）。
+class SeekingUserProfile {
+  const SeekingUserProfile({this.lastSeenAt, this.avatarTemplate});
+
+  final DateTime? lastSeenAt;
+  final String? avatarTemplate;
+
+  String getAvatarUrl({int size = 120}) {
+    final template = avatarTemplate;
+    if (template == null || template.isEmpty) return '';
+    return template.replaceAll('{size}', '$size');
+  }
+}

--- a/lib/navigation/nav_action_bus.dart
+++ b/lib/navigation/nav_action_bus.dart
@@ -170,4 +170,5 @@ class NavEntryIds {
   static const String drafts = 'drafts';
   static const String notifications = 'notifications';
   static const String messages = 'messages';
+  static const String seeking = 'seeking';
 }

--- a/lib/navigation/nav_action_bus.dart
+++ b/lib/navigation/nav_action_bus.dart
@@ -121,6 +121,20 @@ final _navActionNonceProvider = StateProvider<int>((ref) => 0);
 /// 动作事件总线。页面通过 `ref.listen(navActionBusProvider, ...)` 订阅。
 final navActionBusProvider = StateProvider<NavActionEvent?>((ref) => null);
 
+/// 外部入口请求切换到某个稳定导航项。
+///
+/// 不能复用按数字下标切换的 [switchTabProvider]：底栏允许用户重排，首页
+/// 并不永远是第 0 个 page。通知、深链等入口应按 [NavEntryIds] 请求。
+class NavDestinationRequest {
+  const NavDestinationRequest({required this.targetId, required this.nonce});
+
+  final String targetId;
+  final int nonce;
+}
+
+final navDestinationRequestProvider =
+    StateProvider<NavDestinationRequest?>((ref) => null);
+
 /// 派发入口
 extension NavActionDispatch on WidgetRef {
   void dispatchNavAction(String targetId, NavAction action) {
@@ -129,6 +143,15 @@ extension NavActionDispatch on WidgetRef {
     read(navActionBusProvider.notifier).state = NavActionEvent(
       targetId: targetId,
       action: action,
+      nonce: next,
+    );
+  }
+
+  void requestNavDestination(String targetId) {
+    final next = read(_navActionNonceProvider) + 1;
+    read(_navActionNonceProvider.notifier).state = next;
+    read(navDestinationRequestProvider.notifier).state = NavDestinationRequest(
+      targetId: targetId,
       nonce: next,
     );
   }

--- a/lib/navigation/nav_entry_registry.dart
+++ b/lib/navigation/nav_entry_registry.dart
@@ -9,6 +9,7 @@ import '../pages/browsing_history_page.dart';
 import '../pages/drafts_page.dart';
 import '../pages/private_messages_page.dart';
 import '../pages/profile_page.dart';
+import '../pages/seeking_page.dart';
 import '../pages/topics_screen.dart';
 import '../providers/discourse_providers.dart';
 import '../widgets/common/smart_avatar.dart';
@@ -87,6 +88,15 @@ class NavEntryRegistry {
         label: (ctx) => ctx.l10n.nav_messages,
         pageBuilder: (ctx, isActive) =>
             PrivateMessagesPage(isActive: isActive),
+        requiresLogin: true,
+      ),
+      NavEntry(
+        id: NavEntryIds.seeking,
+        kind: NavEntryKind.page,
+        iconData: Symbols.visibility_rounded,
+        selectedIconData: Symbols.visibility_rounded,
+        label: (ctx) => ctx.l10n.seeking_title,
+        pageBuilder: (ctx, isActive) => SeekingPage(isActive: isActive),
         requiresLogin: true,
       ),
       NavEntry(

--- a/lib/pages/bookmarks_page.dart
+++ b/lib/pages/bookmarks_page.dart
@@ -15,6 +15,8 @@ import '../providers/preferences_provider.dart';
 import '../providers/bookmarks_reconciler.dart';
 import '../providers/user_content_providers.dart';
 import '../providers/user_content_search_provider.dart';
+import '../models/shortcut_binding.dart';
+import '../providers/shortcut_provider.dart';
 import '../services/app_error_handler.dart';
 import '../services/discourse/discourse_service.dart';
 import '../services/toast_service.dart';
@@ -62,9 +64,26 @@ class _BookmarksPageState extends ConsumerState<BookmarksPage> {
   String? _selectedBookmarkName;
   BookmarksWorkspaceState _workspaceState = const BookmarksWorkspaceState();
 
+  /// 桌面端 Esc 退出书签页(maybePop 会依次经过 PopScope:搜索模式先退
+  /// 搜索、手机工作区先回书签标签,最后才真正 pop 路由)。
+  late final ShortcutScopeBinding _shortcutScopeBinding = ShortcutScopeBinding(
+    ref: ref,
+    scope: ShortcutScope.context,
+  );
+
   @override
   void initState() {
     super.initState();
+    if (PlatformUtils.isDesktop) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _shortcutScopeBinding.register(context, {
+          ShortcutAction.closeOverlay: () {
+            if (mounted) Navigator.of(context).maybePop();
+          },
+        });
+      });
+    }
     _scrollController.addListener(_onScroll);
     _searchNotifier = ref.read(
       userContentSearchProvider(SearchInType.bookmarks).notifier,
@@ -88,6 +107,7 @@ class _BookmarksPageState extends ConsumerState<BookmarksPage> {
 
   @override
   void dispose() {
+    _shortcutScopeBinding.disposeDeferred();
     _setMobileBottomBarHidden(false);
     _scrollController.dispose();
     Future.microtask(_searchNotifier.exitSearchMode);
@@ -780,6 +800,9 @@ class _BookmarksPageState extends ConsumerState<BookmarksPage> {
             activeTabId: _workspaceState.activeTabId,
             topicTabs: _workspaceState.topicTabs,
             bookmarksLabel: context.l10n.bookmarks_title,
+            onBack: Navigator.of(context).canPop()
+                ? () => Navigator.of(context).maybePop()
+                : null,
             isSearchMode: searchState.isSearchMode,
             onSearchTap: () => _onSearchPressed(true),
             onBookmarksTap: () {

--- a/lib/pages/drafts_page.dart
+++ b/lib/pages/drafts_page.dart
@@ -13,8 +13,11 @@ import '../services/toast_service.dart';
 import '../widgets/common/relative_time_text.dart';
 import '../l10n/s.dart';
 import '../utils/dialog_utils.dart';
-import 'topic_detail_page/topic_detail_page.dart';
+import '../services/drafts_signal.dart';
+import '../providers/selected_topic_provider.dart';
+import '../widgets/layout/master_detail_layout.dart';
 import 'create_topic_page.dart';
+import 'topic_detail_page/topic_detail_page.dart';
 
 /// 草稿列表 Provider
 final draftsProvider = FutureProvider.autoDispose<List<Draft>>((ref) async {
@@ -25,10 +28,36 @@ final draftsProvider = FutureProvider.autoDispose<List<Draft>>((ref) async {
 
 /// 草稿列表页面
 class DraftsPage extends ConsumerStatefulWidget {
-  const DraftsPage({super.key, this.isActive = true});
+  const DraftsPage({
+    super.key,
+    this.isActive = true,
+    this.embeddedMode = false,
+    this.onEmbeddedBack,
+    this.onAllHandled,
+    this.autoCloseWhenEmpty = false,
+  });
+
+  /// 列表空了就回调 [onAllHandled]（把草稿这一层撤掉）。
+  ///
+  /// 只有**左栏处理栏**该开：那个位置的草稿栏存在意义就是"还有东西要
+  /// 处理"。栈顶（右栏）的草稿栏空了要老实显示空态。
+  final bool autoCloseWhenEmpty;
 
   /// 是否为当前活跃的 tab（嵌入底栏时用于决定是否响应 NavActionBus）
   final bool isActive;
+
+  /// 平行视界嵌入模式：本页是栈里的一层（右栏内容），AppBar 用
+  /// [onEmbeddedBack] 关闭当前层而不是 Navigator pop（嵌入面板不在
+  /// Navigator 路由栈里）。语义与 [SettingsPage] 一致。
+  final bool embeddedMode;
+  final VoidCallback? onEmbeddedBack;
+
+  /// 草稿从"有"变成"全部处理完"时回调一次。
+  ///
+  /// 与 [onEmbeddedBack] 分开是有意的：master 面板里的草稿栏**不该有
+  /// 返回按钮**（onEmbeddedBack 为 null），但它恰恰是最需要自动退场的
+  /// 那一个 —— 复用同一个回调会把返回按钮一起带出来。
+  final VoidCallback? onAllHandled;
 
   @override
   ConsumerState<DraftsPage> createState() => _DraftsPageState();
@@ -37,26 +66,61 @@ class DraftsPage extends ConsumerStatefulWidget {
 class _DraftsPageState extends ConsumerState<DraftsPage> {
   final ScrollController _scrollController = ScrollController();
 
+
+  /// 当前是否有右栏可用（宽屏双栏）。
+  ///
+  /// **必须在 build 里取**：`canShowBothPanesFor` 内部是
+  /// `MediaQuery.sizeOf(context)`，会注册 InheritedWidget 依赖。在点击
+  /// 回调里调用 = 在 build 之外注册依赖，而本页所在的面板子树会被
+  /// GlobalKey 换父节点（master 预览位 ↔ detail 位），换完这条依赖就
+  /// 指向了非后代元素 —— 实测红屏 `check that it really is our descendant`。
+  bool _canShowBothPanes = false;
+
   @override
   void initState() {
     super.initState();
     _scrollController.addListener(_publishScrollProgress);
+    // 发送/舍弃都会删草稿 → 服务层 bump 信号 → 这里刷新，那一条自动
+    // 消失。页面自己看不到回复框里发生了什么，只能靠这个信号。
+    DraftsSignal.revision.addListener(_onDraftsChanged);
+  }
+
+  @override
+  void didUpdateWidget(DraftsPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // 重新变成活跃 tab → 刷一次。草稿可能是在**别的 tab** 里产生的
+    // （典型：跑去私信回了一半），本页一直挂在 IndexedStack 里没重建，
+    // 不主动刷就永远停在切走之前那份列表。
+    if (!oldWidget.isActive && widget.isActive) {
+      // didUpdateWidget 跑在 **build 阶段**，这里直接 ref.invalidate 会在
+      // 构建途中改 provider，把元素树搞成不一致状态（实测红屏：
+      // `_dependents.isEmpty is not true`）。挪到帧后。
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _onDraftsChanged();
+      });
+    }
   }
 
   @override
   void dispose() {
+    DraftsSignal.revision.removeListener(_onDraftsChanged);
     _scrollController.dispose();
     super.dispose();
   }
 
+  void _onDraftsChanged() {
+    if (!mounted) return;
+    ref.invalidate(draftsProvider);
+  }
+
+  /// 发布"距顶进度"给底栏图标（NavActionBus 的 progress provider）
   void _publishScrollProgress() {
     if (!_scrollController.hasClients) return;
     final raw = _scrollController.offset;
     final progress = raw < 0 ? 0.0 : raw;
     final current = ref.read(navScrollProgressProvider(NavEntryIds.drafts));
     final atZero = progress == 0 && current != 0;
-    final crossed =
-        (progress >= navScrollIconThreshold) !=
+    final crossed = (progress >= navScrollIconThreshold) !=
         (current >= navScrollIconThreshold);
     if (!atZero && !crossed && (progress - current).abs() < 4.0) return;
     ref.read(navScrollProgressProvider(NavEntryIds.drafts).notifier).state =
@@ -71,6 +135,8 @@ class _DraftsPageState extends ConsumerState<DraftsPage> {
   @override
   Widget build(BuildContext context) {
     final draftsAsync = ref.watch(draftsProvider);
+    // 在 build 里取（见字段注释：不能在点击回调里读 MediaQuery）
+    _canShowBothPanes = MasterDetailLayout.canShowBothPanesFor(context);
 
     // 嵌入底栏时响应快捷动作（仅活跃 tab 响应）
     ref.listen(navActionBusProvider, (_, event) {
@@ -100,12 +166,38 @@ class _DraftsPageState extends ConsumerState<DraftsPage> {
       }
     });
 
-    return Scaffold(
-      appBar: AppBar(title: Text(context.l10n.drafts_title)),
+    final page = Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.drafts_title),
+        // embeddedMode 但 onEmbeddedBack 为空（master 面板"上一层预览"）
+        // 时不塞 BackButton——BackButton(onPressed: null) 会退化成默认
+        // Navigator.maybePop()，捅穿到应用根导航栈（见 settings_page 同注）。
+        automaticallyImplyLeading: !widget.embeddedMode,
+        leading: widget.embeddedMode && widget.onEmbeddedBack != null
+            ? BackButton(onPressed: widget.onEmbeddedBack)
+            : null,
+      ),
       body: DesktopRefreshIndicator(
         onRefresh: _onRefresh,
         child: draftsAsync.when(
           data: (drafts) {
+            // 草稿处理完 → 这一层自动退场：右边的内容留着，左边回到
+            // 信息流 / 私信列表。
+            //
+            // 判据是**栈位置**，不是"本页见过草稿没有"：
+            // - 在栈顶（右栏，随便看看）→ 空了就老实显示空态，自己关掉
+            //   会让人以为点击没生效；
+            // - 在栈顶之下（左栏处理栏）→ 空了就是没得处理了，撤掉。
+            //
+            // 早先用的是本地历史标记（_hadDrafts），但左栏那个 DraftsPage
+            // 是**另一个实例**，它常常是在列表已经空了之后才建出来的，
+            // 标记恒为 false，于是永远不触发 —— 实测"处理完草稿点私信"
+            // 停在「左草稿(空) + 右私信」。
+            if (drafts.isEmpty && widget.autoCloseWhenEmpty) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (mounted) widget.onAllHandled?.call();
+              });
+            }
             if (drafts.isEmpty) {
               return Center(
                 child: Column(
@@ -155,6 +247,8 @@ class _DraftsPageState extends ConsumerState<DraftsPage> {
         ),
       ),
     );
+
+    return page;
   }
 
   /// 点击草稿
@@ -200,21 +294,44 @@ class _DraftsPageState extends ConsumerState<DraftsPage> {
             draft.topicId ?? int.tryParse(draftKey.replaceFirst('topic_', ''));
       }
 
-      if (topicId != null) {
-        await Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: topicId!,
-              scrollToPostNumber: replyToPostNumber, // 跳转到对应帖子
-              autoOpenReply: true,
-              autoReplyToPostNumber: replyToPostNumber,
-            ),
-          ),
+      if (topicId == null) return; // 不刷新
+
+      // 按**草稿自己的类型**分流到对应的那套栈，摆成 `[草稿, 内容]`：
+      // 左栏草稿处理栏、右栏正在处理的那条。处理完草稿层被抽掉，栈剩
+      // `[内容]`，左栏自然退回该内容对应的列表（信息流 / 私信列表）。
+      //
+      // **不能用 `EmbeddedStackScope.maybePushTopic`**：它跟着"当前所处的
+      // 作用域"走。草稿栏一旦被摆到私信栈上（处理某条私信草稿时），在它
+      // 里面再点一条**普通话题**的草稿，就会把话题压进**私信栈** ——
+      // 实测左边私信列表、右边话题。归属得由草稿类型决定，与当前在哪无关。
+      if (_canShowBothPanes) {
+        final isPm = draft.isPrivateMessage;
+        ref.requestNavDestination(
+          isPm ? NavEntryIds.messages : NavEntryIds.home,
         );
-      } else {
-        return; // 不刷新
+        ref
+            .read(
+              (isPm ? selectedMessageProvider : selectedTopicProvider).notifier,
+            )
+            .openDraftTarget(
+              topicId: topicId,
+              scrollToPostNumber: replyToPostNumber,
+              autoReplyToPostNumber: replyToPostNumber,
+            );
+        return;
       }
+      // 不在任何嵌入面板里（窄屏全屏路由）：照旧 push，回来再刷新
+      await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => TopicDetailPage(
+            topicId: topicId!,
+            scrollToPostNumber: replyToPostNumber,
+            autoOpenReply: true,
+            autoReplyToPostNumber: replyToPostNumber,
+          ),
+        ),
+      );
     } else {
       return; // 不刷新
     }

--- a/lib/pages/private_messages_page.dart
+++ b/lib/pages/private_messages_page.dart
@@ -5,17 +5,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import '../models/topic.dart';
 import '../navigation/nav_action_bus.dart';
+import '../providers/selected_topic_provider.dart';
 import '../providers/user_content_providers.dart';
 import '../providers/preferences_provider.dart';
 import '../utils/load_more_coordinator.dart';
 import '../widgets/common/paged_list_footer.dart';
+import '../widgets/layout/auto_restore_master_detail_route.dart';
+import '../widgets/layout/master_detail_layout.dart';
 import '../widgets/topic/topic_item_builder.dart';
 import '../widgets/topic/topic_list_skeleton.dart';
 import '../widgets/post/reply_sheet.dart';
 import '../widgets/common/error_view.dart';
 import '../widgets/desktop_refresh_indicator.dart';
 import '../l10n/s.dart';
+import 'settings_page.dart';
 import 'topic_detail_page/topic_detail_page.dart';
+import 'topics_screen.dart' show PaneContentWidget;
+import 'user_profile_page.dart';
 
 /// 内部 tab 动作：外层根据当前激活 filter 派发给对应子 widget。
 /// 用 nonce 让连续同类事件也能触发 Riverpod 监听。
@@ -50,16 +56,111 @@ class _PrivateMessagesPageState extends ConsumerState<PrivateMessagesPage>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
 
+  /// 用持久化 GlobalKey 做 master/detail 槽位间的话题面板"挪动"已回退——
+  /// 实测多切换几个私信会命中 Flutter 框架级断言
+  /// `'_elements.contains(element)': is not true`（红屏崩溃），比原来要
+  /// 解决的销毁重建竞态更严重。理由详见 topics_screen.dart 同名注释。
+  Key _keyForTopic(int topicId) => ValueKey('topic_$topicId');
+
+  /// 平行视界压栈时：左侧显示栈里"上一层"内容而不是简单隐藏，右侧显示
+  /// 新顶替的内容；列表用 Offstage 保留，退回最底层时原样恢复。
+  Widget _buildMasterPane(SelectedTopicState selectedMessage, Widget list) {
+    if (!selectedMessage.isStacked) return list;
+    final previous = selectedMessage.stack[selectedMessage.stack.length - 2];
+    return Stack(
+      children: [
+        Offstage(offstage: true, child: list),
+        PaneContentWidget(
+          key: previous.kind == PaneKind.topic
+              ? _keyForTopic(previous.topicId!)
+              : ValueKey('master_${previous.kind}_${previous.username}'),
+          entry: previous,
+          stackProvider: selectedMessageProvider,
+          truncateOnPush: true,
+        ),
+      ],
+    );
+  }
+
   static const _filters = [
     PrivateMessageFilter.inbox,
     PrivateMessageFilter.sent,
     PrivateMessageFilter.archive,
   ];
 
+  bool? _lastCanShowDetailPane;
+  bool _isAutoSwitching = false;
+
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: _filters.length, vsync: this);
+  }
+
+  /// 双栏→单栏（窗口缩小）时自动把当前栈顶层 push 成全屏详情页，而不是
+  /// 让选中状态"静默消失"、只剩下私信列表——之前这里完全没做，缩小窗口
+  /// 就直接掉回私信列表本身，而不是栈顶（最新压的那层，比如内部链接点
+  /// 开的话题）。逻辑对齐 topics_screen.dart 的 `_maybePushDetail`。
+  void _maybePushDetail(SelectedTopicState selectedMessage, bool canShowDetailPane) {
+    if (_isAutoSwitching) return;
+    if (!widget.isActive) {
+      _lastCanShowDetailPane = canShowDetailPane;
+      return;
+    }
+
+    final previous = _lastCanShowDetailPane;
+    _lastCanShowDetailPane = canShowDetailPane;
+
+    if (!canShowDetailPane &&
+        selectedMessage.hasSelection &&
+        (previous == null || previous == true)) {
+      final topicId = selectedMessage.topicId;
+      if (topicId == null) {
+        final username = selectedMessage.username;
+        final isSettings = selectedMessage.kind == PaneKind.settings;
+        if (username == null && !isSettings) return;
+        _isAutoSwitching = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final navigator = Navigator.of(context);
+          // 不清空栈状态，回宽屏时自动恢复（理由见 topics_screen.dart
+          // 同名方法的注释）。
+          navigator
+              .push(MaterialPageRoute(
+                builder: (_) => AutoRestoreMasterDetailRoute(
+                  child: isSettings
+                      ? const SettingsPage()
+                      : UserProfilePage(username: username!),
+                ),
+              ))
+              .whenComplete(() {
+            if (mounted) setState(() => _isAutoSwitching = false);
+          });
+        });
+        return;
+      }
+
+      _isAutoSwitching = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final navigator = Navigator.of(context);
+        // 同上：不清空栈状态。
+        navigator
+            .push(MaterialPageRoute(
+              builder: (_) => TopicDetailPage(
+                topicId: topicId,
+                initialTitle: selectedMessage.initialTitle,
+                scrollToPostNumber: selectedMessage.scrollToPostNumber,
+                autoSwitchToMasterDetail: true,
+                restoreExistingPaneStack: true,
+                stackProvider: selectedMessageProvider,
+              ),
+            ))
+            .whenComplete(() {
+          if (mounted) setState(() => _isAutoSwitching = false);
+        });
+      });
+    }
   }
 
   @override
@@ -114,7 +215,7 @@ class _PrivateMessagesPageState extends ConsumerState<PrivateMessagesPage>
       );
     });
 
-    return NotificationListener<ScrollNotification>(
+    final listScaffold = NotificationListener<ScrollNotification>(
       onNotification: _onScrollNotification,
       child: Scaffold(
         appBar: AppBar(
@@ -144,6 +245,32 @@ class _PrivateMessagesPageState extends ConsumerState<PrivateMessagesPage>
           child: const Icon(Icons.edit_rounded),
         ),
       ),
+    );
+
+    // 平行视界：宽屏双栏下私信列表跟话题列表一样，走独立的
+    // selectedMessageProvider 导航栈，不再单独弹全屏详情页。
+    final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
+    final selectedMessage = ref.watch(selectedMessageProvider);
+    _maybePushDetail(selectedMessage, canShowDetailPane);
+    if (!canShowDetailPane) return listScaffold;
+
+    return MasterDetailLayout(
+      maxMasterRatio: selectedMessage.isStacked ? 0.8 : MasterDetailLayout.defaultMaxMasterRatio,
+      preferredMasterRatio: selectedMessage.isStacked ? 0.5 : 0.25,
+      master: _buildMasterPane(selectedMessage, listScaffold),
+      detail: selectedMessage.hasSelection
+          ? PaneContentWidget(
+              key: selectedMessage.kind == PaneKind.topic
+                  ? _keyForTopic(selectedMessage.topicId!)
+                  : ValueKey('${selectedMessage.kind}_${selectedMessage.username}'),
+              entry: selectedMessage.topEntry!,
+              stackProvider: selectedMessageProvider,
+              parentActive: widget.isActive,
+              onBack: selectedMessage.isStacked
+                  ? () => ref.read(selectedMessageProvider.notifier).pop()
+                  : null,
+            )
+          : null,
     );
   }
 }
@@ -238,6 +365,15 @@ class _PrivateMessageTabViewState extends ConsumerState<_PrivateMessageTabView>
   }
 
   void _onItemTap(Topic topic) {
+    final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
+    if (canShowDetailPane) {
+      ref.read(selectedMessageProvider.notifier).select(
+            topicId: topic.id,
+            initialTitle: topic.title,
+            scrollToPostNumber: topic.lastReadPostNumber,
+          );
+      return;
+    }
     Navigator.push(
       context,
       MaterialPageRoute(
@@ -321,10 +457,11 @@ class _PrivateMessageTabViewState extends ConsumerState<_PrivateMessageTabView>
               final enableLongPress = ref
                   .watch(preferencesProvider)
                   .longPressPreview;
+              final selectedTopicId = ref.watch(selectedMessageProvider).topicId;
               return buildTopicItem(
                 context: context,
                 topic: topic,
-                isSelected: false,
+                isSelected: selectedTopicId == topic.id,
                 onTap: () => _onItemTap(topic),
                 enableLongPress: enableLongPress,
                 // 私信语义同邮件:发件人优先的 Gmail 式布局

--- a/lib/pages/private_messages_page.dart
+++ b/lib/pages/private_messages_page.dart
@@ -77,6 +77,7 @@ class _PrivateMessagesPageState extends ConsumerState<PrivateMessagesPage>
           entry: previous,
           stackProvider: selectedMessageProvider,
           truncateOnPush: true,
+          parentActive: widget.isActive,
         ),
       ],
     );
@@ -254,9 +255,16 @@ class _PrivateMessagesPageState extends ConsumerState<PrivateMessagesPage>
     _maybePushDetail(selectedMessage, canShowDetailPane);
     if (!canShowDetailPane) return listScaffold;
 
+    // 左栏本质是不是"列表"（私信列表 / 草稿处理栏）——决定给窄栏还是
+    // 对半分。草稿处理栏是列表，对半分会让它空得离谱。
+    final masterIsListLike = !selectedMessage.isStacked ||
+        selectedMessage.stack[selectedMessage.stack.length - 2].kind ==
+            PaneKind.drafts;
     return MasterDetailLayout(
-      maxMasterRatio: selectedMessage.isStacked ? 0.8 : MasterDetailLayout.defaultMaxMasterRatio,
-      preferredMasterRatio: selectedMessage.isStacked ? 0.5 : 0.25,
+      maxMasterRatio: masterIsListLike
+          ? MasterDetailLayout.defaultMaxMasterRatio
+          : 0.8,
+      preferredMasterRatio: masterIsListLike ? 0.25 : 0.5,
       master: _buildMasterPane(selectedMessage, listScaffold),
       detail: selectedMessage.hasSelection
           ? PaneContentWidget(

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/user.dart';
 import '../providers/discourse_providers.dart';
 import '../providers/selected_topic_provider.dart';
+import 'topics_screen.dart' show PaneContentWidget;
 import '../providers/shortcut_provider.dart';
 import '../widgets/desktop_refresh_indicator.dart';
 import '../services/discourse_cache_manager.dart';
@@ -65,6 +66,9 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
   late ScrollController _rightScrollController;
   bool _showTitle = false;
   bool _isRefreshing = false;
+
+  /// build 里存下的宽屏判定,供点击回调读(不能在回调里读 MediaQuery)。
+  bool _showWideLayout = false;
 
   // 余额卡片(CDK/LDC)是否已可渲染:仅在本页首次成为活跃 tab 后置 true。
   // 避免 IndexedStack 冷启动预构建本页时,balance card 的 watch 就触发
@@ -340,6 +344,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
 
     final isOffline = userState.hasError && userState.hasValue && userState.value != null;
     final showWideLayout = MasterDetailLayout.canShowBothPanesFor(context);
+    _showWideLayout = showWideLayout; // 供点击回调用，见 [_openDrafts]
 
     // 监听底栏派发的快捷动作（仅活跃 tab 响应）
     ref.listen(navActionBusProvider, (_, event) {
@@ -431,7 +436,14 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
             ),
         ] : null,
       ),
-      body: showWideLayout ? _buildWideBody(theme) : _buildMobileBody(theme),
+      // 宽屏才提供平行视界栈：窄屏没有右栏可承载，openDrafts/openSettings
+      // 必须走全屏 push（有 scope 却没人渲染 = 点了没反应）。
+      body: showWideLayout
+          ? EmbeddedStackScope(
+              stackProvider: selectedProfilePaneProvider,
+              child: _buildWideBody(theme),
+            )
+          : _buildMobileBody(theme),
     );
   }
 
@@ -494,6 +506,10 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
 
   /// 平板/桌面端：左右双栏布局
   Widget _buildWideBody(ThemeData theme) {
+    // 右半边：栈为空时是原来的卡片列表，压了内容（草稿/设置）就顶替掉。
+    final selected = ref.watch(selectedProfilePaneProvider);
+    final entry = selected.topEntry;
+    final notifier = ref.read(selectedProfilePaneProvider.notifier);
     return Row(
       children: [
         SizedBox(
@@ -502,7 +518,19 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
         ),
         VerticalDivider(width: 1, thickness: 0.5, color: theme.colorScheme.outlineVariant.withValues(alpha: 0.3)),
         Expanded(
-          child: _buildRightPanel(theme),
+          child: entry == null
+              ? _buildRightPanel(theme)
+              : PaneContentWidget(
+                  key: ValueKey(
+                    'profile_pane_${entry.kind}_'
+                    '${entry.instanceId ?? entry.username ?? entry.topicId}',
+                  ),
+                  entry: entry,
+                  stackProvider: selectedProfilePaneProvider,
+                  parentActive: widget.isActive,
+                  onBack: () =>
+                      selected.isStacked ? notifier.pop() : notifier.clear(),
+                ),
         ),
       ],
     );
@@ -657,6 +685,30 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
     );
   }
 
+  /// 打开草稿：走**和信息流 + 号完全同一条路径**（切到首页栈、草稿进右栏）。
+  ///
+  /// 点某条草稿后草稿自己会挪到左栏当处理栏、内容进右栏，处理完草稿层被
+  /// 抽掉，左栏退回对应的信息流/私信列表 —— 所以这里不需要另造一个页面。
+  ///
+  /// 不用 `EmbeddedStackScope.openDrafts(context)`：这里的 `context` 是
+  /// ProfilePage 自己的 State context，而 EmbeddedStackScope 是它的
+  /// **后代**——`dependOnInheritedWidgetOfExactType` 只往上找，必然落空，
+  /// 于是每次都退化成全屏。（topics_screen 的 FAB 踩过同一个坑。）
+  void _openDrafts() {
+    // 用 build 里存下的值：`canShowBothPanesFor` 内部读 MediaQuery，在
+    // 点击回调里调用等于在 build 之外注册 InheritedWidget 依赖（drafts_page
+    // 那边踩过，红屏 `check that it really is our descendant`）。
+    if (_showWideLayout) {
+      ref.requestNavDestination(NavEntryIds.home);
+      ref.read(selectedTopicProvider.notifier).pushDrafts();
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const DraftsPage()),
+    );
+  }
+
   Widget _buildContentCard(ThemeData theme) {
     final actions = [
       (
@@ -681,10 +733,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
         icon: Symbols.drafts_rounded,
         iconColor: Colors.teal,
         title: context.l10n.profile_myDrafts,
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(builder: (_) => const DraftsPage()),
-        ),
+        onTap: _openDrafts,
       ),
       (
         icon: Symbols.history_rounded,

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/user.dart';
 import '../providers/discourse_providers.dart';
+import '../providers/selected_topic_provider.dart';
 import '../providers/shortcut_provider.dart';
 import '../widgets/desktop_refresh_indicator.dart';
 import '../services/discourse_cache_manager.dart';
@@ -18,7 +19,6 @@ import 'my_topics_page.dart';
 import 'my_badges_page.dart';
 import 'user_profile_page.dart';
 import 'trust_level_requirements_page.dart';
-import 'settings_page.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 import '../widgets/common/loading_dialog.dart';
 import '../widgets/common/notification_icon_button.dart';
@@ -860,7 +860,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
           icon: Symbols.settings_rounded,
           iconColor: Colors.blueGrey,
           title: context.l10n.profile_settings,
-          onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const SettingsPage())),
+          onTap: () => EmbeddedStackScope.openSettings(context),
         ),
       ],
     );

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -29,6 +29,7 @@ import '../utils/blocked_user_filter.dart';
 import '../utils/discourse_url_parser.dart';
 import '../widgets/common/search_capsule.dart';
 import '../utils/link_launcher.dart';
+import 'drafts_page.dart';
 import 'settings_page.dart';
 
 /// 搜索框中的站内直达链接标准化。支持完整 URL、`linux.do/...` 和相对路径；
@@ -944,6 +945,22 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           stackProvider: _stackProvider,
           truncateOnPush: truncateOnPush,
           child: SettingsPage(embeddedMode: true, onEmbeddedBack: onBack),
+        );
+      case PaneKind.drafts:
+        return EmbeddedStackScope(
+          stackProvider: _stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: Consumer(
+            builder: (context, ref, _) => DraftsPage(
+              embeddedMode: true,
+              autoCloseWhenEmpty: truncateOnPush,
+              onEmbeddedBack: onBack,
+              // 草稿处理完 → 抽掉草稿这一层（不是 pop，右边的话题要留着）
+              onAllHandled: () => ref
+                  .read(_stackProvider.notifier)
+                  .removeEntriesOfKind(PaneKind.drafts),
+            ),
+          ),
         );
     }
   }

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -15,7 +15,9 @@ import '../widgets/search/search_list_skeleton.dart';
 import '../widgets/search/search_post_card.dart';
 import '../widgets/search/search_preview_dialog.dart';
 import '../providers/preferences_provider.dart';
+import '../providers/selected_topic_provider.dart';
 import '../providers/shortcut_provider.dart';
+import '../widgets/layout/master_detail_layout.dart';
 import 'topic_detail_page/topic_detail_page.dart';
 import 'package:dio/dio.dart';
 import '../services/app_error_handler.dart';
@@ -24,10 +26,31 @@ import 'user_profile_page.dart';
 import '../utils/dialog_utils.dart';
 import '../utils/load_more_coordinator.dart';
 import '../utils/blocked_user_filter.dart';
+import '../utils/discourse_url_parser.dart';
 import '../widgets/common/search_capsule.dart';
+import '../utils/link_launcher.dart';
+import 'settings_page.dart';
+
+/// 搜索框中的站内直达链接标准化。支持完整 URL、`linux.do/...` 和相对路径；
+/// 普通关键词原样返回，后续由 [isInternalUrlString] 判定后继续普通搜索。
+@visibleForTesting
+String normalizeDirectSearchLink(String rawValue) {
+  final value = rawValue.trim();
+  if (value.startsWith('/')) return value;
+  if (RegExp(
+    r'^(?:www\.)?linux\.do(?::\d+)?/',
+    caseSensitive: false,
+  ).hasMatch(value)) {
+    return 'https://$value';
+  }
+  return value;
+}
 
 /// 搜索页面
 class SearchPage extends ConsumerStatefulWidget {
+  static const double parallelMasterWidth = 440;
+  static const double parallelMinDetailWidth = 480;
+
   final String? initialQuery;
   final SearchFilter? initialFilter;
 
@@ -39,14 +62,32 @@ class SearchPage extends ConsumerStatefulWidget {
     super.key,
     this.initialQuery,
     this.initialFilter,
+    this.embeddedMaster = false,
+    this.stackProvider,
+    this.onClose,
     this.heroCapsule = false,
   });
+
+  final bool embeddedMaster;
+  final SelectedTopicProvider? stackProvider;
+  final VoidCallback? onClose;
+
+  @visibleForTesting
+  static bool canShowParallelFor(BuildContext context) {
+    return MasterDetailLayout.canShowBothPanesFor(
+      context,
+      masterWidth: parallelMasterWidth,
+      minDetailWidth: parallelMinDetailWidth,
+    );
+  }
 
   @override
   ConsumerState<SearchPage> createState() => _SearchPageState();
 }
 
 class _SearchPageState extends ConsumerState<SearchPage> {
+  SelectedTopicProvider get _stackProvider =>
+      widget.stackProvider ?? selectedSearchProvider;
   final _searchController = TextEditingController();
   final _focusNode = FocusNode();
   final _scrollController = ScrollController();
@@ -139,7 +180,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     _route = route;
     _shortcutSurfaceBinding.registerDeferred(
       context,
-      onClose: () => Navigator.of(context).maybePop(),
+      onClose: widget.onClose ?? () => Navigator.of(context).maybePop(),
       onFocus: _revealSelf,
     );
   }
@@ -200,6 +241,11 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   @override
   void dispose() {
     _shortcutSurfaceBinding.disposeDeferred();
+    // 独立搜索页拥有自己的平行视界栈，退出时应清理；嵌入首页左栏时复用
+    // selectedTopicProvider，搜索页被信息流/分类替换不代表右栏详情也应消失。
+    if (widget.stackProvider == null) {
+      ref.read(selectedSearchProvider.notifier).clear();
+    }
     _searchController.dispose();
     _focusNode.dispose();
     _scrollController.dispose();
@@ -218,6 +264,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   void _onSearch(String query) {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return;
+    if (_tryOpenInternalLink(trimmed)) return;
     if (trimmed != _currentQuery || _allPosts.isEmpty) {
       setState(() {
         _currentQuery = trimmed;
@@ -233,6 +280,52 @@ class _SearchPageState extends ConsumerState<SearchPage> {
       });
       _performSearch();
     }
+  }
+
+  bool _tryOpenInternalLink(String rawValue) {
+    final normalized = normalizeDirectSearchLink(rawValue);
+    if (!isInternalUrlString(normalized)) return false;
+
+    final topic = DiscourseUrlParser.parseTopic(normalized);
+    if (topic != null) {
+      if (widget.embeddedMaster || SearchPage.canShowParallelFor(context)) {
+        ref
+            .read(_stackProvider.notifier)
+            .select(
+              topicId: topic.topicId,
+              initialTitle: topic.slug,
+              scrollToPostNumber: topic.postNumber,
+            );
+      } else {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TopicDetailPage(
+              topicId: topic.topicId,
+              initialTitle: topic.slug,
+              scrollToPostNumber: topic.postNumber,
+            ),
+          ),
+        );
+      }
+      _focusNode.unfocus();
+      return true;
+    }
+
+    final user = DiscourseUrlParser.parseUser(normalized);
+    if (user == null) return false;
+    if (widget.embeddedMaster || SearchPage.canShowParallelFor(context)) {
+      ref.read(_stackProvider.notifier).selectProfile(user.username);
+    } else {
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => UserProfilePage(username: user.username),
+        ),
+      );
+    }
+    _focusNode.unfocus();
+    return true;
   }
 
   void _onSortChanged(SearchSortOrder? order) {
@@ -580,10 +673,79 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     }
   }
 
+  void _openTopicResult(SearchPost searchPost) {
+    final topic = searchPost.topic;
+    if (topic == null) return;
+    if (widget.embeddedMaster || SearchPage.canShowParallelFor(context)) {
+      ref
+          .read(_stackProvider.notifier)
+          .select(
+            topicId: topic.id,
+            initialTitle: topic.title,
+            scrollToPostNumber: searchPost.postNumber,
+          );
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TopicDetailPage(
+          topicId: topic.id,
+          scrollToPostNumber: searchPost.postNumber,
+        ),
+      ),
+    );
+  }
+
+  void _openUserResult(SearchUser user) {
+    if (widget.embeddedMaster || SearchPage.canShowParallelFor(context)) {
+      ref.read(_stackProvider.notifier).selectProfile(user.username);
+      return;
+    }
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => UserProfilePage(username: user.username),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final selected = ref.watch(_stackProvider);
+    final canShowParallel =
+        widget.embeddedMaster || SearchPage.canShowParallelFor(context);
 
+    final master = _buildSearchScaffold(theme);
+    if (widget.embeddedMaster) return master;
+    if (!canShowParallel) return master;
+
+    return MasterDetailLayout(
+      masterWidth: SearchPage.parallelMasterWidth,
+      minDetailWidth: SearchPage.parallelMinDetailWidth,
+      minMasterRatio: 0.32,
+      maxMasterRatio: selected.isStacked ? 0.8 : 0.52,
+      preferredMasterRatio: selected.isStacked ? 0.5 : 0.4,
+      master: _buildParallelMaster(selected, master),
+      detail: selected.hasSelection
+          ? _buildParallelPane(
+              selected.topEntry!,
+              onBack: () {
+                final notifier = ref.read(_stackProvider.notifier);
+                if (selected.isStacked) {
+                  notifier.pop();
+                } else {
+                  notifier.clear();
+                }
+              },
+            )
+          : null,
+      emptyDetail: _buildParallelEmptyState(theme),
+    );
+  }
+
+  Widget _buildSearchScaffold(ThemeData theme) {
     final searchField = TextField(
       controller: _searchController,
       focusNode: _focusNode,
@@ -671,6 +833,13 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
+        leading: widget.onClose == null
+            ? null
+            : IconButton(
+                tooltip: context.l10n.common_close,
+                icon: const Icon(Symbols.close_rounded),
+                onPressed: widget.onClose,
+              ),
         titleSpacing: 0,
         title: titleField,
         actions: [
@@ -722,6 +891,86 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                 : _buildSearchResults(theme),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildParallelMaster(SelectedTopicState selected, Widget searchPage) {
+    if (!selected.isStacked) return searchPage;
+    final previous = selected.stack[selected.stack.length - 2];
+    return Stack(
+      children: [
+        ExcludeFocus(
+          excluding: true,
+          child: Offstage(offstage: true, child: searchPage),
+        ),
+        _buildParallelPane(previous, truncateOnPush: true),
+      ],
+    );
+  }
+
+  Widget _buildParallelPane(
+    PaneEntry entry, {
+    VoidCallback? onBack,
+    bool truncateOnPush = false,
+  }) {
+    switch (entry.kind) {
+      case PaneKind.topic:
+        return TopicDetailPage(
+          key: ValueKey('search_topic_${entry.instanceId}'),
+          topicId: entry.topicId!,
+          instanceId: entry.instanceId,
+          initialTitle: entry.initialTitle,
+          scrollToPostNumber: entry.scrollToPostNumber,
+          embeddedMode: true,
+          truncateOnPush: truncateOnPush,
+          onEmbeddedBack: onBack,
+          parentActive: true,
+          stackProvider: _stackProvider,
+        );
+      case PaneKind.profile:
+        return EmbeddedStackScope(
+          stackProvider: _stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: UserProfilePage(
+            key: ValueKey('search_profile_${entry.username}'),
+            username: entry.username!,
+            embeddedMode: true,
+            onEmbeddedBack: onBack,
+          ),
+        );
+      case PaneKind.settings:
+        return EmbeddedStackScope(
+          stackProvider: _stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: SettingsPage(embeddedMode: true, onEmbeddedBack: onBack),
+        );
+    }
+  }
+
+  Widget _buildParallelEmptyState(ThemeData theme) {
+    // 右侧空详情没有 Scaffold，若不显式铺底会透出 MaterialApp 默认
+    // canvasColor，和左侧搜索 Scaffold 的主题背景形成灰蓝/暖色断层。
+    return ColoredBox(
+      color: theme.scaffoldBackgroundColor,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.preview_rounded,
+              size: 56,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              context.l10n.search_selectResultHint,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -1003,38 +1252,12 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                     .longPressPreview;
                 return SearchPostCard(
                   post: searchPost,
-                  onTap: () {
-                    final topic = searchPost.topic;
-                    if (topic != null) {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => TopicDetailPage(
-                            topicId: topic.id,
-                            scrollToPostNumber: searchPost.postNumber,
-                          ),
-                        ),
-                      );
-                    }
-                  },
+                  onTap: () => _openTopicResult(searchPost),
                   onLongPress: enableLongPress
                       ? () => SearchPreviewDialog.show(
                           context,
                           post: searchPost,
-                          onOpen: () {
-                            final topic = searchPost.topic;
-                            if (topic != null) {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) => TopicDetailPage(
-                                    topicId: topic.id,
-                                    scrollToPostNumber: searchPost.postNumber,
-                                  ),
-                                ),
-                              );
-                            }
-                          },
+                          onOpen: () => _openTopicResult(searchPost),
                         )
                       : null,
                 );
@@ -1059,16 +1282,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                 if (userIndex < users.length) {
                   return _SearchUserCard(
                     user: users[userIndex],
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => UserProfilePage(
-                            username: users[userIndex].username,
-                          ),
-                        ),
-                      );
-                    },
+                    onTap: () => _openUserResult(users[userIndex]),
                   );
                 }
               }

--- a/lib/pages/seeking_page.dart
+++ b/lib/pages/seeking_page.dart
@@ -12,10 +12,10 @@ import '../services/toast_service.dart';
 import '../utils/time_utils.dart';
 import '../widgets/common/smart_avatar.dart';
 import '../widgets/content/collapsed_html_content.dart';
+import '../widgets/layout/auto_restore_master_detail_route.dart';
+import '../widgets/layout/full_screen_pane_stack.dart';
 import '../widgets/layout/master_detail_layout.dart';
-import 'topic_detail_page/topic_detail_page.dart';
 import 'topics_screen.dart' show PaneContentWidget;
-import 'user_profile_page.dart';
 
 /// 追觅：实时监控指定用户的发帖 / 回复 / 点赞 / 表情回应 / Boost 动态。
 ///
@@ -37,6 +37,8 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
 
   /// 只看此人过滤（点用户头像切换）
   String? _focusUser;
+  bool? _lastCanShowParallel;
+  bool _isAutoSwitching = false;
 
   @override
   void initState() {
@@ -112,36 +114,31 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
 
   void _openActivity(SeekingActivity activity) {
     if (activity.topicId <= 0) return;
+    final notifier = ref.read(selectedSeekingProvider.notifier);
     if (_canShowParallel(context)) {
-      ref
-          .read(selectedSeekingProvider.notifier)
-          .select(
-            topicId: activity.topicId,
-            initialTitle: activity.title,
-            scrollToPostNumber: activity.postNumber,
-          );
+      notifier.select(
+        topicId: activity.topicId,
+        initialTitle: activity.title,
+        scrollToPostNumber: activity.postNumber,
+      );
       return;
     }
-    Navigator.push(
-      context,
-      MaterialPageRoute(
-        builder: (_) => TopicDetailPage(
-          topicId: activity.topicId,
-          scrollToPostNumber: activity.postNumber,
-        ),
+    _openSelectedPaneInFullScreen(
+      () => notifier.select(
+        topicId: activity.topicId,
+        initialTitle: activity.title,
+        scrollToPostNumber: activity.postNumber,
       ),
     );
   }
 
   void _openProfile(String username) {
+    final notifier = ref.read(selectedSeekingProvider.notifier);
     if (_canShowParallel(context)) {
-      ref.read(selectedSeekingProvider.notifier).selectProfile(username);
+      notifier.selectProfile(username);
       return;
     }
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
-    );
+    _openSelectedPaneInFullScreen(() => notifier.selectProfile(username));
   }
 
   bool _canShowParallel(BuildContext context) =>
@@ -150,6 +147,76 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
         masterWidth: _parallelMasterWidth,
         minDetailWidth: _parallelMinDetailWidth,
       );
+
+  Widget _buildFullScreenPaneStack() => AutoRestoreMasterDetailRoute(
+    masterWidth: _parallelMasterWidth,
+    minDetailWidth: _parallelMinDetailWidth,
+    child: FullScreenPaneStack(
+      stackProvider: selectedSeekingProvider,
+      builder: (_, entry, onBack) => PaneContentWidget(
+        key: _paneKey(entry, 'fullscreen'),
+        entry: entry,
+        stackProvider: selectedSeekingProvider,
+        parentActive: true,
+        onBack: onBack,
+      ),
+    ),
+  );
+
+  void _pushFullScreenPaneStack() {
+    Navigator.of(context)
+        .push<void>(
+          MaterialPageRoute(builder: (_) => _buildFullScreenPaneStack()),
+        )
+        .whenComplete(() {
+          if (!mounted) return;
+          setState(() => _isAutoSwitching = false);
+        });
+  }
+
+  void _openSelectedPaneInFullScreen(VoidCallback selectPane) {
+    if (_isAutoSwitching) return;
+    _isAutoSwitching = true;
+    _lastCanShowParallel = false;
+    selectPane();
+    _pushFullScreenPaneStack();
+  }
+
+  void _maybePushSelectedPane(
+    SelectedTopicState selected,
+    bool canShowParallel,
+  ) {
+    if (_isAutoSwitching) return;
+    if (!widget.isActive) {
+      _lastCanShowParallel = canShowParallel;
+      return;
+    }
+
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) {
+      _lastCanShowParallel = canShowParallel;
+      return;
+    }
+
+    final previous = _lastCanShowParallel;
+    _lastCanShowParallel = canShowParallel;
+    if (canShowParallel ||
+        !selected.hasSelection ||
+        (previous != null && !previous)) {
+      return;
+    }
+
+    _isAutoSwitching = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _pushFullScreenPaneStack();
+    });
+  }
+
+  Key _paneKey(PaneEntry entry, String slot) => ValueKey(
+    'seeking_${slot}_${entry.kind}_'
+    '${entry.instanceId ?? entry.username ?? entry.topicId}',
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -274,12 +341,18 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
     );
 
     final selected = ref.watch(selectedSeekingProvider);
-    if (!_canShowParallel(context) || !selected.hasSelection) return page;
+    final canShowParallel = _canShowParallel(context);
+    _maybePushSelectedPane(selected, canShowParallel);
+    if (!canShowParallel || !selected.hasSelection) return page;
 
     final notifier = ref.read(selectedSeekingProvider.notifier);
-    final master = selected.isStacked
+    final previousEntry = selected.isStacked
+        ? selected.stack[selected.stack.length - 2]
+        : null;
+    final master = previousEntry != null
         ? PaneContentWidget(
-            entry: selected.stack[selected.stack.length - 2],
+            key: _paneKey(previousEntry, 'master'),
+            entry: previousEntry,
             stackProvider: selectedSeekingProvider,
             truncateOnPush: true,
             parentActive: widget.isActive,
@@ -293,6 +366,7 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
       preferredMasterRatio: selected.isStacked ? 0.5 : 0.4,
       master: master,
       detail: PaneContentWidget(
+        key: _paneKey(selected.topEntry!, 'detail'),
         entry: selected.topEntry!,
         stackProvider: selectedSeekingProvider,
         parentActive: widget.isActive,
@@ -867,20 +941,18 @@ class _ActivityTile extends StatelessWidget {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          const Spacer(),
-          const SizedBox(width: 12),
-          SizedBox(
-            width: 76,
-            child: Text(
-              TimeUtils.formatRelativeTime(activity.createdAt),
-              maxLines: 1,
-              textAlign: TextAlign.left,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
         ],
+      ),
+      trailing: SizedBox(
+        width: 76,
+        child: Text(
+          TimeUtils.formatRelativeTime(activity.createdAt),
+          maxLines: 1,
+          textAlign: TextAlign.right,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
       ),
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/pages/seeking_page.dart
+++ b/lib/pages/seeking_page.dart
@@ -1,0 +1,852 @@
+import 'dart:async';
+
+import 'package:app_icons/app_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/s.dart';
+import '../models/seeking.dart';
+import '../providers/seeking_provider.dart';
+import '../services/toast_service.dart';
+import '../utils/time_utils.dart';
+import '../widgets/common/smart_avatar.dart';
+import '../widgets/content/collapsed_html_content.dart';
+import 'topic_detail_page/topic_detail_page.dart';
+import 'user_profile_page.dart';
+
+/// 追觅：实时监控指定用户的发帖 / 回复 / 点赞 / 表情回应 / Boost 动态。
+///
+/// 移植自 BestLINUXDO 扩展的「追觅」面板。刷新调度在 [seekingProvider]，
+/// 页面只负责展示与名单管理。
+class SeekingPage extends ConsumerStatefulWidget {
+  const SeekingPage({super.key, this.isActive = true});
+
+  /// 底栏 PageView 复用时的激活标记。
+  final bool isActive;
+
+  @override
+  ConsumerState<SeekingPage> createState() => _SeekingPageState();
+}
+
+class _SeekingPageState extends ConsumerState<SeekingPage> {
+  /// 只看此人过滤（点用户头像切换）
+  String? _focusUser;
+
+  @override
+  void initState() {
+    super.initState();
+    // PageView 可能提前构建本页，只有用户真正切到追觅时才清零。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && widget.isActive) {
+        unawaited(ref.read(seekingProvider.notifier).markAllRead());
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant SeekingPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isActive && widget.isActive) {
+      unawaited(ref.read(seekingProvider.notifier).markAllRead());
+    }
+  }
+
+  Future<void> _showAddUserDialog() async {
+    final controller = TextEditingController();
+    final username = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(ctx.l10n.seeking_addUser),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: InputDecoration(hintText: ctx.l10n.seeking_addUserHint),
+          onSubmitted: (value) => Navigator.pop(ctx, value),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(ctx.l10n.common_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: Text(ctx.l10n.common_confirm),
+          ),
+        ],
+      ),
+    );
+    if (username == null || username.trim().isEmpty || !mounted) return;
+    final result = await ref.read(seekingProvider.notifier).addUser(username);
+    if (!mounted) return;
+    switch (result) {
+      case 'exists':
+        ToastService.showInfo(context.l10n.seeking_userExists);
+      case 'full':
+        ToastService.showInfo(
+          context.l10n.seeking_userLimit(SeekingNotifier.maxUsers),
+        );
+      case 'notFound':
+        ToastService.showInfo(context.l10n.seeking_userNotFound);
+      case 'failed':
+        ToastService.showError(context.l10n.seeking_addUserFailed);
+      default:
+        break;
+    }
+  }
+
+  Future<void> _syncFollowing() async {
+    final added = await ref.read(seekingProvider.notifier).syncFollowing();
+    if (!mounted) return;
+    if (added < 0) {
+      ToastService.showError(context.l10n.seeking_syncFollowFailed);
+    } else {
+      ToastService.showSuccess(context.l10n.seeking_syncFollowDone(added));
+    }
+  }
+
+  void _openActivity(SeekingActivity activity) {
+    if (activity.topicId <= 0) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => TopicDetailPage(
+          topicId: activity.topicId,
+          scrollToPostNumber: activity.postNumber,
+        ),
+      ),
+    );
+  }
+
+  void _openProfile(String username) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<int>(seekingProvider.select((value) => value.totalUnread), (
+      _,
+      unread,
+    ) {
+      if (widget.isActive && unread > 0) {
+        unawaited(ref.read(seekingProvider.notifier).markAllRead());
+      }
+    });
+    final enabled = ref.watch(seekingProvider.select((value) => value.enabled));
+    final users = ref.watch(seekingProvider.select((value) => value.users));
+    final holdUntil = ref.watch(
+      seekingProvider.select((value) => value.holdUntil),
+    );
+    final paceSeconds = ref.watch(
+      seekingProvider.select((value) => value.paceSeconds),
+    );
+    final l10n = context.l10n;
+
+    final page = Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.seeking_title),
+        actions: [
+          IconButton(
+            tooltip: l10n.seeking_syncFollow,
+            icon: const Icon(Symbols.group_add_rounded),
+            onPressed: _syncFollowing,
+          ),
+          IconButton(
+            tooltip: l10n.seeking_addUser,
+            icon: const Icon(Symbols.person_add_rounded),
+            onPressed: _showAddUserDialog,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Switch(
+              value: enabled,
+              onChanged: (v) =>
+                  ref.read(seekingProvider.notifier).setEnabled(v),
+            ),
+          ),
+        ],
+      ),
+      body: users.isEmpty
+          ? _EmptyHint(onAdd: _showAddUserDialog, onSync: _syncFollowing)
+          : Column(
+              children: [
+                if (holdUntil != null)
+                  MaterialBanner(
+                    content: Text(l10n.seeking_rateLimited),
+                    leading: const Icon(Symbols.hourglass_top_rounded),
+                    actions: const [SizedBox.shrink()],
+                  ),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final wide = constraints.maxWidth >= 780;
+                      final activityPane = _SeekingActivityPane(
+                        focusUser: _focusUser,
+                        onOpenActivity: _openActivity,
+                        onOpenProfile: _openProfile,
+                      );
+                      if (!wide) {
+                        return Column(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                              child: _PaceSelector(
+                                paceSeconds: paceSeconds,
+                                onChanged: (seconds) => ref
+                                    .read(seekingProvider.notifier)
+                                    .setPaceSeconds(seconds),
+                              ),
+                            ),
+                            SizedBox(
+                              height: 76,
+                              child: _buildUserList(compact: true),
+                            ),
+                            const Divider(height: 1),
+                            Expanded(child: activityPane),
+                          ],
+                        );
+                      }
+
+                      return Row(
+                        children: [
+                          SizedBox(
+                            width: 300,
+                            child: Column(
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.all(12),
+                                  child: _PaceSelector(
+                                    paceSeconds: paceSeconds,
+                                    onChanged: (seconds) => ref
+                                        .read(seekingProvider.notifier)
+                                        .setPaceSeconds(seconds),
+                                  ),
+                                ),
+                                const Divider(height: 1),
+                                Expanded(child: _buildUserList(compact: false)),
+                              ],
+                            ),
+                          ),
+                          const VerticalDivider(width: 1),
+                          Expanded(child: activityPane),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+    );
+
+    return page;
+  }
+
+  Widget _buildUserList({required bool compact}) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final users = ref.watch(seekingProvider.select((value) => value.users));
+        final profiles = ref.watch(
+          seekingProvider.select((value) => value.profiles),
+        );
+        final unread = ref.watch(
+          seekingProvider.select((value) => value.unread),
+        );
+        final refreshing = ref.watch(
+          seekingProvider.select((value) => value.refreshing),
+        );
+        final totalUnread = unread.values.fold<int>(
+          0,
+          (sum, value) => sum + value,
+        );
+        return ListView.builder(
+          scrollDirection: compact ? Axis.horizontal : Axis.vertical,
+          padding: compact
+              ? const EdgeInsets.symmetric(horizontal: 12, vertical: 8)
+              : const EdgeInsets.symmetric(vertical: 8),
+          itemCount: users.length + 1,
+          itemBuilder: (context, index) {
+            if (index == 0) {
+              return _AllUsersChip(
+                compact: compact,
+                focused: _focusUser == null,
+                unread: totalUnread,
+                onTap: () => setState(() => _focusUser = null),
+              );
+            }
+            final username = users[index - 1];
+            return _UserChip(
+              username: username,
+              profile: profiles[username],
+              unread: unread[username] ?? 0,
+              refreshing: refreshing == username,
+              focused: _focusUser == username,
+              compact: compact,
+              onTap: () => setState(() {
+                _focusUser = _focusUser == username ? null : username;
+              }),
+              onRemove: () =>
+                  ref.read(seekingProvider.notifier).removeUser(username),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _SeekingActivityPane extends ConsumerWidget {
+  const _SeekingActivityPane({
+    required this.focusUser,
+    required this.onOpenActivity,
+    required this.onOpenProfile,
+  });
+
+  final String? focusUser;
+  final ValueChanged<SeekingActivity> onOpenActivity;
+  final ValueChanged<String> onOpenProfile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final enabled = ref.watch(seekingProvider.select((value) => value.enabled));
+    final data = ref.watch(seekingProvider.select((value) => value.data));
+    final profiles = ref.watch(
+      seekingProvider.select((value) => value.profiles),
+    );
+    final timeline = focusUser == null
+        ? SeekingState(data: data).timeline
+        : (data[focusUser] ?? const <SeekingActivity>[]);
+    final theme = Theme.of(context);
+    if (timeline.isEmpty) {
+      return Center(
+        child: Text(
+          enabled
+              ? context.l10n.seeking_waitingData
+              : context.l10n.seeking_disabledHint,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      itemCount: timeline.length,
+      separatorBuilder: (_, _) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final activity = timeline[index];
+        return _ActivityTile(
+          key: ValueKey('${activity.username}:${activity.uid}'),
+          activity: activity,
+          showAvatar: focusUser == null,
+          avatarUrl: profiles[activity.username]?.getAvatarUrl() ?? '',
+          onTap: () => onOpenActivity(activity),
+          onOpenProfile: () => onOpenProfile(activity.username),
+        );
+      },
+    );
+  }
+}
+
+class _PaceSelector extends StatelessWidget {
+  const _PaceSelector({required this.paceSeconds, required this.onChanged});
+
+  final int paceSeconds;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Row(
+      children: [
+        Text(l10n.seeking_paceTitle),
+        const SizedBox(width: 10),
+        Expanded(
+          child: SegmentedButton<int>(
+            showSelectedIcon: false,
+            segments: [
+              ButtonSegment(value: 10, label: Text(l10n.seeking_paceHigh)),
+              ButtonSegment(value: 30, label: Text(l10n.seeking_paceMedium)),
+              ButtonSegment(value: 60, label: Text(l10n.seeking_paceLow)),
+            ],
+            selected: {paceSeconds},
+            onSelectionChanged: (selection) => onChanged(selection.first),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyHint extends StatelessWidget {
+  const _EmptyHint({required this.onAdd, required this.onSync});
+
+  final VoidCallback onAdd;
+  final VoidCallback onSync;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Symbols.visibility_rounded,
+            size: 48,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            context.l10n.seeking_emptyHint,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FilledButton.tonalIcon(
+                onPressed: onAdd,
+                icon: const Icon(Symbols.person_add_rounded, size: 18),
+                label: Text(context.l10n.seeking_addUser),
+              ),
+              const SizedBox(width: 12),
+              FilledButton.tonalIcon(
+                onPressed: onSync,
+                icon: const Icon(Symbols.group_add_rounded, size: 18),
+                label: Text(context.l10n.seeking_syncFollow),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UserChip extends StatelessWidget {
+  const _UserChip({
+    required this.username,
+    required this.profile,
+    required this.unread,
+    required this.refreshing,
+    required this.focused,
+    required this.compact,
+    required this.onTap,
+    required this.onRemove,
+  });
+
+  final String username;
+  final SeekingUserProfile? profile;
+  final int unread;
+  final bool refreshing;
+  final bool focused;
+  final bool compact;
+  final VoidCallback onTap;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final avatarUrl = profile?.getAvatarUrl() ?? '';
+    return Padding(
+      padding: compact
+          ? const EdgeInsets.only(right: 10)
+          : const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: onTap,
+        onLongPress: () => showDialog<void>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(ctx.l10n.seeking_removeUser),
+            content: Text('@$username'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: Text(ctx.l10n.common_cancel),
+              ),
+              FilledButton(
+                onPressed: () {
+                  Navigator.pop(ctx);
+                  onRemove();
+                },
+                style: FilledButton.styleFrom(
+                  backgroundColor: theme.colorScheme.error,
+                ),
+                child: Text(ctx.l10n.common_delete),
+              ),
+            ],
+          ),
+        ),
+        child: Container(
+          padding: compact
+              ? const EdgeInsets.symmetric(horizontal: 6, vertical: 4)
+              : const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          decoration: focused
+              ? BoxDecoration(
+                  color: theme.colorScheme.primaryContainer.withValues(
+                    alpha: 0.5,
+                  ),
+                  borderRadius: BorderRadius.circular(10),
+                )
+              : null,
+          child: compact
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _UserAvatar(
+                      avatarUrl: avatarUrl,
+                      username: username,
+                      unread: unread,
+                      refreshing: refreshing,
+                    ),
+                    const SizedBox(height: 3),
+                    SizedBox(
+                      width: 52,
+                      child: Text(
+                        username,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.labelSmall,
+                      ),
+                    ),
+                  ],
+                )
+              : Row(
+                  children: [
+                    _UserAvatar(
+                      avatarUrl: avatarUrl,
+                      username: username,
+                      unread: unread,
+                      refreshing: refreshing,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        username,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: focused
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: context.l10n.seeking_removeUser,
+                      icon: const Icon(Symbols.close_rounded, size: 18),
+                      onPressed: onRemove,
+                    ),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AllUsersChip extends StatelessWidget {
+  const _AllUsersChip({
+    required this.compact,
+    required this.focused,
+    required this.unread,
+    required this.onTap,
+  });
+
+  final bool compact;
+  final bool focused;
+  final int unread;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final icon = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        CircleAvatar(
+          radius: 16,
+          backgroundColor: theme.colorScheme.secondaryContainer,
+          child: Icon(
+            Symbols.groups_rounded,
+            size: 18,
+            color: theme.colorScheme.onSecondaryContainer,
+          ),
+        ),
+        if (unread > 0)
+          Positioned(
+            right: -4,
+            top: -4,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.error,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                unread > 99 ? '99+' : '$unread',
+                style: TextStyle(fontSize: 9, color: theme.colorScheme.onError),
+              ),
+            ),
+          ),
+      ],
+    );
+    return Padding(
+      padding: compact
+          ? const EdgeInsets.only(right: 10)
+          : const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: onTap,
+        child: Container(
+          padding: compact
+              ? const EdgeInsets.symmetric(horizontal: 6, vertical: 4)
+              : const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          decoration: focused
+              ? BoxDecoration(
+                  color: theme.colorScheme.primaryContainer.withValues(
+                    alpha: 0.5,
+                  ),
+                  borderRadius: BorderRadius.circular(10),
+                )
+              : null,
+          child: compact
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    icon,
+                    const SizedBox(height: 3),
+                    SizedBox(
+                      width: 52,
+                      child: Text(
+                        context.l10n.common_all,
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.labelSmall,
+                      ),
+                    ),
+                  ],
+                )
+              : Row(
+                  children: [
+                    icon,
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        context.l10n.common_all,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: focused
+                              ? FontWeight.w600
+                              : FontWeight.normal,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _UserAvatar extends StatelessWidget {
+  const _UserAvatar({
+    required this.avatarUrl,
+    required this.username,
+    required this.unread,
+    required this.refreshing,
+  });
+
+  final String avatarUrl;
+  final String username;
+  final int unread;
+  final bool refreshing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        SmartAvatar(imageUrl: avatarUrl, radius: 16, fallbackText: username),
+        if (unread > 0)
+          Positioned(
+            right: -4,
+            top: -4,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.error,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                unread > 99 ? '99+' : '$unread',
+                style: TextStyle(fontSize: 9, color: theme.colorScheme.onError),
+              ),
+            ),
+          ),
+        if (refreshing)
+          const Positioned(
+            right: -2,
+            bottom: -2,
+            child: SizedBox(
+              width: 10,
+              height: 10,
+              child: CircularProgressIndicator(strokeWidth: 1.5),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _ActivityTile extends StatelessWidget {
+  const _ActivityTile({
+    super.key,
+    required this.activity,
+    required this.showAvatar,
+    required this.avatarUrl,
+    required this.onTap,
+    required this.onOpenProfile,
+  });
+
+  final SeekingActivity activity;
+  final bool showAvatar;
+  final String avatarUrl;
+  final VoidCallback onTap;
+  final VoidCallback onOpenProfile;
+
+  (IconData, Color) _typeIcon(ThemeData theme) {
+    return switch (activity.type) {
+      SeekingActivityType.post => (
+        Symbols.edit_note_rounded,
+        theme.colorScheme.primary,
+      ),
+      SeekingActivityType.reply => (
+        Symbols.reply_rounded,
+        theme.colorScheme.tertiary,
+      ),
+      SeekingActivityType.like => (
+        Symbols.favorite_rounded,
+        theme.colorScheme.error,
+      ),
+      SeekingActivityType.reaction => (
+        Symbols.add_reaction_rounded,
+        theme.colorScheme.secondary,
+      ),
+      SeekingActivityType.boost => (
+        Symbols.rocket_launch_rounded,
+        theme.colorScheme.tertiary,
+      ),
+    };
+  }
+
+  String _typeLabel(BuildContext context) {
+    final l10n = context.l10n;
+    return switch (activity.type) {
+      SeekingActivityType.post => l10n.seeking_typePost,
+      SeekingActivityType.reply => l10n.seeking_typeReply,
+      SeekingActivityType.like => l10n.seeking_typeLike,
+      SeekingActivityType.reaction => l10n.seeking_typeReaction,
+      SeekingActivityType.boost => l10n.seeking_typeBoost,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (icon, color) = _typeIcon(theme);
+    final excerpt = activity.excerpt?.trim() ?? '';
+    return ListTile(
+      dense: true,
+      leading: showAvatar
+          ? Stack(
+              clipBehavior: Clip.none,
+              children: [
+                SmartAvatar(
+                  imageUrl: avatarUrl,
+                  radius: 16,
+                  fallbackText: activity.username,
+                ),
+                Positioned(
+                  right: -4,
+                  bottom: -4,
+                  child: CircleAvatar(
+                    radius: 8,
+                    backgroundColor: theme.colorScheme.surface,
+                    child: Icon(icon, color: color, size: 11),
+                  ),
+                ),
+              ],
+            )
+          : Icon(icon, color: color, size: 20),
+      title: Row(
+        children: [
+          Flexible(
+            child: GestureDetector(
+              onTap: onOpenProfile,
+              child: Text(
+                activity.username,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            _typeLabel(context),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const Spacer(),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 76,
+            child: Text(
+              TimeUtils.formatRelativeTime(activity.createdAt),
+              maxLines: 1,
+              textAlign: TextAlign.left,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        ],
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (activity.title.isNotEmpty)
+            Text(
+              activity.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium,
+            ),
+          if (excerpt.isNotEmpty)
+            CollapsedHtmlContent(
+              html: excerpt,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textStyle: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                height: 1.35,
+              ),
+            ),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/pages/seeking_page.dart
+++ b/lib/pages/seeking_page.dart
@@ -126,6 +126,15 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
 
   @override
   Widget build(BuildContext context) {
+    // 底栏会保活所有已配置页面。追觅后台轮询更新 refreshing / profiles / data
+    // 时，隐藏页面若仍订阅 Provider，会在其他页面操作期间反复重建列表。
+    // 非激活状态只初始化后台监控，不订阅状态；切回本页时再恢复订阅
+    // 和完整界面。read 不会让隐藏页面随轮询结果反复重建。
+    if (!widget.isActive) {
+      ref.read(seekingProvider);
+      return const SizedBox.shrink();
+    }
+
     ref.listen<int>(seekingProvider.select((value) => value.totalUnread), (
       _,
       unread,

--- a/lib/pages/seeking_page.dart
+++ b/lib/pages/seeking_page.dart
@@ -41,20 +41,12 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
   bool _isAutoSwitching = false;
 
   @override
-  void initState() {
-    super.initState();
-    // PageView 可能提前构建本页，只有用户真正切到追觅时才清零。
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && widget.isActive) {
-        unawaited(ref.read(seekingProvider.notifier).markAllRead());
-      }
-    });
-  }
-
-  @override
   void didUpdateWidget(covariant SeekingPage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!oldWidget.isActive && widget.isActive) {
+    // 未读清零推迟到**离开**页面时：进入页面就清零会让用户徽标
+    // （_UserChip 的 99+ 角标）永远只存在一帧，谁有新动态根本看不见。
+    // 停留期间徽标保持累积，离开时视为已阅、下次进入从零计。
+    if (oldWidget.isActive && !widget.isActive) {
       unawaited(ref.read(seekingProvider.notifier).markAllRead());
     }
   }
@@ -229,14 +221,6 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
       return const SizedBox.shrink();
     }
 
-    ref.listen<int>(seekingProvider.select((value) => value.totalUnread), (
-      _,
-      unread,
-    ) {
-      if (widget.isActive && unread > 0) {
-        unawaited(ref.read(seekingProvider.notifier).markAllRead());
-      }
-    });
     final enabled = ref.watch(seekingProvider.select((value) => value.enabled));
     final users = ref.watch(seekingProvider.select((value) => value.users));
     final holdUntil = ref.watch(

--- a/lib/pages/seeking_page.dart
+++ b/lib/pages/seeking_page.dart
@@ -7,11 +7,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/s.dart';
 import '../models/seeking.dart';
 import '../providers/seeking_provider.dart';
+import '../providers/selected_topic_provider.dart';
 import '../services/toast_service.dart';
 import '../utils/time_utils.dart';
 import '../widgets/common/smart_avatar.dart';
 import '../widgets/content/collapsed_html_content.dart';
+import '../widgets/layout/master_detail_layout.dart';
 import 'topic_detail_page/topic_detail_page.dart';
+import 'topics_screen.dart' show PaneContentWidget;
 import 'user_profile_page.dart';
 
 /// 追觅：实时监控指定用户的发帖 / 回复 / 点赞 / 表情回应 / Boost 动态。
@@ -29,6 +32,9 @@ class SeekingPage extends ConsumerStatefulWidget {
 }
 
 class _SeekingPageState extends ConsumerState<SeekingPage> {
+  static const double _parallelMasterWidth = 440;
+  static const double _parallelMinDetailWidth = 480;
+
   /// 只看此人过滤（点用户头像切换）
   String? _focusUser;
 
@@ -106,6 +112,16 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
 
   void _openActivity(SeekingActivity activity) {
     if (activity.topicId <= 0) return;
+    if (_canShowParallel(context)) {
+      ref
+          .read(selectedSeekingProvider.notifier)
+          .select(
+            topicId: activity.topicId,
+            initialTitle: activity.title,
+            scrollToPostNumber: activity.postNumber,
+          );
+      return;
+    }
     Navigator.push(
       context,
       MaterialPageRoute(
@@ -118,11 +134,22 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
   }
 
   void _openProfile(String username) {
+    if (_canShowParallel(context)) {
+      ref.read(selectedSeekingProvider.notifier).selectProfile(username);
+      return;
+    }
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
     );
   }
+
+  bool _canShowParallel(BuildContext context) =>
+      MasterDetailLayout.canShowBothPanesFor(
+        context,
+        masterWidth: _parallelMasterWidth,
+        minDetailWidth: _parallelMinDetailWidth,
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -218,29 +245,26 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
                         );
                       }
 
-                      return Row(
-                        children: [
-                          SizedBox(
-                            width: 300,
-                            child: Column(
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.all(12),
-                                  child: _PaceSelector(
-                                    paceSeconds: paceSeconds,
-                                    onChanged: (seconds) => ref
-                                        .read(seekingProvider.notifier)
-                                        .setPaceSeconds(seconds),
-                                  ),
-                                ),
-                                const Divider(height: 1),
-                                Expanded(child: _buildUserList(compact: false)),
-                              ],
+                      // 宽屏复用项目统一的平行视界布局，名单栏支持拖动调宽。
+                      return MasterDetailLayout(
+                        masterWidth: 300,
+                        minDetailWidth: 480,
+                        master: Column(
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: _PaceSelector(
+                                paceSeconds: paceSeconds,
+                                onChanged: (seconds) => ref
+                                    .read(seekingProvider.notifier)
+                                    .setPaceSeconds(seconds),
+                              ),
                             ),
-                          ),
-                          const VerticalDivider(width: 1),
-                          Expanded(child: activityPane),
-                        ],
+                            const Divider(height: 1),
+                            Expanded(child: _buildUserList(compact: false)),
+                          ],
+                        ),
+                        detail: activityPane,
                       );
                     },
                   ),
@@ -249,7 +273,32 @@ class _SeekingPageState extends ConsumerState<SeekingPage> {
             ),
     );
 
-    return page;
+    final selected = ref.watch(selectedSeekingProvider);
+    if (!_canShowParallel(context) || !selected.hasSelection) return page;
+
+    final notifier = ref.read(selectedSeekingProvider.notifier);
+    final master = selected.isStacked
+        ? PaneContentWidget(
+            entry: selected.stack[selected.stack.length - 2],
+            stackProvider: selectedSeekingProvider,
+            truncateOnPush: true,
+            parentActive: widget.isActive,
+          )
+        : page;
+    return MasterDetailLayout(
+      masterWidth: _parallelMasterWidth,
+      minDetailWidth: _parallelMinDetailWidth,
+      minMasterRatio: 0.32,
+      maxMasterRatio: selected.isStacked ? 0.8 : 0.52,
+      preferredMasterRatio: selected.isStacked ? 0.5 : 0.4,
+      master: master,
+      detail: PaneContentWidget(
+        entry: selected.topEntry!,
+        stackProvider: selectedSeekingProvider,
+        parentActive: widget.isActive,
+        onBack: () => selected.isStacked ? notifier.pop() : notifier.clear(),
+      ),
+    );
   }
 
   Widget _buildUserList({required bool compact}) {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -10,6 +10,7 @@ import '../settings/search/settings_search_index.dart';
 import '../utils/appearance_warmup.dart';
 import '../utils/platform_utils.dart';
 import 'package:m3e_ui/m3e_ui.dart';
+import '../widgets/layout/master_detail_layout.dart';
 import 'about_page.dart';
 import 'appearance_page.dart';
 import 'bottom_nav_settings_page.dart';
@@ -21,7 +22,29 @@ import 'reading_settings_page.dart';
 import 'shortcut_settings_page.dart';
 
 class SettingsPage extends ConsumerStatefulWidget {
-  const SettingsPage({super.key});
+  static const double parallelMasterWidth = 380;
+  static const double parallelMinDetailWidth = 480;
+
+  /// 平行视界嵌入模式：AppBar 用 [onEmbeddedBack] 关闭当前层，而不是
+  /// Navigator pop（嵌入面板不在 Navigator 路由栈里）。页面自身宽度
+  /// 足够时，子设置页会进入右侧的独立 Navigator；窄屏仍全屏 push。
+  final bool embeddedMode;
+  final VoidCallback? onEmbeddedBack;
+
+  const SettingsPage({
+    super.key,
+    this.embeddedMode = false,
+    this.onEmbeddedBack,
+  });
+
+  @visibleForTesting
+  static bool canShowParallelFor(BuildContext context) {
+    return MasterDetailLayout.canShowBothPanesFor(
+      context,
+      masterWidth: parallelMasterWidth,
+      minDetailWidth: parallelMinDetailWidth,
+    );
+  }
 
   @override
   ConsumerState<SettingsPage> createState() => _SettingsPageState();
@@ -30,6 +53,7 @@ class SettingsPage extends ConsumerStatefulWidget {
 class _SettingsPageState extends ConsumerState<SettingsPage> {
   final _searchController = TextEditingController();
   final _focusNode = FocusNode();
+  final _detailNavigatorKey = GlobalKey<NavigatorState>();
   late final ShortcutSurfaceBinding _shortcutSurfaceBinding =
       ShortcutSurfaceBinding(
         ref: ref,
@@ -82,8 +106,44 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     final l10n = context.l10n;
     final isSearching = _query.isNotEmpty;
 
+    final master = _buildSettingsScaffold(theme, l10n, isSearching);
+    final canShowParallel = SettingsPage.canShowParallelFor(context);
+    if (!canShowParallel) return master;
+
+    return MasterDetailLayout(
+      masterWidth: SettingsPage.parallelMasterWidth,
+      minDetailWidth: SettingsPage.parallelMinDetailWidth,
+      minMasterRatio: 0.28,
+      maxMasterRatio: 0.48,
+      preferredMasterRatio: 0.34,
+      master: master,
+      detail: Navigator(
+        key: _detailNavigatorKey,
+        onGenerateRoute: (_) => MaterialPageRoute(
+          settings: const RouteSettings(name: 'settings-detail-empty'),
+          builder: (_) => _buildDetailEmptyState(theme),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsScaffold(
+    ThemeData theme,
+    AppLocalizations l10n,
+    bool isSearching,
+  ) {
     return Scaffold(
-      appBar: AppBar(title: Text(l10n.settings_title)),
+      appBar: AppBar(
+        title: Text(l10n.settings_title),
+        // embeddedMode 但 onEmbeddedBack 为空（master 面板"上一层预览"，
+        // 非当前可交互栈顶）时不能塞 BackButton——BackButton(onPressed:
+        // null) 会退化成默认 Navigator.maybePop()，直接捅穿到应用根导航
+        // 栈（见 user_profile_page.dart 同类修复的注释）。
+        automaticallyImplyLeading: !widget.embeddedMode,
+        leading: widget.embeddedMode && widget.onEmbeddedBack != null
+            ? BackButton(onPressed: widget.onEmbeddedBack)
+            : null,
+      ),
       body: Column(
         children: [
           // 搜索栏
@@ -132,6 +192,55 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         ],
       ),
     );
+  }
+
+  Widget _buildDetailEmptyState(ThemeData theme) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Symbols.settings_rounded,
+              size: 56,
+              color: theme.colorScheme.outlineVariant,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              context.l10n.settings_selectHint,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _openSettingsPage(WidgetBuilder builder) {
+    final canShowParallel = SettingsPage.canShowParallelFor(context);
+    if (!canShowParallel) {
+      Navigator.push(context, MaterialPageRoute(builder: builder));
+      return;
+    }
+
+    void pushIntoDetail() {
+      final navigator = _detailNavigatorKey.currentState;
+      if (navigator == null) return;
+      navigator.pushAndRemoveUntil(
+        MaterialPageRoute(builder: builder),
+        (route) => route.isFirst,
+      );
+    }
+
+    if (_detailNavigatorKey.currentState == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) pushIntoDetail();
+      });
+    } else {
+      pushIntoDetail();
+    }
   }
 
   /// 搜索结果（自动从数据声明派生）
@@ -203,12 +312,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               size: 18,
             ),
             dense: true,
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) =>
-                    result.pageBuilder(highlightId: result.model.id),
-              ),
+            onTap: () => _openSettingsPage(
+              (_) => result.pageBuilder(highlightId: result.model.id),
             ),
           ),
         );
@@ -227,72 +332,46 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               icon: Symbols.color_lens_rounded,
               iconColor: Colors.teal,
               title: l10n.settings_appearance,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const AppearancePage()),
-              ),
+              onTap: () => _openSettingsPage((_) => const AppearancePage()),
             ),
             _buildOptionTile(
               icon: Symbols.auto_stories_rounded,
               iconColor: Colors.deepOrange,
               title: l10n.settings_reading,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const ReadingSettingsPage(),
-                ),
-              ),
+              onTap: () =>
+                  _openSettingsPage((_) => const ReadingSettingsPage()),
             ),
             _buildOptionTile(
               icon: Symbols.network_check_rounded,
               iconColor: Colors.blueGrey,
               title: l10n.settings_network,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const NetworkSettingsPage(),
-                ),
-              ),
+              onTap: () =>
+                  _openSettingsPage((_) => const NetworkSettingsPage()),
             ),
             _buildOptionTile(
               icon: Symbols.tune_rounded,
               iconColor: Colors.deepPurple,
               title: l10n.settings_preferences,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const PreferencesPage()),
-              ),
+              onTap: () => _openSettingsPage((_) => const PreferencesPage()),
             ),
             _buildOptionTile(
               icon: Symbols.view_day_rounded,
               iconColor: Colors.amber,
               title: l10n.settings_bottomNav,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const BottomNavSettingsPage(),
-                ),
-              ),
+              onTap: () =>
+                  _openSettingsPage((_) => const BottomNavSettingsPage()),
             ),
             _buildOptionTile(
               icon: Symbols.storage_rounded,
               iconColor: Colors.brown,
               title: l10n.settings_dataManagement,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const DataManagementPage()),
-              ),
+              onTap: () => _openSettingsPage((_) => const DataManagementPage()),
             ),
             _buildOptionTile(
               icon: Symbols.cloud_sync_rounded,
               iconColor: Colors.deepPurple,
               title: l10n.notion_title,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => const NotionSettingsPage(),
-                ),
-              ),
+              onTap: () => _openSettingsPage((_) => const NotionSettingsPage()),
             ),
             // 快捷键（仅桌面端）
             if (PlatformUtils.isDesktop)
@@ -300,21 +379,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 icon: Symbols.keyboard_rounded,
                 iconColor: Colors.cyan,
                 title: l10n.settings_shortcuts,
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const ShortcutSettingsPage(),
-                  ),
-                ),
+                onTap: () =>
+                    _openSettingsPage((_) => const ShortcutSettingsPage()),
               ),
             _buildOptionTile(
               icon: Symbols.info_rounded,
               iconColor: Colors.indigo,
               title: l10n.settings_about,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const AboutPage()),
-              ),
+              onTap: () => _openSettingsPage((_) => const AboutPage()),
             ),
           ],
         ),

--- a/lib/pages/topic_detail_page/actions/_scroll_actions.dart
+++ b/lib/pages/topic_detail_page/actions/_scroll_actions.dart
@@ -46,8 +46,13 @@ extension _ScrollActions on _TopicDetailPageState {
 
     // 记录当前浏览位置，用于布局切换时恢复
     _controller.updateViewportPostNumber(postNumber);
-    ref.read(detailScrollPositionProvider(widget.topicId).notifier).state =
-        postNumber;
+    final positionNotifier = ref.read(
+      detailScrollPositionProvider((
+        topicId: widget.topicId,
+        instanceId: _instanceId,
+      )).notifier,
+    );
+    positionNotifier.state = postNumber;
 
     final params = _params;
     final detail = ref.read(topicDetailProvider(params)).value;
@@ -124,8 +129,13 @@ extension _ScrollActions on _TopicDetailPageState {
     // 本方法在 build 期间调用，provider 写入需推迟到帧后
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref.read(detailScrollPositionProvider(widget.topicId).notifier).state =
-          targetPostNumber;
+      final positionNotifier = ref.read(
+        detailScrollPositionProvider((
+          topicId: widget.topicId,
+          instanceId: _instanceId,
+        )).notifier,
+      );
+      positionNotifier.state = targetPostNumber;
     });
 
     final streamIndex = detail.postStream.stream.indexOf(targetPost.id);
@@ -383,8 +393,7 @@ extension _ScrollActions on _TopicDetailPageState {
         // center 坐标系下列表顶是 minScrollExtent 而非 0
         offsetDelta = math.max(
           offsetDelta,
-          scrollController.position.minScrollExtent -
-              scrollController.offset,
+          scrollController.position.minScrollExtent - scrollController.offset,
         );
       }
     } else if (delta > 0 && hasMoreBelowInPost) {
@@ -460,8 +469,17 @@ extension _ScrollActions on _TopicDetailPageState {
     }
 
     if (!forceLocalJump && _controller.isPostRendered(postIndex)) {
-      await _controller.scrollToPost(postNumber, posts);
-    } else {
+      final positioned = await _controller.scrollToPost(postNumber, posts);
+      forceLocalJump = !positioned;
+      if (!positioned) {
+        FrameJankMonitor.logEvent(
+          'SCROLL-FUSE',
+          'scrollToPost 未收敛，切换本地锚点：post=$postNumber index=$postIndex',
+          persistWhenStopped: true,
+        );
+      }
+    }
+    if (forceLocalJump || !_controller.isPostRendered(postIndex)) {
       // 换 center 锚点到目标帖，首帧即构造性定位（收尾贴底见
       // _finalizeInitialPosition，由 build 里的初始定位块统一触发）
       _controller.jumpToPostLocally(postNumber);
@@ -495,11 +513,24 @@ extension _ScrollActions on _TopicDetailPageState {
       }
 
       if (!forceLocalJump && _controller.isPostRendered(postIndex)) {
-        // 同 _scrollToPost：走 jumpTo 而非 animateTo，避免触底回弹
+        // 同 _scrollToPost：走 jumpTo 而非 animateTo，避免触底回弹；
+        // jumpTo 后仍复查是否收敛，未收敛降级本地锚点（SCROLL-FUSE）
+        final scrollIndex = _controller.scrollIndexForPostIndex(postIndex);
         await _controller.scrollController.jumpToRenderedScrollIndex(
-          _controller.scrollIndexForPostIndex(postIndex),
+          scrollIndex,
         );
-      } else {
+        forceLocalJump = !_controller.scrollController
+            .isIndexStateInLayoutRange(scrollIndex);
+        if (forceLocalJump) {
+          FrameJankMonitor.logEvent(
+            'SCROLL-FUSE',
+            'scrollToPostById 未收敛，切换本地锚点：'
+                'post=${post.postNumber} index=$scrollIndex',
+            persistWhenStopped: true,
+          );
+        }
+      }
+      if (forceLocalJump || !_controller.isPostRendered(postIndex)) {
         // 同 _scrollToPost：center 换锚构造性定位
         _controller.jumpToPostLocally(post.postNumber);
         if (mounted) setState(() {});

--- a/lib/pages/topic_detail_page/controllers/topic_detail_controller.dart
+++ b/lib/pages/topic_detail_page/controllers/topic_detail_controller.dart
@@ -269,17 +269,17 @@ class TopicDetailController extends ChangeNotifier {
     return 0;
   }
 
-  /// 滚动到指定帖子（近距跳转，目标已渲染）
+  /// 滚动到指定帖子（近距跳转，目标已渲染），返回是否收敛到布局范围。
   ///
   /// 用 jumpTo 而非 animateTo：动画窗口内维度收缩会留下越界位置，
   /// 触底回弹的成因见 [AutoScrollJump.jumpToRenderedScrollIndex]。
-  Future<void> scrollToPost(int postNumber, List<Post> posts) async {
+  Future<bool> scrollToPost(int postNumber, List<Post> posts) async {
     final postIndex = posts.indexWhere((p) => p.postNumber == postNumber);
-    if (postIndex == -1) return;
+    if (postIndex == -1) return false;
 
-    await scrollController.jumpToRenderedScrollIndex(
-      scrollIndexForPostIndex(postIndex),
-    );
+    final scrollIndex = scrollIndexForPostIndex(postIndex);
+    await scrollController.jumpToRenderedScrollIndex(scrollIndex);
+    return scrollController.isIndexStateInLayoutRange(scrollIndex);
   }
 
   /// 回到顶部

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -97,6 +97,12 @@ class TopicDetailPage extends ConsumerStatefulWidget {
   final bool restoreExistingPaneStack; // 宽屏缩窄产生的临时路由，恢复时保留原栈
   final VoidCallback? restoreParentPaneStack; // 恢复前先还原下层临时路由的平行视界栈
   final bool autoOpenReply; // 自动打开回复框（从草稿进入时使用）
+
+  /// 自动回复意图**已消费**：调用方应把它从状态源头清掉。
+  ///
+  /// [_autoOpenReplyHandled] 只是 State 字段，面板一重建就重置，拦不住
+  /// 重复弹出（实测发完私信回复框又弹一次）。
+  final VoidCallback? onAutoReplyConsumed;
   final int? autoReplyToPostNumber; // 自动回复的帖子编号（从草稿进入时使用）
   final String? instanceId; // 外部指定的 provider 实例 ID（布局切换时复用）
   final bool autoOpenAiChat; // 自动打开 AI 聊天面板
@@ -140,6 +146,7 @@ class TopicDetailPage extends ConsumerStatefulWidget {
     this.restoreExistingPaneStack = false,
     this.restoreParentPaneStack,
     this.autoOpenReply = false,
+    this.onAutoReplyConsumed,
     this.autoReplyToPostNumber,
     this.instanceId,
     this.stackProvider,
@@ -1967,6 +1974,8 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           _autoOpenReplyHandled = true;
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (mounted) {
+              // 先从状态源头清掉意图,再弹框:清晚了这一帧的重建又会命中
+              widget.onAutoReplyConsumed?.call();
               // 如果指定了回复帖子编号，找到对应的帖子
               Post? replyToPost;
               if (widget.autoReplyToPostNumber != null) {

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -95,6 +95,7 @@ class TopicDetailPage extends ConsumerStatefulWidget {
   final bool parentActive; // 父容器是否可见（IndexedStack/双栏切 tab 时用）
   final bool autoSwitchToMasterDetail; // 仅在从首页进入时允许自动切换
   final bool restoreExistingPaneStack; // 宽屏缩窄产生的临时路由，恢复时保留原栈
+  final VoidCallback? restoreParentPaneStack; // 恢复前先还原下层临时路由的平行视界栈
   final bool autoOpenReply; // 自动打开回复框（从草稿进入时使用）
   final int? autoReplyToPostNumber; // 自动回复的帖子编号（从草稿进入时使用）
   final String? instanceId; // 外部指定的 provider 实例 ID（布局切换时复用）
@@ -137,6 +138,7 @@ class TopicDetailPage extends ConsumerStatefulWidget {
     this.parentActive = true,
     this.autoSwitchToMasterDetail = false,
     this.restoreExistingPaneStack = false,
+    this.restoreParentPaneStack,
     this.autoOpenReply = false,
     this.autoReplyToPostNumber,
     this.instanceId,
@@ -163,6 +165,8 @@ class TopicDetailPage extends ConsumerStatefulWidget {
 
 class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     with WidgetsBindingObserver, SingleTickerProviderStateMixin, RouteAware {
+  late ProviderContainer _providerContainer;
+
   /// 唯一实例 ID，确保每次打开页面都创建新的 provider 实例
   /// 支持外部传入以在布局切换时复用同一个 provider
   late final String _instanceId = widget.instanceId ?? const Uuid().v4();
@@ -311,8 +315,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         debugPrint(
           '[TopicDetail] onTimingsSent callback triggered: topicId=$topicId, highestSeen=$highestSeen',
         );
+        final container = _providerContainer;
         // 更新会话已读状态，触发 PostItem 消除未读圆点
-        ref
+        container
             .read(topicSessionProvider(topicId).notifier)
             .markAsRead(postNumbers);
         // 先只更新一份全局追踪状态。之前在每个分类列表的 updateSeen 内
@@ -320,9 +325,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         // provider，导致一次阅读上报并发加载全部置顶分类。
         SchedulerBinding.instance.scheduleTask(() {
           if (!mounted) return;
-          final tracked = ref.read(topicTrackingStateProvider)[topicId];
+          final tracked = container.read(topicTrackingStateProvider)[topicId];
           if (tracked != null) {
-            ref
+            container
                 .read(topicTrackingStateProvider.notifier)
                 .updateTopicRead(
                   topicId,
@@ -333,12 +338,12 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
 
           // 只更新已经存在的列表 provider；未打开的分类没有 UI 状态需要
           // 同步，绝不能为了一次本地字段更新触发网络初始化。
-          final pinnedIds = ref.read(pinnedCategoriesProvider);
+          final pinnedIds = container.read(pinnedCategoriesProvider);
           final categoryIds = [null, ...pinnedIds];
           for (final categoryId in categoryIds) {
             final provider = topicListProvider(categoryId);
-            if (!ref.exists(provider)) continue;
-            ref
+            if (!container.exists(provider)) continue;
+            container
                 .read(provider.notifier)
                 .updateSeen(topicId, highestSeen, updateTracking: false);
           }
@@ -566,7 +571,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       ...shortcuts,
       ShortcutAction.closeOverlay: _handleCloseShortcut,
     };
-    _shortcutScopeBinding.register(context, registeredShortcuts);
+    _shortcutScopeBinding.registerForRoute(_route, registeredShortcuts);
   }
 
   void _exitSearchMode() {
@@ -658,6 +663,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _providerContainer = ProviderScope.containerOf(context, listen: false);
     final route = ModalRoute.of(context);
     if (route == _route || route == null) return;
 
@@ -889,31 +895,59 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         return;
       }
 
-      final currentPostNumber = _resolvedViewportPostNumber;
       final stackProvider = widget.stackProvider ?? selectedTopicProvider;
       final stackNotifier = ref.read(stackProvider.notifier);
-      // 切换瞬间现读即可,不需要 build 期持有 detail(顶层已不再
-      // watch 完整 detail,见 build 内注释)
-      final title =
-          ref.read(topicDetailProvider(_params)).value?.title ??
-          widget.initialTitle;
-      if (widget.restoreExistingPaneStack) {
-        stackNotifier.updateTopTopic(
-          topicId: widget.topicId,
-          initialTitle: title,
-          scrollToPostNumber: currentPostNumber,
-          instanceId: _instanceId,
-        );
-      } else {
-        stackNotifier.select(
-          topicId: widget.topicId,
-          initialTitle: title,
-          scrollToPostNumber: currentPostNumber,
-          instanceId: _instanceId,
-        );
-      }
+      _syncTopicToPaneStack(stackNotifier);
       navigator.pop();
     });
+  }
+
+  void _syncTopicToPaneStack(SelectedTopicNotifier stackNotifier) {
+    final currentPostNumber = _resolvedViewportPostNumber;
+    // 切换瞬间现读即可,不需要 build 期持有 detail(顶层已不再
+    // watch 完整 detail,见 build 内注释)
+    final title =
+        ref.read(topicDetailProvider(_params)).value?.title ??
+        widget.initialTitle;
+    if (widget.restoreParentPaneStack != null) {
+      widget.restoreParentPaneStack!();
+      stackNotifier.push(
+        topicId: widget.topicId,
+        initialTitle: title,
+        scrollToPostNumber: currentPostNumber,
+        instanceId: _instanceId,
+      );
+      return;
+    }
+    if (widget.restoreExistingPaneStack) {
+      stackNotifier.updateTopTopic(
+        topicId: widget.topicId,
+        initialTitle: title,
+        scrollToPostNumber: currentPostNumber,
+        instanceId: _instanceId,
+      );
+    } else {
+      stackNotifier.select(
+        topicId: widget.topicId,
+        initialTitle: title,
+        scrollToPostNumber: currentPostNumber,
+        instanceId: _instanceId,
+      );
+    }
+  }
+
+  void _restoreCurrentPaneToMasterDetail() {
+    if (!mounted) return;
+    final route = ModalRoute.of(context);
+    if (route == null || !route.isActive) return;
+    final navigator = Navigator.of(context);
+
+    final stackProvider = widget.stackProvider ?? selectedTopicProvider;
+    final stackNotifier = ref.read(stackProvider.notifier);
+    _syncTopicToPaneStack(stackNotifier);
+
+    // 当前路由上方可能还有资料页，不能 pop；精确移除本话题路由。
+    if (route.isActive) navigator.removeRoute(route);
   }
 
   Future<void> _handleExternalScrollTargetUpdate(int postNumber) async {
@@ -2162,12 +2196,21 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   /// 分栏本身没问题，但链接点击时 stackProvider 始终为 null——根因就是
   /// 这个分支漏包）。
   Widget _wrapEmbeddedStack(Widget child) {
-    if (!widget.embeddedMode) return child;
-    return EmbeddedStackScope(
-      stackProvider: widget.stackProvider ?? selectedTopicProvider,
-      truncateOnPush: widget.truncateOnPush,
-      child: child,
-    );
+    if (widget.embeddedMode) {
+      return EmbeddedStackScope(
+        stackProvider: widget.stackProvider ?? selectedTopicProvider,
+        truncateOnPush: widget.truncateOnPush,
+        child: child,
+      );
+    }
+    if (widget.autoSwitchToMasterDetail) {
+      return FullScreenPaneRestoreScope(
+        stackProvider: widget.stackProvider ?? selectedTopicProvider,
+        restoreCurrentPane: _restoreCurrentPaneToMasterDetail,
+        child: child,
+      );
+    }
+    return child;
   }
 
   void _showAiAssistantSheet(TopicDetail detail) {
@@ -2375,7 +2418,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
   /// postIndex 数学，riverpod 状态实例与名单实例都未变时直接复用上次
   /// 结果，避免每次 read 都重新过滤。
   TopicDetail _filteredDetail(TopicDetail detail) {
-    final blocked = ref.read(preferencesProvider).normalizedBlockedUsernames;
+    final blocked = _providerContainer
+        .read(preferencesProvider)
+        .normalizedBlockedUsernames;
     if (identical(_blockedFilterInput, detail) &&
         identical(_blockedFilterBlocked, blocked)) {
       return _blockedFilterOutput!;

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -94,6 +94,7 @@ class TopicDetailPage extends ConsumerStatefulWidget {
   final bool embeddedMode; // 嵌入模式（双栏布局中使用，不显示返回按钮）
   final bool parentActive; // 父容器是否可见（IndexedStack/双栏切 tab 时用）
   final bool autoSwitchToMasterDetail; // 仅在从首页进入时允许自动切换
+  final bool restoreExistingPaneStack; // 宽屏缩窄产生的临时路由，恢复时保留原栈
   final bool autoOpenReply; // 自动打开回复框（从草稿进入时使用）
   final int? autoReplyToPostNumber; // 自动回复的帖子编号（从草稿进入时使用）
   final String? instanceId; // 外部指定的 provider 实例 ID（布局切换时复用）
@@ -115,17 +116,31 @@ class TopicDetailPage extends ConsumerStatefulWidget {
   final VoidCallback? onEmbeddedShowTabs;
   final bool hideInlineHeaderTitle;
 
+  /// 平行视界导航栈：内部链接点击或全屏路由恢复时使用的目标 provider。
+  /// 默认 [selectedTopicProvider]（首页话题列表）；私信详情面板传
+  /// [selectedMessageProvider]，保证两套历史互不干扰。
+  final SelectedTopicProvider? stackProvider;
+
+  /// master 面板显示"上一层预览"时传 true：这层内容不是当前可交互的
+  /// 栈顶，内部链接点击应该"替换右侧正显示的那层"（截断栈顶后压入），
+  /// 而不是在已经很深的栈上继续叠层——见
+  /// [EmbeddedStackScope.truncateOnPush] 的注释。
+  final bool truncateOnPush;
+
   const TopicDetailPage({
     super.key,
     required this.topicId,
     this.initialTitle,
     this.scrollToPostNumber,
     this.embeddedMode = false,
+    this.truncateOnPush = false,
     this.parentActive = true,
     this.autoSwitchToMasterDetail = false,
+    this.restoreExistingPaneStack = false,
     this.autoOpenReply = false,
     this.autoReplyToPostNumber,
     this.instanceId,
+    this.stackProvider,
     this.autoOpenAiChat = false,
     this.initialSessionId,
     this.highlightBoostUsername,
@@ -300,16 +315,32 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
         ref
             .read(topicSessionProvider(topicId).notifier)
             .markAsRead(postNumbers);
-        // 遍历所有分类 tab 更新列表页 lastReadPostNumber。会重建栈底的
-        // 列表页,推迟到 idle 执行,避免上报回调恰好落在滚动帧内造成掉帧
+        // 先只更新一份全局追踪状态。之前在每个分类列表的 updateSeen 内
+        // 重复写一次，还会因为 ref.read(notifier) 初始化从未打开过的
+        // provider，导致一次阅读上报并发加载全部置顶分类。
         SchedulerBinding.instance.scheduleTask(() {
           if (!mounted) return;
+          final tracked = ref.read(topicTrackingStateProvider)[topicId];
+          if (tracked != null) {
+            ref
+                .read(topicTrackingStateProvider.notifier)
+                .updateTopicRead(
+                  topicId,
+                  highestSeen,
+                  tracked.highestPostNumber,
+                );
+          }
+
+          // 只更新已经存在的列表 provider；未打开的分类没有 UI 状态需要
+          // 同步，绝不能为了一次本地字段更新触发网络初始化。
           final pinnedIds = ref.read(pinnedCategoriesProvider);
           final categoryIds = [null, ...pinnedIds];
           for (final categoryId in categoryIds) {
+            final provider = topicListProvider(categoryId);
+            if (!ref.exists(provider)) continue;
             ref
-                .read(topicListProvider(categoryId).notifier)
-                .updateSeen(topicId, highestSeen);
+                .read(provider.notifier)
+                .updateSeen(topicId, highestSeen, updateTracking: false);
           }
         }, Priority.idle);
       },
@@ -398,7 +429,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
 
   void _onScrollIdle() {
     if (!mounted) return;
-    if (_idleFlushPosition?.isScrollingNotifier.value ?? true) return;
+    final scrolling =
+        _idleFlushPosition?.isScrollingNotifier.value ?? true;
+    if (scrolling) return;
     if (_deferredPostUpdates.isEmpty) return;
     // 推迟一帧回放:isScrollingNotifier 翻 false 发生在惯性最后一个 tick
     // 的同一帧,若同帧内直接回放,布局时 pixels 相对上一帧仍在变,
@@ -526,6 +559,9 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       },
     };
     // Esc 优先退出页内搜索/AI，再按当前布局执行嵌入返回或路由返回。
+    // （_handleCloseShortcut 的嵌入分支会调 onEmbeddedBack——平行视界
+    // 栈深度 > 1 时非空,Esc 退回上一层,与返回按钮一致;为 null 时
+    // 刻意空操作,不会误 pop 宿主路由。）
     final registeredShortcuts = {
       ...shortcuts,
       ShortcutAction.closeOverlay: _handleCloseShortcut,
@@ -854,18 +890,28 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       }
 
       final currentPostNumber = _resolvedViewportPostNumber;
-      ref
-          .read(selectedTopicProvider.notifier)
-          .select(
-            topicId: widget.topicId,
-            // 切换瞬间现读即可,不需要 build 期持有 detail(顶层已不再
-            // watch 完整 detail,见 build 内注释)
-            initialTitle:
-                ref.read(topicDetailProvider(_params)).value?.title ??
-                widget.initialTitle,
-            scrollToPostNumber: currentPostNumber,
-            instanceId: _instanceId,
-          );
+      final stackProvider = widget.stackProvider ?? selectedTopicProvider;
+      final stackNotifier = ref.read(stackProvider.notifier);
+      // 切换瞬间现读即可,不需要 build 期持有 detail(顶层已不再
+      // watch 完整 detail,见 build 内注释)
+      final title =
+          ref.read(topicDetailProvider(_params)).value?.title ??
+          widget.initialTitle;
+      if (widget.restoreExistingPaneStack) {
+        stackNotifier.updateTopTopic(
+          topicId: widget.topicId,
+          initialTitle: title,
+          scrollToPostNumber: currentPostNumber,
+          instanceId: _instanceId,
+        );
+      } else {
+        stackNotifier.select(
+          topicId: widget.topicId,
+          initialTitle: title,
+          scrollToPostNumber: currentPostNumber,
+          instanceId: _instanceId,
+        );
+      }
       navigator.pop();
     });
   }
@@ -961,6 +1007,13 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
 
               return AppBar(
                 automaticallyImplyLeading: !widget.embeddedMode,
+                // 平行视界导航栈：embeddedMode 下默认不显示返回按钮（双栏
+                // 选中态没有"返回"概念），但栈深度 > 1（内部链接跳转堆上来
+                // 的层）时，onEmbeddedBack 会被显式传入，这里补一个返回按钮
+                // 弹出当前层，退回上一层。
+                leading: widget.embeddedMode && widget.onEmbeddedBack != null
+                    ? BackButton(onPressed: widget.onEmbeddedBack)
+                    : null,
                 elevation: currentElevation,
                 scrolledUnderElevation: currentElevation,
                 shadowColor: Colors.transparent,
@@ -1039,7 +1092,11 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
                   alignment: PlaceholderAlignment.middle,
                   child: Padding(
                     padding: const EdgeInsets.only(right: 4),
-                    child: Icon(Symbols.check_box_rounded, size: 18, color: Colors.green),
+                    child: Icon(
+                      Symbols.check_box_rounded,
+                      size: 18,
+                      color: Colors.green,
+                    ),
                   ),
                 ),
               ...EmojiText.buildEmojiSpans(
@@ -1151,7 +1208,11 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
                 alignment: PlaceholderAlignment.middle,
                 child: Padding(
                   padding: const EdgeInsets.only(right: 4),
-                  child: Icon(Symbols.check_box_rounded, size: 16, color: Colors.green),
+                  child: Icon(
+                    Symbols.check_box_rounded,
+                    size: 16,
+                    color: Colors.green,
+                  ),
                 ),
               ),
             ...EmojiText.buildEmojiSpans(
@@ -1746,63 +1807,76 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     _maybeSwitchToMasterDetail(canShowDetailPane);
 
     // 监听 MessageBus 事件
+    //
+    // 平行视界：压栈/退栈会把话题面板从 detail 槽移到 master 槽（或反过
+    // 来），这两个槽位是 widget 树里不同分支，没法用 GlobalKey 跨槽复用
+    // （试过，会命中 Flutter 框架级 GlobalKey 断言崩溃，已回退——见
+    // topics_screen.dart `_keyForTopic` 的注释），所以每次挪槽本面板都
+    // 会被销毁重建。如果这个窗口期正好撞上一条实时推送到达，下面这些
+    // ref.read 可能作用在已失效的 widget 上而报错（表现为点头像/内部
+    // 链接后卡死不响应——实测复现过）。整个回调包一层 try-catch：面板
+    // 反正要没了，跳过这次更新是安全的，比让异常直接把交互链路搅死强。
     ref.listen(topicChannelProvider(widget.topicId), (previous, next) {
       if (!context.mounted) return;
-      // 1. reload_topic（话题状态变更：关闭/打开/固定等）
-      if (next.reloadRequested && !(previous?.reloadRequested ?? false)) {
-        ref
-            .read(topicChannelProvider(widget.topicId).notifier)
-            .clearReloadRequest();
-        _handleReloadTopic(notifier, next.refreshStreamRequested);
-        return;
-      }
-
-      // 2. notification_level_change（通知级别变更）
-      if (next.notificationLevelChange != null &&
-          previous?.notificationLevelChange != next.notificationLevelChange) {
-        final level = TopicNotificationLevel.fromValue(
-          next.notificationLevelChange!,
-        );
-        ref
-            .read(topicChannelProvider(widget.topicId).notifier)
-            .clearNotificationLevelChange();
-        notifier.updateNotificationLevelLocally(level);
-        return;
-      }
-
-      // 3. stats 更新
-      if (next.statsUpdate != null &&
-          previous?.statsUpdate != next.statsUpdate) {
-        notifier.applyStatsUpdate(next.statsUpdate!);
-        ref
-            .read(topicChannelProvider(widget.topicId).notifier)
-            .clearStatsUpdate();
-      }
-
-      // 3.1 "俺也一样" (shared_issue) 计数更新
-      //   - 服务端广播包含 `count` 与 *操作用户的* userCreated
-      //   - 接收端只接受 count；userCreated 不能覆写本地状态(因为对所有订阅者一致)
-      //   - 自己点击的 toggle 响应已直接写入 detail,所以即便回声也只是同值刷新,幂等
-      if (next.sharedIssueUpdate != null &&
-          previous?.sharedIssueUpdate != next.sharedIssueUpdate) {
-        final currentDetail = ref.read(topicDetailProvider(params)).value;
-        if (currentDetail != null) {
-          notifier.updateSharedIssue(
-            next.sharedIssueUpdate!.count,
-            currentDetail.userCreatedSharedIssue,
-          );
+      try {
+        // 1. reload_topic（话题状态变更：关闭/打开/固定等）
+        if (next.reloadRequested && !(previous?.reloadRequested ?? false)) {
+          ref
+              .read(topicChannelProvider(widget.topicId).notifier)
+              .clearReloadRequest();
+          _handleReloadTopic(notifier, next.refreshStreamRequested);
+          return;
         }
-        ref
-            .read(topicChannelProvider(widget.topicId).notifier)
-            .clearSharedIssueUpdate();
-      }
 
-      // 4. 帖子级别更新（created/revised/deleted/liked 等）:
-      // generation 变化 = 新一批(postUpdates 即该批全量,由频道层在
-      // 微任务边界攒批)。批入口统一做去重与积压坍缩。
-      if (next.postUpdatesGeneration !=
-          (previous?.postUpdatesGeneration ?? 0)) {
-        _handlePostUpdateBatch(notifier, next.postUpdates);
+        // 2. notification_level_change（通知级别变更）
+        if (next.notificationLevelChange != null &&
+            previous?.notificationLevelChange != next.notificationLevelChange) {
+          final level = TopicNotificationLevel.fromValue(
+            next.notificationLevelChange!,
+          );
+          ref
+              .read(topicChannelProvider(widget.topicId).notifier)
+              .clearNotificationLevelChange();
+          notifier.updateNotificationLevelLocally(level);
+          return;
+        }
+
+        // 3. stats 更新
+        if (next.statsUpdate != null &&
+            previous?.statsUpdate != next.statsUpdate) {
+          notifier.applyStatsUpdate(next.statsUpdate!);
+          ref
+              .read(topicChannelProvider(widget.topicId).notifier)
+              .clearStatsUpdate();
+        }
+
+        // 3.1 "俺也一样" (shared_issue) 计数更新
+        //   - 服务端广播包含 `count` 与 *操作用户的* userCreated
+        //   - 接收端只接受 count；userCreated 不能覆写本地状态(因为对所有订阅者一致)
+        //   - 自己点击的 toggle 响应已直接写入 detail,所以即便回声也只是同值刷新,幂等
+        if (next.sharedIssueUpdate != null &&
+            previous?.sharedIssueUpdate != next.sharedIssueUpdate) {
+          final currentDetail = ref.read(topicDetailProvider(params)).value;
+          if (currentDetail != null) {
+            notifier.updateSharedIssue(
+              next.sharedIssueUpdate!.count,
+              currentDetail.userCreatedSharedIssue,
+            );
+          }
+          ref
+              .read(topicChannelProvider(widget.topicId).notifier)
+              .clearSharedIssueUpdate();
+        }
+
+        // 4. 帖子级别更新（created/revised/deleted/liked 等）:
+        // generation 变化 = 新一批(postUpdates 即该批全量,由频道层在
+        // 微任务边界攒批)。批入口统一做去重与积压坍缩。
+        if (next.postUpdatesGeneration !=
+            (previous?.postUpdatesGeneration ?? 0)) {
+          _handlePostUpdateBatch(notifier, next.postUpdates);
+        }
+      } catch (_) {
+        // 面板销毁重建窗口期撞上推送，跳过这次更新。
       }
     });
 
@@ -1811,10 +1885,20 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       if (!context.mounted) return;
       final detail = next.value;
       // 记录话题标题到会话状态，供用户卡片「基于话题的私信」预填标题
+      //
+      // 平行视界下这个话题面板可能在 listener 触发的同一拍被压栈顶替
+      // （比如刚点了头像跳资料，本面板从 detail 槽移到 master 槽，
+      // key 变化导致 Element 被销毁重建）——`context.mounted` 检查和
+      // 这次 provider 读取之间存在极短窗口，命中过
+      // "Looking up a deactivated widget's ancestor is unsafe"（见
+      // app_log.jsonl）。这里只是写会话态标题，面板都要没了就跳过，
+      // 用 try-catch 兜底避免这条竞态崩掉整个交互。
       if (detail != null) {
-        ref
-            .read(topicSessionProvider(widget.topicId).notifier)
-            .setTopicTitle(detail.title);
+        try {
+          ref
+              .read(topicSessionProvider(widget.topicId).notifier)
+              .setTopicTitle(detail.title);
+        } catch (_) {}
       }
       // 首次拿到 detail 后再决定是否应用默认嵌套视图：
       // 私信场景下树形视图 API 拉不到数据，跳过该配置
@@ -1969,22 +2053,30 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
     );
 
     // 无 AI 模型或非滑动入口模式：普通布局
+    //
+    // 平行视界：这是绝大多数话题（尤其私信——基本不会挂 AI 模型）走的
+    // 分支，之前 EmbeddedStackScope 只包在下面"AI 滑动入口"那条分支里，
+    // 导致常规话题/私信内部链接点击永远找不到嵌入面板、一直全屏 push
+    // （实测确认：私信打开话题分栏正常，但点内部链接 EmbeddedStackScope
+    // 始终为 null——根因就是这条分支从没被 EmbeddedStackScope 包过）。
     if (!hasAiModel || !useSwipeEntry) {
-      return LazyLoadScope(
-        child: PopScope(
-          canPop: !isSearchMode,
-          onPopInvokedWithResult: (bool didPop, dynamic result) {
-            if (!didPop) {
-              _exitSearchMode();
-            }
-          },
-          child: topicScaffold,
+      return _wrapEmbeddedStack(
+        LazyLoadScope(
+          child: PopScope(
+            canPop: !isSearchMode,
+            onPopInvokedWithResult: (bool didPop, dynamic result) {
+              if (!didPop) {
+                _exitSearchMode();
+              }
+            },
+            child: topicScaffold,
+          ),
         ),
       );
     }
 
     // 滑动入口模式：PageView 包裹话题详情和 AI 聊天
-    return LazyLoadScope(
+    final pageViewScope = LazyLoadScope(
       child: ValueListenableBuilder<int>(
         valueListenable: _currentPageNotifier,
         builder: (context, currentPage, _) {
@@ -2053,6 +2145,28 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
           );
         },
       ),
+    );
+
+    return _wrapEmbeddedStack(pageViewScope);
+  }
+
+  /// 平行视界导航栈：内部链接点击时该压到哪个栈（首页话题栈还是私信栈
+  /// 等），用 InheritedWidget 按实际 widget 树最近祖先解析，而不是全局
+  /// 可变状态——IndexedStack 里首页跟私信的嵌入面板可能同时挂载，全局
+  /// "当前活跃面板"标记会被互相踩掉（这是更早一版的 bug）。
+  ///
+  /// 两条 return 分支（AI 滑动入口 / 普通布局）都要包——之前只包了
+  /// "AI 滑动入口"那条分支，绝大多数话题（尤其私信，基本不会挂 AI
+  /// 模型）走的是普通布局分支，从没被包过，导致这些话题内部链接点击
+  /// 永远找不到 EmbeddedStackScope、一直全屏 push（实测确认：日志显示
+  /// 分栏本身没问题，但链接点击时 stackProvider 始终为 null——根因就是
+  /// 这个分支漏包）。
+  Widget _wrapEmbeddedStack(Widget child) {
+    if (!widget.embeddedMode) return child;
+    return EmbeddedStackScope(
+      stackProvider: widget.stackProvider ?? selectedTopicProvider,
+      truncateOnPush: widget.truncateOnPush,
+      child: child,
     );
   }
 
@@ -2164,7 +2278,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
 
     // Stack 组装
     return Stack(
-      children: [
+        children: [
         // 使用 Offstage 保持帖子列表存在但在搜索模式下隐藏，保留滚动位置
         Offstage(offstage: isSearchMode, child: content),
 
@@ -2251,7 +2365,7 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
               );
             },
           ),
-      ],
+        ],
     );
   }
 

--- a/lib/pages/topic_detail_page/widgets/topic_detail_header.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_detail_header.dart
@@ -12,6 +12,7 @@ import '../../../utils/time_utils.dart';
 import '../../../widgets/common/relative_time_text.dart';
 import '../../../utils/number_utils.dart';
 import '../../../widgets/topic/topic_notification_button.dart';
+import '../../../widgets/layout/home_workspace_scope.dart';
 import 'topic_vote_button.dart';
 import '../../../widgets/common/topic_badges.dart';
 import '../../category_topics_page.dart';
@@ -153,12 +154,20 @@ class TopicDetailHeader extends ConsumerWidget {
                     category: category,
                     faIcon: faIcon,
                     logoUrl: logoUrl,
-                    onTap: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => CategoryTopicsPage(category: category),
-                      ),
-                    ),
+                    onTap: () {
+                      final workspace = HomeWorkspaceScope.maybeOf(context);
+                      if (workspace != null) {
+                        workspace.onShowCategory(category);
+                        return;
+                      }
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              CategoryTopicsPage(category: category),
+                        ),
+                      );
+                    },
                   ),
 
                 // 标签 Badges
@@ -166,12 +175,19 @@ class TopicDetailHeader extends ConsumerWidget {
                   ...detail.tags!.map(
                     (tag) => TagBadge(
                       name: tag.name,
-                      onTap: () => Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => TagTopicsPage(tagName: tag.name),
-                        ),
-                      ),
+                      onTap: () {
+                        final workspace = HomeWorkspaceScope.maybeOf(context);
+                        if (workspace != null) {
+                          workspace.onShowTag(tag.name);
+                          return;
+                        }
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => TagTopicsPage(tagName: tag.name),
+                          ),
+                        );
+                      },
                     ),
                   ),
               ],

--- a/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
+++ b/lib/pages/topic_detail_page/widgets/topic_progress_gestures.dart
@@ -52,10 +52,7 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   /// 环还在累积，强化"按住越久越满"的感受
   static const Duration _pressProgressDuration = Duration(milliseconds: 520);
 
-  late final AnimationController _pressController = AnimationController(
-    vsync: this,
-    duration: _pressProgressDuration,
-  );
+  late final AnimationController _pressController;
 
   // 滑动预览状态
   OverlayEntry? _swipeEntry;
@@ -65,6 +62,15 @@ class _TopicProgressGesturesState extends ConsumerState<TopicProgressGestures>
   _SwipeDirection? _swipeDirection;
   ProgressGestureAction? _swipeAction;
   bool _swipeTriggerable = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pressController = AnimationController(
+      vsync: this,
+      duration: _pressProgressDuration,
+    );
+  }
 
   @override
   void dispose() {

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -655,7 +655,16 @@ class _TabListScrollController extends ScrollController {
 
 /// 帖子列表页面 - 分类 Tab + 排序下拉 + 标签 Chips
 class TopicsPage extends ConsumerStatefulWidget {
-  const TopicsPage({super.key});
+  const TopicsPage({
+    super.key,
+    this.onSearchRequested,
+    this.externalCategoryId,
+    this.externalTag,
+  });
+
+  final ValueChanged<SearchFilter?>? onSearchRequested;
+  final int? externalCategoryId;
+  final String? externalTag;
 
   @override
   ConsumerState<TopicsPage> createState() => _TopicsPageState();
@@ -677,6 +686,7 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
   int _tabLength = 1; // 初始只有"全部"
   int _currentTabIndex = 0;
   List<int> _visiblePinnedIds = []; // 过滤后的可见分类 ID
+  (int?, String?)? _lastExternalSelection;
 
   late final _HeaderCollapseController _headerController;
   bool _invalidateScheduled = false;
@@ -1050,7 +1060,13 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
 
     final topPadding = MediaQuery.of(context).padding.top;
     final isLoggedIn = ref.watch(currentUserProvider).value != null;
-    final allPinnedIds = ref.watch(pinnedCategoriesProvider);
+    final savedPinnedIds = ref.watch(pinnedCategoriesProvider);
+    final allPinnedIds = <int>[
+      ...savedPinnedIds,
+      if (widget.externalCategoryId case final id?
+          when !savedPinnedIds.contains(id))
+        id,
+    ];
     final categoryMapAsync = ref.watch(categoryMapProvider);
     final categoryMap = categoryMapAsync.value;
     // 首页卡片统一复用页面层的分类快照，避免每张 TopicCard 单独订阅
@@ -1063,6 +1079,23 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
         : allPinnedIds;
     final currentFilter = ref.watch(topicFilterProvider);
     _syncTabsIfNeeded(pinnedIds);
+
+    final externalSelection = (widget.externalCategoryId, widget.externalTag);
+    if (_lastExternalSelection != externalSelection) {
+      _lastExternalSelection = externalSelection;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final categoryId = widget.externalCategoryId;
+        final index = categoryId == null
+            ? 0
+            : pinnedIds.indexOf(categoryId) + 1;
+        if (index >= 0 && index < _tabController.length) {
+          _tabController.animateTo(index);
+        }
+        ref.read(tabTagsProvider(categoryId).notifier).state =
+            widget.externalTag == null ? const [] : [widget.externalTag!];
+      });
+    }
 
     // 监听侧栏分类选中变化，同步切换 tab
     ref.listen(activeSidebarCategoryIdProvider, (prev, next) {

--- a/lib/pages/topics_screen.dart
+++ b/lib/pages/topics_screen.dart
@@ -6,17 +6,25 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import '../l10n/s.dart';
+import '../models/search_filter.dart';
+import '../models/category.dart';
 import '../navigation/nav_action_bus.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/selected_topic_provider.dart';
 import '../providers/shortcut_provider.dart';
 import '../providers/discourse_providers.dart';
+import '../services/dynamic_content_suspension_service.dart';
 import '../utils/platform_utils.dart';
 import '../utils/blur_config.dart';
 import '../utils/responsive.dart';
+import '../widgets/layout/auto_restore_master_detail_route.dart';
 import '../widgets/layout/master_detail_layout.dart';
+import '../widgets/layout/home_workspace_scope.dart';
 import 'topics_page.dart';
+import 'search_page.dart';
+import 'settings_page.dart';
 import 'topic_detail_page/topic_detail_page.dart';
+import 'user_profile_page.dart';
 import 'create_topic_page.dart';
 import 'drafts_page.dart';
 
@@ -33,12 +41,35 @@ class TopicsScreen extends ConsumerStatefulWidget {
 }
 
 class _TopicsScreenState extends ConsumerState<TopicsScreen> {
+  bool _showEmbeddedSearch = false;
+  SearchFilter? _embeddedSearchFilter;
+  Category? _leftCategory;
+  String? _leftTag;
   bool? _lastCanShowDetailPane;
   bool _isAutoSwitching = false;
 
   /// 当前活跃的 provider 实例 ID，布局切换时复用
   String? _activeInstanceId;
   int? _activeTopicId;
+
+  @override
+  void didUpdateWidget(covariant TopicsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.isActive && widget.isActive) {
+      // 非活跃期间可能由通知/深链写入了新选择。重新激活时必须重新投影
+      // 当前状态，不能把上一次窄/宽布局判断当成已经处理。
+      _lastCanShowDetailPane = null;
+    }
+  }
+
+  /// 曾经尝试过用持久化的 per-topicId GlobalKey 让话题面板在 master/
+  /// detail 槽位间"挪动"而不是销毁重建（意图：避开 TopicDetailPage 内
+  /// 部 ref.listen 撞上销毁重建窗口期的竞态）。实测翻车更严重：多切换
+  /// 几个私信后直接命中 Flutter 框架级断言
+  /// `'_elements.contains(element)': is not true`（GlobalKey 内部记账
+  /// 出错，红屏崩溃）——比原来要解决的问题更糟，已回退。槽位切换时
+  /// 话题面板销毁重建暂时接受，如果 ref.listen 竞态复现再单独处理。
+  Key _keyForTopic(int topicId) => ValueKey('topic_$topicId');
 
   /// topicId 变化时生成新 instanceId，相同 topicId 复用
   /// 如果提供了 existingInstanceId（如从全屏详情页传回），直接采用
@@ -55,7 +86,10 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     return _activeInstanceId!;
   }
 
-  void _maybePushDetail(SelectedTopicState selectedTopic, bool canShowDetailPane) {
+  void _maybePushDetail(
+    SelectedTopicState selectedTopic,
+    bool canShowDetailPane,
+  ) {
     if (_isAutoSwitching) return;
 
     // IndexedStack 中非活跃 tab 仍需更新状态，避免切回时误触发
@@ -67,15 +101,8 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     // 当前路由不在栈顶时（有其他页面覆盖），根据布局判断是否清除选中
     final route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) {
-      // 单栏模式下选中状态没有意义（看不到），清除并释放 provider 缓存
-      if (!canShowDetailPane && selectedTopic.hasSelection) {
-        _activeTopicId = null;
-        _activeInstanceId = null;
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) ref.read(selectedTopicProvider.notifier).clear();
-        });
-      }
-      // 双栏模式下保留选中状态（从详情面板 push 到其他页面，回来还要显示）
+      // 页面被窄屏临时详情路由或其他内容覆盖时也必须保留选择；否则用户
+      // 在小屏打开话题/资料后再放大，平行视界历史已经被后台清空。
       _lastCanShowDetailPane = canShowDetailPane;
       return;
     }
@@ -85,39 +112,77 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
 
     // 从双栏切到单栏时自动 push；如果 previous 为空但当前为单栏且有选中，
     // 也执行 push，避免因状态丢失导致无法自动进入详情。
-    if (!canShowDetailPane && selectedTopic.hasSelection && (previous == null || previous == true)) {
-
+    if (!canShowDetailPane &&
+        selectedTopic.hasSelection &&
+        (previous == null || previous == true)) {
       final topicId = selectedTopic.topicId;
-      if (topicId == null) return;
+      if (topicId == null) {
+        // 个人资料/设置层：没有可复用的 instanceId/滚动位置，直接全屏 push。
+        final username = selectedTopic.username;
+        final isSettings = selectedTopic.kind == PaneKind.settings;
+        if (username == null && !isSettings) return;
+        _isAutoSwitching = true;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          final navigator = Navigator.of(context);
+          // 不清空栈状态：只是临时用全屏页面顶替（因为窄屏放不下双栏），
+          // 状态还留着——回到宽屏时（这个全屏页面还盖在上面时）
+          // "route 不在栈顶"那个分支会把双栏状态原样恢复回去。之前这里
+          // 会 clear()，导致缩小后又放大回去，压栈的内容就丢了，只剩
+          // 空列表。
+          navigator
+              .push(
+                MaterialPageRoute(
+                  builder: (_) => AutoRestoreMasterDetailRoute(
+                    child: isSettings
+                        ? const SettingsPage()
+                        : UserProfilePage(username: username!),
+                  ),
+                ),
+              )
+              .whenComplete(() {
+                if (mounted) setState(() => _isAutoSwitching = false);
+              });
+        });
+        return;
+      }
 
       // 复用同一个 instanceId，避免重新 fetch
       final instanceId = _getOrCreateInstanceId(topicId);
       // 读取嵌入式详情页的实际浏览位置（在当前 build 中嵌入页还在 tree 中）
-      final scrollPosition = ref.read(detailScrollPositionProvider(topicId))
-          ?? selectedTopic.scrollToPostNumber;
+      final scrollPosition =
+          ref.read(
+            detailScrollPositionProvider((
+              topicId: topicId,
+              instanceId: instanceId,
+            )),
+          ) ??
+          selectedTopic.scrollToPostNumber;
 
       _isAutoSwitching = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final navigator = Navigator.of(context);
-        ref.read(selectedTopicProvider.notifier).clear();
+        // 同上：不清空栈状态，回宽屏时自动恢复。
         navigator
             .push(
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: topicId,
-              initialTitle: selectedTopic.initialTitle,
-              scrollToPostNumber: scrollPosition,
-              autoSwitchToMasterDetail: true,
-              instanceId: instanceId,
-            ),
-          ),
-        )
+              MaterialPageRoute(
+                builder: (_) => TopicDetailPage(
+                  topicId: topicId,
+                  initialTitle: selectedTopic.initialTitle,
+                  scrollToPostNumber: scrollPosition,
+                  autoSwitchToMasterDetail: true,
+                  restoreExistingPaneStack: true,
+                  instanceId: instanceId,
+                  stackProvider: selectedTopicProvider,
+                ),
+              ),
+            )
             .whenComplete(() {
-          if (mounted) {
-            setState(() => _isAutoSwitching = false);
-          }
-        });
+              if (mounted) {
+                setState(() => _isAutoSwitching = false);
+              }
+            });
       });
       return;
     }
@@ -129,11 +194,40 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
     final user = ref.watch(currentUserProvider).value;
 
+    // 左侧导航栏的板块快捷入口位于平行视界布局之外。切换板块时除了让
+    // TopicsPage 换 Tab，还必须收起“上一层内容”左栏，否则列表虽然已在
+    // 后台切换，界面仍被旧话题覆盖，看起来就像点击无响应。
+    ref.listen(activeSidebarCategoryIdProvider, (_, _) {
+      final state = ref.read(selectedTopicProvider);
+      if (!state.isStacked &&
+          !_showEmbeddedSearch &&
+          _leftCategory == null &&
+          _leftTag == null) {
+        return;
+      }
+      ref.read(selectedTopicProvider.notifier).collapseToTop();
+      if (mounted) {
+        setState(() {
+          _showEmbeddedSearch = false;
+          _embeddedSearchFilter = null;
+          _leftCategory = null;
+          _leftTag = null;
+        });
+      }
+    });
+
     // 监听底栏派发的快捷动作（仅活跃 tab 响应）
     ref.listen(navActionBusProvider, (_, event) {
       if (event == null) return;
       if (event.targetId != NavEntryIds.home) return;
       if (!widget.isActive) return;
+      if (_showEmbeddedSearch ||
+          _leftCategory != null ||
+          _leftTag != null ||
+          selectedTopic.isStacked) {
+        _showFeed();
+        return;
+      }
       switch (event.action) {
         case NavAction.scrollToTop:
           ref.read(fabRefreshModeProvider.notifier).state = false;
@@ -153,27 +247,149 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     // 统一使用 MasterDetailLayout 处理所有情况
     // 手机/平板单栏：只显示 master
     // 平板双栏：显示 master + detail
-    return MasterDetailLayout(
-      master: _wrapPaneTap(ActivePane.master, const TopicsPage()),
-      detail: selectedTopic.hasSelection && canShowDetailPane
-          ? _wrapPaneTap(ActivePane.detail, TopicDetailPane(
-              key: ValueKey(selectedTopic.topicId),
-              topicId: selectedTopic.topicId!,
-              parentActive: widget.isActive,
-              instanceId: _getOrCreateInstanceId(
-                selectedTopic.topicId!,
-                existingInstanceId: selectedTopic.instanceId,
-              ),
-              initialTitle: selectedTopic.initialTitle,
-              scrollToPostNumber: selectedTopic.scrollToPostNumber,
-            ))
-          : null,
-      masterFloatingActionButton: user != null
-          ? _TopicsFab(
-              onCreateTopic: () => _createTopic(context, ref),
-              onOpenDrafts: () => _openDrafts(context),
-            )
-          : null,
+    return HomeWorkspaceScope(
+      onShowFeed: _showFeed,
+      onShowCategory: _showCategory,
+      onShowTag: _showTag,
+      child: MasterDetailLayout(
+        // 压栈时 master 显示的是"上一层"内容而不是列表，才是真正的平行
+        // 视界——放宽到接近对半分；master 还是列表时维持列表该有的窄栏。
+        maxMasterRatio: selectedTopic.isStacked
+            ? 0.8
+            : MasterDetailLayout.defaultMaxMasterRatio,
+        preferredMasterRatio: selectedTopic.isStacked ? 0.5 : 0.25,
+        master: _wrapPaneTap(
+          ActivePane.master,
+          _buildMasterPane(selectedTopic),
+        ),
+        detail: selectedTopic.hasSelection && canShowDetailPane
+            ? _wrapPaneTap(
+                ActivePane.detail,
+                PaneContentWidget(
+                  key: selectedTopic.kind == PaneKind.topic
+                      ? _keyForTopic(selectedTopic.topicId!)
+                      : ValueKey(
+                          '${selectedTopic.kind}_${selectedTopic.username}',
+                        ),
+                  entry: selectedTopic.topEntry!.kind == PaneKind.topic
+                      ? PaneEntry.topic(
+                          topicId: selectedTopic.topicId!,
+                          initialTitle: selectedTopic.initialTitle,
+                          scrollToPostNumber: selectedTopic.scrollToPostNumber,
+                          instanceId: _getOrCreateInstanceId(
+                            selectedTopic.topicId!,
+                            existingInstanceId: selectedTopic.instanceId,
+                          ),
+                          highlightBoostUsername:
+                              selectedTopic.highlightBoostUsername,
+                          initialRevisionPostNumber:
+                              selectedTopic.initialRevisionPostNumber,
+                          initialRevisionNumber:
+                              selectedTopic.initialRevisionNumber,
+                        )
+                      : selectedTopic.topEntry!,
+                  stackProvider: selectedTopicProvider,
+                  parentActive: widget.isActive,
+                  onBack: selectedTopic.isStacked
+                      ? () => ref.read(selectedTopicProvider.notifier).pop()
+                      : null,
+                ),
+              )
+            : null,
+        // 压栈时 master 显示的是话题预览（不可交互，见
+        // TopicDetailPage.truncateOnPush 注释），不是列表——"新建话题"这个
+        // FAB 只在 master 真的是列表时才有意义，之前没跟着切换，压栈后
+        // 预览一个话题下面还挂着"新建话题"的加号，容易被当成回复按钮。
+        masterFloatingActionButton: user != null && !selectedTopic.isStacked
+            ? _TopicsFab(
+                onCreateTopic: () => _createTopic(context, ref),
+                onOpenDrafts: () => _openDrafts(context),
+              )
+            : null,
+      ),
+    );
+  }
+
+  void _showFeed() {
+    ref.read(selectedTopicProvider.notifier).collapseToTop();
+    setState(() {
+      _showEmbeddedSearch = false;
+      _embeddedSearchFilter = null;
+      _leftCategory = null;
+      _leftTag = null;
+    });
+  }
+
+  void _showCategory(Category category) {
+    ref.read(selectedTopicProvider.notifier).collapseToTop();
+    setState(() {
+      _showEmbeddedSearch = false;
+      _embeddedSearchFilter = null;
+      _leftCategory = category;
+      _leftTag = null;
+    });
+  }
+
+  void _showTag(String tag) {
+    ref.read(selectedTopicProvider.notifier).collapseToTop();
+    setState(() {
+      _showEmbeddedSearch = false;
+      _embeddedSearchFilter = null;
+      _leftCategory = null;
+      _leftTag = tag;
+    });
+  }
+
+  /// 平行视界压栈时（stack.length > 1）：左侧不再显示话题列表，改显示
+  /// 栈里"上一层"的话题（当前顶层内容左移那一层），右侧显示新顶替的
+  /// 内容——而不是简单隐藏 master。列表用 Offstage 保留而非卸载，退回
+  /// 最底层时原样恢复（含滚动位置）。
+  Widget _buildMasterPane(SelectedTopicState selectedTopic) {
+    final topicsPage = TopicsPage(
+      externalCategoryId: _leftCategory?.id,
+      externalTag: _leftTag,
+      onSearchRequested: (filter) => setState(() {
+        _embeddedSearchFilter = filter;
+        _showEmbeddedSearch = true;
+        _leftCategory = null;
+        _leftTag = null;
+      }),
+    );
+    // 信息流始终保活，搜索只是覆盖左栏。退出搜索后滚动位置、Tab 和已加载
+    // 数据原样恢复，不能因为一次搜索重新创建整棵信息流。
+    final list = Stack(
+      children: [
+        ExcludeFocus(
+          excluding: _showEmbeddedSearch,
+          child: Offstage(offstage: _showEmbeddedSearch, child: topicsPage),
+        ),
+        if (_showEmbeddedSearch)
+          SearchPage(
+            key: ValueKey(_embeddedSearchFilter),
+            initialFilter: _embeddedSearchFilter,
+            embeddedMaster: true,
+            stackProvider: selectedTopicProvider,
+            onClose: _showFeed,
+          ),
+      ],
+    );
+    if (!selectedTopic.isStacked) return list;
+    final previous = selectedTopic.stack[selectedTopic.stack.length - 2];
+    return Stack(
+      children: [
+        ExcludeFocus(
+          excluding: true,
+          child: Offstage(offstage: true, child: list),
+        ),
+        PaneContentWidget(
+          key: previous.kind == PaneKind.topic
+              ? _keyForTopic(previous.topicId!)
+              : ValueKey('master_${previous.kind}_${previous.username}'),
+          entry: previous,
+          stackProvider: selectedTopicProvider,
+          truncateOnPush: true,
+        ),
+      ],
     );
   }
 
@@ -204,10 +420,12 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     final tags = ref.read(tabTagsProvider(categoryId));
     final topicId = await Navigator.push<int>(
       context,
-      MaterialPageRoute(builder: (_) => CreateTopicPage(
-        initialCategoryId: categoryId,
-        initialTags: tags.isNotEmpty ? tags : null,
-      )),
+      MaterialPageRoute(
+        builder: (_) => CreateTopicPage(
+          initialCategoryId: categoryId,
+          initialTags: tags.isNotEmpty ? tags : null,
+        ),
+      ),
     );
     if (topicId != null && context.mounted) {
       // 刷新当前 tab 的列表
@@ -234,10 +452,7 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
 
 /// 首页 FAB：向上滚动时切换为刷新按钮，正常模式下点击展开 Speed Dial 菜单
 class _TopicsFab extends ConsumerStatefulWidget {
-  const _TopicsFab({
-    required this.onCreateTopic,
-    required this.onOpenDrafts,
-  });
+  const _TopicsFab({required this.onCreateTopic, required this.onOpenDrafts});
 
   final VoidCallback onCreateTopic;
   final VoidCallback onOpenDrafts;
@@ -253,6 +468,7 @@ class _TopicsFabState extends ConsumerState<_TopicsFab>
   final LayerLink _layerLink = LayerLink();
   bool _isExpanded = false;
   OverlayEntry? _overlayEntry;
+  DynamicContentSuspensionLease? _dynamicContentLease;
 
   @override
   void initState() {
@@ -279,8 +495,8 @@ class _TopicsFabState extends ConsumerState<_TopicsFab>
       _close();
     } else {
       setState(() => _isExpanded = true);
-      _controller.forward();
       _showOverlay();
+      _controller.forward();
       HapticFeedback.lightImpact();
     }
   }
@@ -301,10 +517,14 @@ class _TopicsFabState extends ConsumerState<_TopicsFab>
 
   void _showOverlay() {
     _removeOverlay();
+    // 在展开动画和全屏背景模糊开始前先暂停帖子动态内容，避免首帧就与
+    // SVG/WebView 纹理提交争抢 UI、raster 和 GPU。
+    _acquireDynamicContentSuspension();
     final theme = Theme.of(context);
-    final dialogBlur = ProviderScope.containerOf(context, listen: false)
-        .read(preferencesProvider)
-        .dialogBlur;
+    final dialogBlur = ProviderScope.containerOf(
+      context,
+      listen: false,
+    ).read(preferencesProvider).dialogBlur;
 
     // 桌面 acrylic 模式下 NavigationRail 背景透明，
     // BackdropFilter 对其模糊效果异常，需跳过该区域
@@ -428,6 +648,18 @@ class _TopicsFabState extends ConsumerState<_TopicsFab>
     _overlayEntry?.remove();
     _overlayEntry?.dispose();
     _overlayEntry = null;
+    _releaseDynamicContentSuspension();
+  }
+
+  void _acquireDynamicContentSuspension() {
+    _dynamicContentLease ??= DynamicContentSuspensionService.instance.acquire(
+      reason: 'topics_fab_speed_dial',
+    );
+  }
+
+  void _releaseDynamicContentSuspension() {
+    _dynamicContentLease?.release();
+    _dynamicContentLease = null;
   }
 
   void _refreshTopics() {
@@ -526,7 +758,9 @@ class _TopicsFabState extends ConsumerState<_TopicsFab>
                 onTap: onTap,
                 child: Padding(
                   padding: const EdgeInsets.symmetric(
-                      horizontal: 12, vertical: 8),
+                    horizontal: 12,
+                    vertical: 8,
+                  ),
                   child: Text(
                     label,
                     style: theme.textTheme.labelLarge?.copyWith(
@@ -611,17 +845,24 @@ class _PaneActiveIndicatorState extends ConsumerState<_PaneActiveIndicator>
               child: FadeTransition(
                 opacity: _anim,
                 child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 14,
+                  ),
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.inverseSurface
-                        .withValues(alpha: 0.8),
+                    color: theme.colorScheme.inverseSurface.withValues(
+                      alpha: 0.8,
+                    ),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(icon, size: 18, color: theme.colorScheme.onInverseSurface),
+                      Icon(
+                        icon,
+                        size: 18,
+                        color: theme.colorScheme.onInverseSurface,
+                      ),
                       const SizedBox(width: 8),
                       Text(
                         label,
@@ -642,6 +883,10 @@ class _PaneActiveIndicatorState extends ConsumerState<_PaneActiveIndicator>
 }
 
 /// 话题详情面板（用于双栏模式，不包含返回按钮）
+///
+/// 首页话题列表跟私信列表各自有一份独立的平行视界导航栈
+/// （[selectedTopicProvider] / [selectedMessageProvider]），这个面板
+/// 两边都复用，靠 [stackProvider] 区分内部链接点击该压到哪个栈。
 class TopicDetailPane extends ConsumerWidget {
   const TopicDetailPane({
     super.key,
@@ -650,6 +895,12 @@ class TopicDetailPane extends ConsumerWidget {
     this.instanceId,
     this.initialTitle,
     this.scrollToPostNumber,
+    this.highlightBoostUsername,
+    this.initialRevisionPostNumber,
+    this.initialRevisionNumber,
+    this.onBack,
+    this.stackProvider,
+    this.truncateOnPush = false,
   });
 
   final int topicId;
@@ -657,16 +908,106 @@ class TopicDetailPane extends ConsumerWidget {
   final String? instanceId;
   final String? initialTitle;
   final int? scrollToPostNumber;
+  final String? highlightBoostUsername;
+  final int? initialRevisionPostNumber;
+  final int? initialRevisionNumber;
+
+  /// 平行视界导航栈：非 null 时说明当前层是内部链接跳转堆上来的
+  /// （栈深度 > 1），显示返回按钮弹出当前层。
+  final VoidCallback? onBack;
+
+  /// 内部链接点击时压栈的目标 provider，默认 [selectedTopicProvider]。
+  final SelectedTopicProvider? stackProvider;
+
+  /// true = 这份内容只是 master 面板里的"上一层预览"，不是当前可交互
+  /// 的栈顶——内部链接点击应该截断栈顶后压入（替换右侧正显示的那层），
+  /// 见 [TopicDetailPage.truncateOnPush] 注释。
+  final bool truncateOnPush;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final restoredScrollPosition = instanceId == null
+        ? null
+        : ref.read(
+            detailScrollPositionProvider((
+              topicId: topicId,
+              instanceId: instanceId!,
+            )),
+          );
     return TopicDetailPage(
       topicId: topicId,
       instanceId: instanceId,
+      stackProvider: stackProvider,
       initialTitle: initialTitle,
-      scrollToPostNumber: scrollToPostNumber,
-      embeddedMode: true, // 嵌入模式，不显示返回按钮
+      // 面板在 master/detail 槽位之间搬动会重建 Widget，但 provider 与
+      // 视口位置都沿用同一个 instanceId，不再退回最初进入时的楼层。
+      scrollToPostNumber: restoredScrollPosition ?? scrollToPostNumber,
+      highlightBoostUsername: highlightBoostUsername,
+      initialRevisionPostNumber: initialRevisionPostNumber,
+      initialRevisionNumber: initialRevisionNumber,
+      embeddedMode: true, // 嵌入模式，返回按钮由 onEmbeddedBack 控制
+      truncateOnPush: truncateOnPush,
+      onEmbeddedBack: onBack,
       parentActive: parentActive,
     );
+  }
+}
+
+/// 平行视界导航栈某一层的内容——按 [entry.kind] 分发到话题详情或个人
+/// 资料页，两者共用同一套栈（[stackProvider]）+ 返回语义（[onBack]）。
+class PaneContentWidget extends StatelessWidget {
+  const PaneContentWidget({
+    super.key,
+    required this.entry,
+    required this.stackProvider,
+    this.onBack,
+    this.parentActive = false,
+    this.truncateOnPush = false,
+  });
+
+  final PaneEntry entry;
+  final SelectedTopicProvider stackProvider;
+  final VoidCallback? onBack;
+  final bool parentActive;
+
+  /// true = master 面板里的"上一层预览"——内部链接点击/列表点击应该
+  /// 截断栈顶后压入（替换右侧正显示的那层），而不是在已经很深的栈上
+  /// 继续叠层——见 [EmbeddedStackScope.truncateOnPush] 注释。
+  final bool truncateOnPush;
+
+  @override
+  Widget build(BuildContext context) {
+    switch (entry.kind) {
+      case PaneKind.topic:
+        return TopicDetailPane(
+          topicId: entry.topicId!,
+          parentActive: parentActive,
+          instanceId: entry.instanceId,
+          initialTitle: entry.initialTitle,
+          scrollToPostNumber: entry.scrollToPostNumber,
+          highlightBoostUsername: entry.highlightBoostUsername,
+          initialRevisionPostNumber: entry.initialRevisionPostNumber,
+          initialRevisionNumber: entry.initialRevisionNumber,
+          onBack: onBack,
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+        );
+      case PaneKind.profile:
+        return EmbeddedStackScope(
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: UserProfilePage(
+            username: entry.username!,
+            embeddedMode: true,
+            onEmbeddedBack: onBack,
+          ),
+        );
+      case PaneKind.settings:
+        return EmbeddedStackScope(
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: SettingsPage(embeddedMode: true, onEmbeddedBack: onBack),
+        );
+    }
   }
 }

--- a/lib/pages/topics_screen.dart
+++ b/lib/pages/topics_screen.dart
@@ -90,6 +90,26 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     return _activeInstanceId!;
   }
 
+  /// 侧栏板块导航（切换或重选）时收起深层平行视界与嵌入态，退回列表。
+  void _collapseParallelForSidebarNav() {
+    final state = ref.read(selectedTopicProvider);
+    if (!state.isStacked &&
+        !_showEmbeddedSearch &&
+        _leftCategory == null &&
+        _leftTag == null) {
+      return;
+    }
+    ref.read(selectedTopicProvider.notifier).collapseToTop();
+    if (mounted) {
+      setState(() {
+        _showEmbeddedSearch = false;
+        _embeddedSearchFilter = null;
+        _leftCategory = null;
+        _leftTag = null;
+      });
+    }
+  }
+
   void _maybePushDetail(
     SelectedTopicState selectedTopic,
     bool canShowDetailPane,
@@ -205,23 +225,15 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
     // 左侧导航栏的板块快捷入口位于平行视界布局之外。切换板块时除了让
     // TopicsPage 换 Tab，还必须收起“上一层内容”左栏，否则列表虽然已在
     // 后台切换，界面仍被旧话题覆盖，看起来就像点击无响应。
+    //
+    // 两个来源都要听：高亮状态变化（含置 null 的路径，如打开板块管理），
+    // 以及 tap 事件——后者覆盖「重选当前板块」（状态同值被去重，只有
+    // tap 事件会到）。普通切换两个都触发，处理器有早退保护，跑两遍无害。
     ref.listen(activeSidebarCategoryIdProvider, (_, _) {
-      final state = ref.read(selectedTopicProvider);
-      if (!state.isStacked &&
-          !_showEmbeddedSearch &&
-          _leftCategory == null &&
-          _leftTag == null) {
-        return;
-      }
-      ref.read(selectedTopicProvider.notifier).collapseToTop();
-      if (mounted) {
-        setState(() {
-          _showEmbeddedSearch = false;
-          _embeddedSearchFilter = null;
-          _leftCategory = null;
-          _leftTag = null;
-        });
-      }
+      _collapseParallelForSidebarNav();
+    });
+    ref.listen(sidebarCategoryTapProvider, (_, _) {
+      _collapseParallelForSidebarNav();
     });
 
     // 监听底栏派发的快捷动作（仅活跃 tab 响应）

--- a/lib/pages/topics_screen.dart
+++ b/lib/pages/topics_screen.dart
@@ -48,6 +48,10 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
   bool? _lastCanShowDetailPane;
   bool _isAutoSwitching = false;
 
+  /// 左栏是不是"列表形态"（信息流 / 草稿列表）。列表给窄栏，内容预览
+  /// 才对半分。build 里按当前栈算。
+  bool _masterIsListLike = true;
+
   /// 当前活跃的 provider 实例 ID，布局切换时复用
   String? _activeInstanceId;
   int? _activeTopicId;
@@ -192,6 +196,10 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
   Widget build(BuildContext context) {
     final selectedTopic = ref.watch(selectedTopicProvider);
     final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
+    // 左栏本质是不是"列表"（信息流 / 草稿列表）——决定给窄栏还是对半分
+    _masterIsListLike = !selectedTopic.isStacked ||
+        selectedTopic.stack[selectedTopic.stack.length - 2].kind ==
+            PaneKind.drafts;
     final user = ref.watch(currentUserProvider).value;
 
     // 左侧导航栏的板块快捷入口位于平行视界布局之外。切换板块时除了让
@@ -254,10 +262,14 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
       child: MasterDetailLayout(
         // 压栈时 master 显示的是"上一层"内容而不是列表，才是真正的平行
         // 视界——放宽到接近对半分；master 还是列表时维持列表该有的窄栏。
-        maxMasterRatio: selectedTopic.isStacked
+        //
+        // 例外：上一层是**草稿列表**时它本质仍是列表（一列卡片），
+        // 对半分太宽、右边话题被挤扁 —— 按列表口径给窄栏。
+        maxMasterRatio: selectedTopic.isStacked && !_masterIsListLike
             ? 0.8
             : MasterDetailLayout.defaultMaxMasterRatio,
-        preferredMasterRatio: selectedTopic.isStacked ? 0.5 : 0.25,
+        preferredMasterRatio:
+            selectedTopic.isStacked && !_masterIsListLike ? 0.5 : 0.25,
         master: _wrapPaneTap(
           ActivePane.master,
           _buildMasterPane(selectedTopic),
@@ -286,6 +298,12 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
                               selectedTopic.initialRevisionPostNumber,
                           initialRevisionNumber:
                               selectedTopic.initialRevisionNumber,
+                          // 这里是**重建** entry，漏一个字段就等于把它吞掉：
+                          // 之前漏了这两个，话题草稿点进来回复框根本不弹。
+                          autoOpenReply:
+                              selectedTopic.topEntry!.autoOpenReply,
+                          autoReplyToPostNumber:
+                              selectedTopic.topEntry!.autoReplyToPostNumber,
                         )
                       : selectedTopic.topEntry!,
                   stackProvider: selectedTopicProvider,
@@ -388,6 +406,8 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
           entry: previous,
           stackProvider: selectedTopicProvider,
           truncateOnPush: true,
+          // 左栏预览位也要跟随 tab 活跃态（草稿列表靠它决定何时重拉）
+          parentActive: widget.isActive,
         ),
       ],
     );
@@ -409,6 +429,15 @@ class _TopicsScreenState extends ConsumerState<TopicsScreen> {
   }
 
   void _openDrafts(BuildContext context) {
+    // 首页信息流**自己**就是平行视界宿主（左列表 + 右 detail），但这里的
+    // context 在栈外（FAB/菜单），拿不到 EmbeddedStackScope —— 之前靠
+    // scope 查找必然落空、每次都全屏。直接压首页栈：草稿列表进右栏，
+    // 左边信息流不动。
+    if (MasterDetailLayout.canShowBothPanesFor(context)) {
+      ref.read(selectedTopicProvider.notifier).pushDrafts();
+      return;
+    }
+    // 窄屏没有右栏可承载，照旧全屏
     Navigator.push(
       context,
       MaterialPageRoute(builder: (_) => const DraftsPage()),
@@ -901,6 +930,8 @@ class TopicDetailPane extends ConsumerWidget {
     this.onBack,
     this.stackProvider,
     this.truncateOnPush = false,
+    this.autoOpenReply = false,
+    this.autoReplyToPostNumber,
   });
 
   final int topicId;
@@ -923,6 +954,10 @@ class TopicDetailPane extends ConsumerWidget {
   /// 的栈顶——内部链接点击应该截断栈顶后压入（替换右侧正显示的那层），
   /// 见 [TopicDetailPage.truncateOnPush] 注释。
   final bool truncateOnPush;
+
+  /// 进入即弹回复框(草稿续写)。
+  final bool autoOpenReply;
+  final int? autoReplyToPostNumber;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -949,6 +984,12 @@ class TopicDetailPane extends ConsumerWidget {
       truncateOnPush: truncateOnPush,
       onEmbeddedBack: onBack,
       parentActive: parentActive,
+      autoOpenReply: autoOpenReply,
+      // 弹过一次就把意图从栈里清掉，否则面板每次重建都会再弹
+      onAutoReplyConsumed: () => ref
+          .read((stackProvider ?? selectedTopicProvider).notifier)
+          .consumeAutoOpenReply(),
+      autoReplyToPostNumber: autoReplyToPostNumber,
     );
   }
 }
@@ -991,6 +1032,8 @@ class PaneContentWidget extends StatelessWidget {
           onBack: onBack,
           stackProvider: stackProvider,
           truncateOnPush: truncateOnPush,
+          autoOpenReply: entry.autoOpenReply,
+          autoReplyToPostNumber: entry.autoReplyToPostNumber,
         );
       case PaneKind.profile:
         return EmbeddedStackScope(
@@ -1007,6 +1050,27 @@ class PaneContentWidget extends StatelessWidget {
           stackProvider: stackProvider,
           truncateOnPush: truncateOnPush,
           child: SettingsPage(embeddedMode: true, onEmbeddedBack: onBack),
+        );
+      case PaneKind.drafts:
+        return EmbeddedStackScope(
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+          // 草稿处理完 → 把草稿这一层从栈里抽掉（不是 pop：pop 会连右边
+          // 的话题一起关掉）。master 预览位的 onBack 本来就是 null，所以
+          // 这条必须独立接线，否则草稿栏永远赖着不走。
+          child: Consumer(
+            builder: (context, ref, _) => DraftsPage(
+              embeddedMode: true,
+              // 跟随宿主 tab 的活跃状态：切走再切回来要重新拉一次草稿
+              isActive: parentActive,
+              // truncateOnPush = 我在左栏预览位 = 我是"处理栏"，空了该撤
+              autoCloseWhenEmpty: truncateOnPush,
+              onEmbeddedBack: onBack,
+              onAllHandled: () => ref
+                  .read(stackProvider.notifier)
+                  .removeEntriesOfKind(PaneKind.drafts),
+            ),
+          ),
         );
     }
   }

--- a/lib/pages/user_profile_page.dart
+++ b/lib/pages/user_profile_page.dart
@@ -137,6 +137,23 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       return;
     }
 
+    final restoreScope = FullScreenPaneRestoreScope.maybeOf(context);
+    if (restoreScope != null) {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => TopicDetailPage(
+            topicId: topicId,
+            initialTitle: initialTitle,
+            scrollToPostNumber: scrollToPostNumber,
+            autoSwitchToMasterDetail: true,
+            stackProvider: restoreScope.stackProvider,
+            restoreParentPaneStack: restoreScope.restoreCurrentPane,
+          ),
+        ),
+      );
+      return;
+    }
+
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => TopicDetailPage(

--- a/lib/pages/user_profile_page.dart
+++ b/lib/pages/user_profile_page.dart
@@ -1509,33 +1509,45 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                 );
                               }
                             },
-                            child: Container(
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                border: Border.all(
-                                  color: Colors.white,
-                                  width: 2,
-                                ),
-                              ),
-                              child: AvatarWithFlair(
-                                flairSize: 30,
-                                flairRight: -7,
-                                flairBottom: -4,
-                                flairUrl: _user?.flairUrl,
-                                flairName: _user?.flairName,
-                                flairBgColor: _user?.flairBgColor,
-                                flairColor: _user?.flairColor,
-                                avatar: Hero(
-                                  tag: 'user_avatar_${_user?.username ?? ''}',
-                                  child: SmartAvatar(
-                                    imageUrl: _user?.getAvatarUrl() != null
-                                        ? _user!.getAvatarUrl(size: 144)
+                            child: Builder(
+                              builder: (context) {
+                                // linux.do 站点定制:个别账号头像方形化,外层白边框
+                                // 得跟 SmartAvatar 里的裁切形状对齐,不然会出现
+                                // "图是方的、外层白圈还是圆的"这种两层错位。
+                                final avatarUrl = _user?.getAvatarUrl(size: 144);
+                                final isSquare = isSquareAvatarUrl(avatarUrl);
+                                return Container(
+                                  decoration: BoxDecoration(
+                                    shape: isSquare
+                                        ? BoxShape.rectangle
+                                        : BoxShape.circle,
+                                    borderRadius: isSquare
+                                        ? BorderRadius.circular(8)
                                         : null,
-                                    radius: 36,
-                                    fallbackText: _user?.username,
+                                    border: Border.all(
+                                      color: Colors.white,
+                                      width: 2,
+                                    ),
                                   ),
-                                ),
-                              ),
+                                  child: AvatarWithFlair(
+                                    flairSize: 30,
+                                    flairRight: -7,
+                                    flairBottom: -4,
+                                    flairUrl: _user?.flairUrl,
+                                    flairName: _user?.flairName,
+                                    flairBgColor: _user?.flairBgColor,
+                                    flairColor: _user?.flairColor,
+                                    avatar: Hero(
+                                      tag: 'user_avatar_${_user?.username ?? ''}',
+                                      child: SmartAvatar(
+                                        imageUrl: avatarUrl,
+                                        radius: 36,
+                                        fallbackText: _user?.username,
+                                      ),
+                                    ),
+                                  ),
+                                );
+                              },
                             ),
                           ),
                           const SizedBox(width: 16),

--- a/lib/pages/user_profile_page.dart
+++ b/lib/pages/user_profile_page.dart
@@ -23,6 +23,9 @@ import '../services/app_error_handler.dart';
 import '../utils/share_utils.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/selected_topic_provider.dart';
+import '../models/shortcut_binding.dart';
+import '../providers/shortcut_provider.dart';
+import '../utils/platform_utils.dart';
 import '../widgets/common/flair_badge.dart';
 import '../widgets/common/grain_gradient_background.dart';
 import '../widgets/common/error_view.dart';
@@ -95,6 +98,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   }) {
     final stackProvider = EmbeddedStackScope.maybeOf(context);
     if (stackProvider != null) {
+      ref.read(activePaneProvider.notifier).state = ActivePane.detail;
       final container = ProviderScope.containerOf(context, listen: false);
       final notifier = container.read(stackProvider.notifier);
       if (EmbeddedStackScope.isTruncating(context)) {
@@ -198,9 +202,33 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     'solved',
   ];
 
+  /// 桌面端 Esc 关闭当前层:平行视界嵌入层走 onEmbeddedBack,普通路由
+  /// maybePop —— 与 TopicDetailPage 的 closeOverlay 语义对齐。
+  late final ShortcutScopeBinding _shortcutScopeBinding = ShortcutScopeBinding(
+    ref: ref,
+    scope: widget.embeddedMode ? ShortcutScope.detail : ShortcutScope.context,
+  );
+
+  void _registerShortcuts() {
+    if (!PlatformUtils.isDesktop) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final back = widget.embeddedMode
+          ? widget.onEmbeddedBack
+          : () {
+              if (mounted) Navigator.of(context).maybePop();
+            };
+      if (back == null) return;
+      _shortcutScopeBinding.register(context, {
+        ShortcutAction.closeOverlay: back,
+      });
+    });
+  }
+
   @override
   void initState() {
     super.initState();
+    _registerShortcuts();
     _tabController = TabController(length: _tabFilters.length, vsync: this);
     _tabController.addListener(_onTabChanged);
     // 预先为所有 tab 设置 loading 状态，避免切换时闪现空状态
@@ -224,6 +252,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
   @override
   void dispose() {
+    _shortcutScopeBinding.disposeDeferred();
     _tabController.dispose();
     _scrollController.dispose();
     super.dispose();

--- a/lib/pages/user_profile_page.dart
+++ b/lib/pages/user_profile_page.dart
@@ -22,6 +22,7 @@ import '../utils/url_helper.dart';
 import '../services/app_error_handler.dart';
 import '../utils/share_utils.dart';
 import '../providers/preferences_provider.dart';
+import '../providers/selected_topic_provider.dart';
 import '../widgets/common/flair_badge.dart';
 import '../widgets/common/grain_gradient_background.dart';
 import '../widgets/common/error_view.dart';
@@ -52,7 +53,17 @@ import '../utils/dialog_utils.dart';
 class UserProfilePage extends ConsumerStatefulWidget {
   final String username;
 
-  const UserProfilePage({super.key, required this.username});
+  /// 平行视界嵌入模式：AppBar 用 [onEmbeddedBack] 关闭当前层，而不是
+  /// Navigator pop（嵌入面板不在 Navigator 路由栈里）。
+  final bool embeddedMode;
+  final VoidCallback? onEmbeddedBack;
+
+  const UserProfilePage({
+    super.key,
+    required this.username,
+    this.embeddedMode = false,
+    this.onEmbeddedBack,
+  });
 
   @override
   ConsumerState<UserProfilePage> createState() => _UserProfilePageState();
@@ -72,6 +83,67 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   bool _isFollowed = false;
   bool _isFollowLoading = false;
 
+  /// 本资料页最近一次从列表压栈打开的话题 ID——用来判断栈顶是不是"我
+  /// 自己上次点开的那个"，只有这种情况下才能安全替换（否则会把资料页
+  /// 这一层本身，或者别的来源压上去的层，给顶掉）。
+  int? _lastOpenedTopicId;
+
+  void _openTopic({
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+  }) {
+    final stackProvider = EmbeddedStackScope.maybeOf(context);
+    if (stackProvider != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(stackProvider.notifier);
+      if (EmbeddedStackScope.isTruncating(context)) {
+        // 这份资料页是 master 面板的"上一层预览"——点列表里的话题永远
+        // 是"替换右边正显示的那层"，跟本页自己是不是压过东西无关。
+        notifier.pushTruncating(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+        );
+        _lastOpenedTopicId = topicId;
+        return;
+      }
+      final stack = container.read(stackProvider).stack;
+      final top = stack.isEmpty ? null : stack.last;
+      // 资料页的话题/回复等列表点开话题：语义是"逛列表换一项"，用替换
+      // 而不是一直压栈——但只有栈顶确实还是"我上次自己压的那个"才能
+      // 替换，否则会误伤资料页这一层本身，或者别的来源压上去的层。
+      if (_lastOpenedTopicId != null &&
+          top != null &&
+          top.kind == PaneKind.topic &&
+          top.topicId == _lastOpenedTopicId) {
+        notifier.replaceTop(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+        );
+      } else {
+        notifier.push(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+        );
+      }
+      _lastOpenedTopicId = topicId;
+      return;
+    }
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => TopicDetailPage(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+        ),
+      ),
+    );
+  }
+
   // 订阅级别: normal / mute / ignore
   String _notificationLevel = 'normal';
 
@@ -87,7 +159,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   bool _reactionsHasMore = true;
   bool _reactionsLoading = false;
   bool _reactionsLoadMoreFailed = false;
-  final LoadMoreCoordinator _reactionsLoadMoreCoordinator = LoadMoreCoordinator();
+  final LoadMoreCoordinator _reactionsLoadMoreCoordinator =
+      LoadMoreCoordinator();
 
   // Boost 列表单独缓存（游标分页）
   List<UserBoost>? _boostsCache;
@@ -114,7 +187,15 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   // tab 对应的 filter: summary=总结, 4,5=全部(话题+回复), 4=话题, 5=回复, 1=点赞,
   // reactions=回应, boosts=Boost, votes=投票, solved=已解决
   static const List<String> _tabFilters = [
-    'summary', '4,5', '4', '5', '1', 'reactions', 'boosts', 'votes', 'solved',
+    'summary',
+    '4,5',
+    '4',
+    '5',
+    '1',
+    'reactions',
+    'boosts',
+    'votes',
+    'solved',
   ];
 
   @override
@@ -194,8 +275,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           _notificationLevel = user.ignored == true
               ? 'ignore'
               : user.muted == true
-                  ? 'mute'
-                  : 'normal';
+              ? 'mute'
+              : 'normal';
           _isLoading = false;
         });
         // 总结 tab 数据已从 _summary 获取，无需额外加载
@@ -244,10 +325,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   void _openMessageDialog() {
     if (_user == null) return;
 
-    showReplySheet(
-      context: context,
-      targetUsername: _user!.username,
-    );
+    showReplySheet(context: context, targetUsername: _user!.username);
   }
 
   /// 打开用户内容搜索
@@ -310,12 +388,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       await service.updateUserNotificationLevel(_user!.username, level: level);
       if (mounted) {
         setState(() {
-          _user = _user!.copyWith(
-            muted: level == 'mute',
-            ignored: false,
-          );
+          _user = _user!.copyWith(muted: level == 'mute', ignored: false);
         });
-        final label = level == 'mute' ? S.current.userProfile_setToMute : S.current.userProfile_restored;
+        final label = level == 'mute'
+            ? S.current.userProfile_setToMute
+            : S.current.userProfile_restored;
         ToastService.showSuccess(label);
       }
     } catch (_) {
@@ -324,7 +401,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   }
 
   /// 显示忽略时长选择弹窗，返回 expiringAt 时间字符串
-  Future<String?> _showIgnoreDurationPicker() => showIgnoreDurationPicker(context);
+  Future<String?> _showIgnoreDurationPicker() =>
+      showIgnoreDurationPicker(context);
 
   /// 显示用户详细信息弹窗
   void _showUserInfo() {
@@ -337,7 +415,14 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     final isSuspended = _user!.isSuspended;
     final isSilenced = _user!.isSilenced;
 
-    if (!hasBio && !hasLocation && !hasWebsite && !hasJoinedAt && !isSuspended && !isSilenced) return;
+    if (!hasBio &&
+        !hasLocation &&
+        !hasWebsite &&
+        !hasJoinedAt &&
+        !isSuspended &&
+        !isSilenced) {
+      return;
+    }
 
     showAppBottomSheet(
       context: context,
@@ -353,10 +438,12 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           return Container(
             decoration: BoxDecoration(
               color: theme.scaffoldBackgroundColor,
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(24),
+              ),
               boxShadow: [
                 BoxShadow(
-                  color: Colors.black.withValues(alpha:0.1),
+                  color: Colors.black.withValues(alpha: 0.1),
                   blurRadius: 10,
                   offset: const Offset(0, -2),
                 ),
@@ -396,7 +483,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                 Expanded(
                   child: ListView(
                     controller: scrollController,
-                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 24,
+                    ),
                     children: [
                       // 封禁/禁言状态
                       if (isSuspended)
@@ -406,7 +496,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                           title: context.l10n.userProfile_suspendedStatus,
                           label: _user!.isSuspendedForever
                               ? context.l10n.userProfile_permanentlySuspended
-                              : context.l10n.userProfile_suspendedUntil(TimeUtils.formatFullDate(_user!.suspendedTill)),
+                              : context.l10n.userProfile_suspendedUntil(
+                                  TimeUtils.formatFullDate(
+                                    _user!.suspendedTill,
+                                  ),
+                                ),
                           reason: _user!.suspendReason,
                           color: theme.colorScheme.error,
                         ),
@@ -417,7 +511,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                           title: context.l10n.userProfile_silencedStatus,
                           label: _user!.isSilencedForever
                               ? context.l10n.userProfile_permanentlySilenced
-                              : context.l10n.userProfile_silencedUntil(TimeUtils.formatFullDate(_user!.silencedTill)),
+                              : context.l10n.userProfile_silencedUntil(
+                                  TimeUtils.formatFullDate(_user!.silencedTill),
+                                ),
                           reason: _user!.silenceReason,
                           color: Colors.orange,
                         ),
@@ -434,7 +530,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                         const SizedBox(height: 12),
                         // 个人简介属只读展示：走新引擎 FluxdoRender，关闭划词选区。
                         FluxdoRenderCallbacks.generic(
-                          heroTagNamespace: 'user_profile_bio_${_user!.username}',
+                          heroTagNamespace:
+                              'user_profile_bio_${_user!.username}',
                         ).render(
                           cookedHtml: _user!.bio!,
                           baseTextStyle: theme.textTheme.bodyLarge?.copyWith(
@@ -559,7 +656,14 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     );
   }
 
-  Widget _buildInfoRow(BuildContext context, IconData icon, String label, String value, {String? url, bool isLink = false}) {
+  Widget _buildInfoRow(
+    BuildContext context,
+    IconData icon,
+    String label,
+    String value, {
+    String? url,
+    bool isLink = false,
+  }) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.only(bottom: 16),
@@ -571,10 +675,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
             Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest.withValues(alpha:0.5),
+                color: theme.colorScheme.surfaceContainerHighest.withValues(
+                  alpha: 0.5,
+                ),
                 borderRadius: BorderRadius.circular(8),
               ),
-              child: Icon(icon, size: 20, color: theme.colorScheme.onSurfaceVariant),
+              child: Icon(
+                icon,
+                size: 20,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -591,9 +701,13 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                   Text(
                     value,
                     style: theme.textTheme.bodyMedium?.copyWith(
-                      color: isLink ? theme.colorScheme.primary : theme.colorScheme.onSurface,
+                      color: isLink
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurface,
                       decoration: isLink ? TextDecoration.underline : null,
-                      decorationColor: theme.colorScheme.primary.withValues(alpha:0.3),
+                      decorationColor: theme.colorScheme.primary.withValues(
+                        alpha: 0.3,
+                      ),
                     ),
                   ),
                 ],
@@ -603,7 +717,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               Icon(
                 Symbols.open_in_new_rounded,
                 size: 16,
-                color: theme.colorScheme.outline.withValues(alpha:0.5),
+                color: theme.colorScheme.outline.withValues(alpha: 0.5),
               ),
           ],
         ),
@@ -618,10 +732,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
   );
 
   /// 用户回应分页助手（游标分页）
-  static final _reactionsPaginationHelper = PaginationHelpers.forList<UserReaction>(
-    keyExtractor: (r) => r.id,
-    expectedPageSize: 20,
-  );
+  static final _reactionsPaginationHelper =
+      PaginationHelpers.forList<UserReaction>(
+        keyExtractor: (r) => r.id,
+        expectedPageSize: 20,
+      );
 
   /// 用户 Boost 分页助手（游标分页）
   static final _boostsPaginationHelper = PaginationHelpers.forList<UserBoost>(
@@ -690,7 +805,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
   Future<void> _loadActions(String filter, {bool loadMore = false}) async {
     // 如果已有数据且正在加载，跳过（防止重复加载更多）
-    if (_loadingCache[filter] == true && _actionsCache.containsKey(filter)) return;
+    if (_loadingCache[filter] == true && _actionsCache.containsKey(filter)) {
+      return;
+    }
 
     if (!loadMore) {
       _actionLoadMoreCoordinator(filter).resetCooldown();
@@ -713,7 +830,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       if (mounted) {
         setState(() {
           if (loadMore) {
-            final currentState = PaginationState<UserAction>(items: _actionsCache[filter] ?? []);
+            final currentState = PaginationState<UserAction>(
+              items: _actionsCache[filter] ?? [],
+            );
             final result = _actionsPaginationHelper.processLoadMore(
               currentState,
               PaginationResult(items: response.actions, expectedPageSize: 30),
@@ -757,15 +876,21 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     try {
       final service = ref.read(discourseServiceProvider);
-      final beforeId = loadMore && _reactionsCache != null && _reactionsCache!.isNotEmpty
+      final beforeId =
+          loadMore && _reactionsCache != null && _reactionsCache!.isNotEmpty
           ? _reactionsCache!.last.id
           : null;
-      final response = await service.getUserReactions(widget.username, beforeReactionUserId: beforeId);
+      final response = await service.getUserReactions(
+        widget.username,
+        beforeReactionUserId: beforeId,
+      );
 
       if (mounted) {
         setState(() {
           if (loadMore) {
-            final currentState = PaginationState<UserReaction>(items: _reactionsCache ?? []);
+            final currentState = PaginationState<UserReaction>(
+              items: _reactionsCache ?? [],
+            );
             final result = _reactionsPaginationHelper.processLoadMore(
               currentState,
               PaginationResult(items: response.reactions, expectedPageSize: 20),
@@ -809,15 +934,21 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     try {
       final service = ref.read(discourseServiceProvider);
-      final beforeId = loadMore && _boostsCache != null && _boostsCache!.isNotEmpty
+      final beforeId =
+          loadMore && _boostsCache != null && _boostsCache!.isNotEmpty
           ? _boostsCache!.last.id
           : null;
-      final response = await service.getUserBoostsGiven(widget.username, beforeBoostId: beforeId);
+      final response = await service.getUserBoostsGiven(
+        widget.username,
+        beforeBoostId: beforeId,
+      );
 
       if (mounted) {
         setState(() {
           if (loadMore) {
-            final currentState = PaginationState<UserBoost>(items: _boostsCache ?? []);
+            final currentState = PaginationState<UserBoost>(
+              items: _boostsCache ?? [],
+            );
             final result = _boostsPaginationHelper.processLoadMore(
               currentState,
               PaginationResult(items: response.boosts, expectedPageSize: 20),
@@ -862,14 +993,19 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     try {
       final service = ref.read(discourseServiceProvider);
       final page = loadMore ? _votesPage + 1 : 0;
-      final response = await service.getVotedTopics(widget.username, page: page);
+      final response = await service.getVotedTopics(
+        widget.username,
+        page: page,
+      );
 
       if (mounted) {
         setState(() {
           if (loadMore) {
             // 按 id 去重后追加
             final existing = (_votesCache ?? []).map((t) => t.id).toSet();
-            final fresh = response.topics.where((t) => !existing.contains(t.id));
+            final fresh = response.topics.where(
+              (t) => !existing.contains(t.id),
+            );
             _votesCache = [...?_votesCache, ...fresh];
           } else {
             _votesCache = response.topics;
@@ -907,12 +1043,17 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     try {
       final service = ref.read(discourseServiceProvider);
       final offset = loadMore ? (_solvedCache?.length ?? 0) : 0;
-      final response = await service.getUserSolvedPosts(widget.username, offset: offset);
+      final response = await service.getUserSolvedPosts(
+        widget.username,
+        offset: offset,
+      );
 
       if (mounted) {
         setState(() {
           if (loadMore) {
-            final currentState = PaginationState<SolvedPost>(items: _solvedCache ?? []);
+            final currentState = PaginationState<SolvedPost>(
+              items: _solvedCache ?? [],
+            );
             final result = _solvedPaginationHelper.processLoadMore(
               currentState,
               PaginationResult(items: response.posts, expectedPageSize: 30),
@@ -955,7 +1096,21 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     if (_error != null) {
       return Scaffold(
-        appBar: AppBar(title: Text(widget.username)),
+        appBar: AppBar(
+          title: Text(widget.username),
+          // embeddedMode 但 onEmbeddedBack 为空（master 面板的"上一层
+          // 预览"，非当前可交互栈顶）时不该有任何返回键——之前不管
+          // onEmbeddedBack 是否为空都塞 BackButton，BackButton(onPressed:
+          // null) 不会被禁用，而是退化成默认的 Navigator.maybePop()，
+          // 直接捅穿到应用根导航栈（表现为点它弹出"再点一次退出"提示，
+          // 然后卡死）。automaticallyImplyLeading 也要关掉，否则即使
+          // leading 传 null，只要外层 Navigator 能 pop，Flutter 还是会
+          // 自动塞一个隐式返回键，同样的问题。
+          automaticallyImplyLeading: !widget.embeddedMode,
+          leading: widget.embeddedMode && widget.onEmbeddedBack != null
+              ? BackButton(onPressed: widget.onEmbeddedBack)
+              : null,
+        ),
         body: ErrorView(
           error: _error!,
           stackTrace: _errorStack,
@@ -972,7 +1127,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     }
 
     // 计算 pinned header 高度
-    final double pinnedHeaderHeight = kToolbarHeight + MediaQuery.of(context).padding.top + 36; // 36 是 TabBar 高度
+    final double pinnedHeaderHeight =
+        kToolbarHeight +
+        MediaQuery.of(context).padding.top +
+        36; // 36 是 TabBar 高度
 
     return Scaffold(
       body: ScrollConfiguration(
@@ -1006,11 +1164,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     );
   }
 
-  Widget _buildSliverAppBar(BuildContext context, ThemeData theme, User? currentUser) {
+  Widget _buildSliverAppBar(
+    BuildContext context,
+    ThemeData theme,
+    User? currentUser,
+  ) {
     final bgUrl = _user?.backgroundUrl;
     final hasBackground = bgUrl != null && bgUrl.isNotEmpty;
     // Standard toolbar height is usually 56.0 + status bar height
-    final double pinnedHeight = kToolbarHeight + MediaQuery.of(context).padding.top;
+    final double pinnedHeight =
+        kToolbarHeight + MediaQuery.of(context).padding.top;
     // 横屏时屏幕高度有限，限制 expandedHeight 不超过屏幕高度的 70%
     final screenHeight = MediaQuery.of(context).size.height;
     final double expandedHeight = 410.0.clamp(0.0, screenHeight * 0.7);
@@ -1023,7 +1186,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     final hasInfo = hasBio || hasLocation || hasWebsite || hasJoinedAt;
 
     // 检查是否是自己
-    final isOwnProfile = currentUser != null && _user != null && currentUser.username == _user!.username;
+    final isOwnProfile =
+        currentUser != null &&
+        _user != null &&
+        currentUser.username == _user!.username;
 
     return SliverAppBar(
       expandedHeight: expandedHeight,
@@ -1031,9 +1197,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       stretch: true,
       elevation: 0,
       scrolledUnderElevation: 0,
-      backgroundColor: Colors.transparent, // Transparent to show FlexibleSpaceBar background
+      backgroundColor:
+          Colors.transparent, // Transparent to show FlexibleSpaceBar background
       surfaceTintColor: Colors.transparent, // Prevent M3 tint
       iconTheme: const IconThemeData(color: Colors.white),
+      // 同上（错误态 AppBar）的注释：onEmbeddedBack 为空时不能塞
+      // BackButton，且要显式关掉 automaticallyImplyLeading。
+      automaticallyImplyLeading: !widget.embeddedMode,
+      leading: widget.embeddedMode && widget.onEmbeddedBack != null
+          ? BackButton(onPressed: widget.onEmbeddedBack)
+          : null,
       actions: [
         IconButton(
           icon: const Icon(Symbols.search_rounded),
@@ -1068,7 +1241,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                 value: 'about',
                 child: Row(
                   children: [
-                    Icon(Symbols.info_rounded, size: 20, color: theme.colorScheme.onSurface),
+                    Icon(
+                      Symbols.info_rounded,
+                      size: 20,
+                      color: theme.colorScheme.onSurface,
+                    ),
                     const SizedBox(width: 12),
                     Text(context.l10n.common_about),
                   ],
@@ -1078,7 +1255,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                 value: 'share',
                 child: Row(
                   children: [
-                    Icon(Symbols.share_rounded, size: 20, color: theme.colorScheme.onSurface),
+                    Icon(
+                      Symbols.share_rounded,
+                      size: 20,
+                      color: theme.colorScheme.onSurface,
+                    ),
                     const SizedBox(width: 12),
                     Text(context.l10n.userProfile_shareUser),
                   ],
@@ -1091,11 +1272,19 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                   value: 'level_normal',
                   child: Row(
                     children: [
-                      Icon(Symbols.notifications_rounded, size: 20, color: theme.colorScheme.onSurface),
+                      Icon(
+                        Symbols.notifications_rounded,
+                        size: 20,
+                        color: theme.colorScheme.onSurface,
+                      ),
                       const SizedBox(width: 12),
                       Expanded(child: Text(context.l10n.userProfile_normal)),
                       if (_notificationLevel == 'normal')
-                        Icon(Symbols.check_rounded, size: 18, color: theme.colorScheme.primary),
+                        Icon(
+                          Symbols.check_rounded,
+                          size: 18,
+                          color: theme.colorScheme.primary,
+                        ),
                     ],
                   ),
                 ),
@@ -1104,11 +1293,19 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                     value: 'level_mute',
                     child: Row(
                       children: [
-                        Icon(Symbols.notifications_off_rounded, size: 20, color: theme.colorScheme.onSurface),
+                        Icon(
+                          Symbols.notifications_off_rounded,
+                          size: 20,
+                          color: theme.colorScheme.onSurface,
+                        ),
                         const SizedBox(width: 12),
                         Expanded(child: Text(context.l10n.userProfile_mute)),
                         if (_notificationLevel == 'mute')
-                          Icon(Symbols.check_rounded, size: 18, color: theme.colorScheme.primary),
+                          Icon(
+                            Symbols.check_rounded,
+                            size: 18,
+                            color: theme.colorScheme.primary,
+                          ),
                       ],
                     ),
                   ),
@@ -1117,11 +1314,19 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                     value: 'level_ignore',
                     child: Row(
                       children: [
-                        Icon(Symbols.visibility_off_rounded, size: 20, color: theme.colorScheme.onSurface),
+                        Icon(
+                          Symbols.visibility_off_rounded,
+                          size: 20,
+                          color: theme.colorScheme.onSurface,
+                        ),
                         const SizedBox(width: 12),
                         Expanded(child: Text(context.l10n.userProfile_ignored)),
                         if (_notificationLevel == 'ignore')
-                          Icon(Symbols.check_rounded, size: 18, color: theme.colorScheme.primary),
+                          Icon(
+                            Symbols.check_rounded,
+                            size: 18,
+                            color: theme.colorScheme.primary,
+                          ),
                       ],
                     ),
                   ),
@@ -1141,27 +1346,27 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           child: Material(
             color: Theme.of(context).scaffoldBackgroundColor,
             child: TabBar(
-            controller: _tabController,
-            isScrollable: true,
-            tabAlignment: TabAlignment.start,
-            labelColor: theme.colorScheme.primary,
-            unselectedLabelColor: theme.colorScheme.onSurfaceVariant,
-            indicatorColor: theme.colorScheme.primary,
-            labelPadding: const EdgeInsets.symmetric(horizontal: 12),
-            indicatorSize: TabBarIndicatorSize.label,
-            dividerColor: Colors.transparent,
-            tabs: [
-              Tab(height: 36, text: context.l10n.userProfile_tabSummary),
-              Tab(height: 36, text: context.l10n.userProfile_tabActivity),
-              Tab(height: 36, text: context.l10n.userProfile_tabTopics),
-              Tab(height: 36, text: context.l10n.userProfile_tabReplies),
-              Tab(height: 36, text: context.l10n.userProfile_tabLikes),
-              Tab(height: 36, text: context.l10n.userProfile_tabReactions),
-              Tab(height: 36, text: context.l10n.userProfile_tabBoosts),
-              Tab(height: 36, text: context.l10n.userProfile_tabVotes),
-              Tab(height: 36, text: context.l10n.userProfile_tabSolved),
-            ],
-          ),
+              controller: _tabController,
+              isScrollable: true,
+              tabAlignment: TabAlignment.start,
+              labelColor: theme.colorScheme.primary,
+              unselectedLabelColor: theme.colorScheme.onSurfaceVariant,
+              indicatorColor: theme.colorScheme.primary,
+              labelPadding: const EdgeInsets.symmetric(horizontal: 12),
+              indicatorSize: TabBarIndicatorSize.label,
+              dividerColor: Colors.transparent,
+              tabs: [
+                Tab(height: 36, text: context.l10n.userProfile_tabSummary),
+                Tab(height: 36, text: context.l10n.userProfile_tabActivity),
+                Tab(height: 36, text: context.l10n.userProfile_tabTopics),
+                Tab(height: 36, text: context.l10n.userProfile_tabReplies),
+                Tab(height: 36, text: context.l10n.userProfile_tabLikes),
+                Tab(height: 36, text: context.l10n.userProfile_tabReactions),
+                Tab(height: 36, text: context.l10n.userProfile_tabBoosts),
+                Tab(height: 36, text: context.l10n.userProfile_tabVotes),
+                Tab(height: 36, text: context.l10n.userProfile_tabSolved),
+              ],
+            ),
           ),
         ),
       ),
@@ -1169,13 +1374,17 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       flexibleSpace: LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {
           final currentHeight = constraints.biggest.height;
-          final t = ((currentHeight - pinnedHeight) / (expandedHeight - pinnedHeight)).clamp(0.0, 1.0);
-          
+          final t =
+              ((currentHeight - pinnedHeight) / (expandedHeight - pinnedHeight))
+                  .clamp(0.0, 1.0);
+
           // 标题透明度：收起时显示（当 t < 0.3 时完全显示，避免半透明）
-          final titleOpacity = t < 0.3 ? 1.0 : (1.0 - ((t - 0.3) / 0.7)).clamp(0.0, 1.0);
+          final titleOpacity = t < 0.3
+              ? 1.0
+              : (1.0 - ((t - 0.3) / 0.7)).clamp(0.0, 1.0);
           // 内容透明度：展开时显示
           final contentOpacity = ((t - 0.4) / 0.6).clamp(0.0, 1.0);
-          
+
           return Stack(
             fit: StackFit.expand,
             children: [
@@ -1188,7 +1397,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                     maxHeight: expandedHeight,
                     child: SizedBox(
                       height: expandedHeight,
-                      child: const GrainGradientBackground(),
+                      // 个人主页可能长时间停留，装饰背景不应常驻 60 FPS
+                      // 刷新；固定 shader 时间轴仍保留原始画质与噪声细节。
+                      child: const GrainGradientBackground(animated: false),
                     ),
                   ),
                 ),
@@ -1200,24 +1411,25 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                   ),
                   fit: BoxFit.cover,
                   alignment: Alignment.center,
-                  frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-                    if (wasSynchronouslyLoaded || frame != null) {
-                      return AnimatedOpacity(
-                        opacity: frame != null ? 1.0 : 0.0,
-                        duration: const Duration(milliseconds: 300),
-                        child: child,
-                      );
-                    }
-                    return const SizedBox.shrink();
-                  },
+                  frameBuilder:
+                      (context, child, frame, wasSynchronouslyLoaded) {
+                        if (wasSynchronouslyLoaded || frame != null) {
+                          return AnimatedOpacity(
+                            opacity: frame != null ? 1.0 : 0.0,
+                            duration: const Duration(milliseconds: 300),
+                            child: child,
+                          );
+                        }
+                        return const SizedBox.shrink();
+                      },
                   errorBuilder: (_, _, _) => const SizedBox.shrink(),
                 ),
 
               // ===== 层 1: 统一压暗遮罩 - 随向上滑动变得更暗 =====
               Container(
                 color: Color.lerp(
-                  Colors.black.withValues(alpha:0.6), // 展开状态：默认更暗 (0.6)
-                  Colors.black.withValues(alpha:0.85), // 收起状态：稍微透一点 (0.85)
+                  Colors.black.withValues(alpha: 0.6), // 展开状态：默认更暗 (0.6)
+                  Colors.black.withValues(alpha: 0.85), // 收起状态：稍微透一点 (0.85)
                   Curves.easeOut.transform(1.0 - t), // 使用 easeOut 曲线优化滑动体验
                 ),
               ),
@@ -1241,7 +1453,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                           GestureDetector(
                             onTap: () {
                               if (_user?.getAvatarUrl() != null) {
-                                final avatarUrl = _user!.getAvatarUrl(size: 360);
+                                final avatarUrl = _user!.getAvatarUrl(
+                                  size: 360,
+                                );
                                 ImageViewerPage.open(
                                   context,
                                   avatarUrl,
@@ -1252,7 +1466,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                             child: Container(
                               decoration: BoxDecoration(
                                 shape: BoxShape.circle,
-                                border: Border.all(color: Colors.white, width: 2),
+                                border: Border.all(
+                                  color: Colors.white,
+                                  width: 2,
+                                ),
                               ),
                               child: AvatarWithFlair(
                                 flairSize: 30,
@@ -1276,7 +1493,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                             ),
                           ),
                           const SizedBox(width: 16),
-                          
+
                           // 2. 姓名、身份信息
                           Expanded(
                             child: Column(
@@ -1288,14 +1505,22 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                   children: [
                                     Flexible(
                                       child: Text(
-                                        (_user?.name?.isNotEmpty == true) ? _user!.name! : (_user?.username ?? ''),
+                                        (_user?.name?.isNotEmpty == true)
+                                            ? _user!.name!
+                                            : (_user?.username ?? ''),
                                         maxLines: 1,
                                         overflow: TextOverflow.ellipsis,
                                         style: const TextStyle(
                                           color: Colors.white,
                                           fontSize: 22,
                                           fontWeight: FontWeight.w600,
-                                          shadows: [Shadow(color: Colors.black45, offset: Offset(0, 1), blurRadius: 2)],
+                                          shadows: [
+                                            Shadow(
+                                              color: Colors.black45,
+                                              offset: Offset(0, 1),
+                                              blurRadius: 2,
+                                            ),
+                                          ],
                                         ),
                                       ),
                                     ),
@@ -1303,34 +1528,48 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                       const SizedBox(width: 8),
                                       Padding(
                                         padding: const EdgeInsets.only(top: 4),
-                                        child: _buildStatusEmoji(_user!.status!),
+                                        child: _buildStatusEmoji(
+                                          _user!.status!,
+                                        ),
                                       ),
                                     ],
                                   ],
                                 ),
-                                
+
                                 // Row 2: Username
                                 if (_user?.username != null)
                                   Padding(
-                                    padding: const EdgeInsets.only(top: 2, bottom: 6),
+                                    padding: const EdgeInsets.only(
+                                      top: 2,
+                                      bottom: 6,
+                                    ),
                                     child: GestureDetector(
                                       behavior: HitTestBehavior.opaque,
                                       // 点击 @username 复制用户名
-                                      onTap: () => copyUsernameToClipboard(_user!.username),
+                                      onTap: () => copyUsernameToClipboard(
+                                        _user!.username,
+                                      ),
                                       child: Text(
-                                         '@${_user?.username}',
-                                         style: TextStyle(color: Colors.white.withValues(alpha:0.85), fontSize: 13),
+                                        '@${_user?.username}',
+                                        style: TextStyle(
+                                          color: Colors.white.withValues(
+                                            alpha: 0.85,
+                                          ),
+                                          fontSize: 13,
+                                        ),
                                       ),
                                     ),
                                   )
                                 else
                                   const SizedBox(height: 6), // 占位
-
                                 // Row 3: Level Badge
                                 Container(
-                                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 10,
+                                    vertical: 2,
+                                  ),
                                   decoration: BoxDecoration(
-                                    color: Colors.white.withValues(alpha:0.2),
+                                    color: Colors.white.withValues(alpha: 0.2),
                                     borderRadius: BorderRadius.circular(12),
                                   ),
                                   child: Text(
@@ -1366,8 +1605,15 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                 _buildRestrictionBanner(
                                   icon: Symbols.block_rounded,
                                   label: _user!.isSuspendedForever
-                                      ? context.l10n.userProfile_suspendedBannerForever
-                                      : context.l10n.userProfile_suspendedBannerUntil(TimeUtils.formatFullDate(_user!.suspendedTill)),
+                                      ? context
+                                            .l10n
+                                            .userProfile_suspendedBannerForever
+                                      : context.l10n
+                                            .userProfile_suspendedBannerUntil(
+                                              TimeUtils.formatFullDate(
+                                                _user!.suspendedTill,
+                                              ),
+                                            ),
                                   reason: _user!.suspendReason,
                                   color: Colors.redAccent,
                                 ),
@@ -1379,8 +1625,15 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                 _buildRestrictionBanner(
                                   icon: Symbols.mic_off_rounded,
                                   label: _user!.isSilencedForever
-                                      ? context.l10n.userProfile_silencedBannerForever
-                                      : context.l10n.userProfile_silencedBannerUntil(TimeUtils.formatFullDate(_user!.silencedTill)),
+                                      ? context
+                                            .l10n
+                                            .userProfile_silencedBannerForever
+                                      : context.l10n
+                                            .userProfile_silencedBannerUntil(
+                                              TimeUtils.formatFullDate(
+                                                _user!.silencedTill,
+                                              ),
+                                            ),
                                   reason: _user!.silenceReason,
                                   color: Colors.orangeAccent,
                                 ),
@@ -1396,7 +1649,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                             height: 54,
                             padding: const EdgeInsets.symmetric(horizontal: 12),
                             decoration: BoxDecoration(
-                              color: Colors.white.withValues(alpha:0.1),
+                              color: Colors.white.withValues(alpha: 0.1),
                               borderRadius: BorderRadius.circular(8),
                             ),
                             child: Row(
@@ -1408,7 +1661,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                           maxLines: 2,
                                           overflow: TextOverflow.ellipsis,
                                           textStyle: TextStyle(
-                                            color: Colors.white.withValues(alpha:0.9),
+                                            color: Colors.white.withValues(
+                                              alpha: 0.9,
+                                            ),
                                             fontSize: 14,
                                             height: 1.3,
                                           ),
@@ -1418,7 +1673,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                           maxLines: 2,
                                           overflow: TextOverflow.ellipsis,
                                           style: TextStyle(
-                                            color: Colors.white.withValues(alpha:0.5),
+                                            color: Colors.white.withValues(
+                                              alpha: 0.5,
+                                            ),
                                             fontSize: 14,
                                             height: 1.3,
                                             fontStyle: FontStyle.italic,
@@ -1430,7 +1687,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                   Icon(
                                     Symbols.chevron_right_rounded,
                                     size: 16,
-                                    color: Colors.white.withValues(alpha:0.6),
+                                    color: Colors.white.withValues(alpha: 0.6),
                                   ),
                                 ],
                               ],
@@ -1446,7 +1703,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             // 第一行：关注、粉丝
-                            if (_user?.totalFollowing != null || _user?.totalFollowers != null)
+                            if (_user?.totalFollowing != null ||
+                                _user?.totalFollowers != null)
                               Wrap(
                                 spacing: 16,
                                 children: [
@@ -1461,7 +1719,13 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                           ),
                                         ),
                                       ),
-                                      child: _buildStatSlot(NumberUtils.formatCount(_user!.totalFollowing!), context.l10n.userProfile_following, _user!.totalFollowing!),
+                                      child: _buildStatSlot(
+                                        NumberUtils.formatCount(
+                                          _user!.totalFollowing!,
+                                        ),
+                                        context.l10n.userProfile_following,
+                                        _user!.totalFollowing!,
+                                      ),
                                     ),
                                   if (_user?.totalFollowers != null)
                                     GestureDetector(
@@ -1474,42 +1738,81 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                                           ),
                                         ),
                                       ),
-                                      child: _buildStatSlot(NumberUtils.formatCount(_user!.totalFollowers!), context.l10n.userProfile_followers, _user!.totalFollowers!),
+                                      child: _buildStatSlot(
+                                        NumberUtils.formatCount(
+                                          _user!.totalFollowers!,
+                                        ),
+                                        context.l10n.userProfile_followers,
+                                        _user!.totalFollowers!,
+                                      ),
                                     ),
                                 ],
                               ),
                             // 第二行：获赞、访问、话题、回复
-                            if (_user?.totalFollowing != null || _user?.totalFollowers != null)
+                            if (_user?.totalFollowing != null ||
+                                _user?.totalFollowers != null)
                               const SizedBox(height: 8),
                             Wrap(
                               spacing: 16,
                               children: [
-                                _buildStatSlot(NumberUtils.formatCount(_summary!.likesReceived), context.l10n.userProfile_statsLikes, _summary!.likesReceived),
-                                _buildStatSlot(NumberUtils.formatCount(_summary!.daysVisited), context.l10n.userProfile_statsVisits, _summary!.daysVisited),
-                                _buildStatSlot(NumberUtils.formatCount(_summary!.topicCount), context.l10n.userProfile_statsTopics, _summary!.topicCount),
-                                _buildStatSlot(NumberUtils.formatCount(_summary!.postCount), context.l10n.userProfile_statsReplies, _summary!.postCount),
+                                _buildStatSlot(
+                                  NumberUtils.formatCount(
+                                    _summary!.likesReceived,
+                                  ),
+                                  context.l10n.userProfile_statsLikes,
+                                  _summary!.likesReceived,
+                                ),
+                                _buildStatSlot(
+                                  NumberUtils.formatCount(
+                                    _summary!.daysVisited,
+                                  ),
+                                  context.l10n.userProfile_statsVisits,
+                                  _summary!.daysVisited,
+                                ),
+                                _buildStatSlot(
+                                  NumberUtils.formatCount(_summary!.topicCount),
+                                  context.l10n.userProfile_statsTopics,
+                                  _summary!.topicCount,
+                                ),
+                                _buildStatSlot(
+                                  NumberUtils.formatCount(_summary!.postCount),
+                                  context.l10n.userProfile_statsReplies,
+                                  _summary!.postCount,
+                                ),
                               ],
                             ),
                           ],
                         ),
-                      
+
                       // 最近活动时间
-                      if (_user?.lastPostedAt != null || _user?.lastSeenAt != null) ...[
+                      if (_user?.lastPostedAt != null ||
+                          _user?.lastSeenAt != null) ...[
                         const SizedBox(height: 12),
                         Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
-                            color: Colors.white.withValues(alpha:0.15),
+                            color: Colors.white.withValues(alpha: 0.15),
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              const Icon(Symbols.flash_on_rounded, size: 12, color: Colors.white70),
+                              const Icon(
+                                Symbols.flash_on_rounded,
+                                size: 12,
+                                color: Colors.white70,
+                              ),
                               const SizedBox(width: 4),
                               RelativeTimeText(
-                                dateTime: _user?.lastSeenAt ?? _user!.lastPostedAt!,
-                                style: const TextStyle(color: Colors.white70, fontSize: 11),
+                                dateTime:
+                                    _user?.lastSeenAt ?? _user!.lastPostedAt!,
+                                style: const TextStyle(
+                                  color: Colors.white70,
+                                  fontSize: 11,
+                                ),
                               ),
                             ],
                           ),
@@ -1526,60 +1829,64 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                 right: 48 + MediaQuery.of(context).padding.right, // 横屏时需加上右侧安全区
                 bottom: 14 + 36, // 调整位置适应 TabBar (36是TabBar高度)
                 child: GestureDetector(
-                  onTap: titleOpacity > 0.5 ? () {
-                    _scrollController.animateTo(
-                      0,
-                      duration: const Duration(milliseconds: 300),
-                      curve: Curves.easeOut,
-                    );
-                  } : null,
+                  onTap: titleOpacity > 0.5
+                      ? () {
+                          _scrollController.animateTo(
+                            0,
+                            duration: const Duration(milliseconds: 300),
+                            curve: Curves.easeOut,
+                          );
+                        }
+                      : null,
                   behavior: HitTestBehavior.opaque,
                   child: Opacity(
                     opacity: titleOpacity,
                     child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      // 头像 radius=16，flair 大小 14，偏移 right=-3, bottom=-1
-                      AvatarWithFlair(
-                        flairSize: 14,
-                        flairRight: -3,
-                        flairBottom: -1,
-                        flairUrl: _user?.flairUrl,
-                        flairName: _user?.flairName,
-                        flairBgColor: _user?.flairBgColor,
-                        flairColor: _user?.flairColor,
-                        avatar: SmartAvatar(
-                          imageUrl: _user?.getAvatarUrl() != null
-                              ? _user!.getAvatarUrl(size: 64)
-                              : null,
-                          radius: 16,
-                          fallbackText: _user?.username,
-                          border: Border.all(color: Colors.white70, width: 1),
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Flexible(
-                        child: Text(
-                          (_user?.name?.isNotEmpty == true) ? _user!.name! : (_user?.username ?? ''),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        // 头像 radius=16，flair 大小 14，偏移 right=-3, bottom=-1
+                        AvatarWithFlair(
+                          flairSize: 14,
+                          flairRight: -3,
+                          flairBottom: -1,
+                          flairUrl: _user?.flairUrl,
+                          flairName: _user?.flairName,
+                          flairBgColor: _user?.flairBgColor,
+                          flairColor: _user?.flairColor,
+                          avatar: SmartAvatar(
+                            imageUrl: _user?.getAvatarUrl() != null
+                                ? _user!.getAvatarUrl(size: 64)
+                                : null,
+                            radius: 16,
+                            fallbackText: _user?.username,
+                            border: Border.all(color: Colors.white70, width: 1),
                           ),
                         ),
-                      ),
-                    ],
+                        const SizedBox(width: 12),
+                        Flexible(
+                          child: Text(
+                            (_user?.name?.isNotEmpty == true)
+                                ? _user!.name!
+                                : (_user?.username ?? ''),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
                 ),
               ),
 
               // 移除之前的所有伪装层
             ],
           );
-        }
+        },
       ),
     );
   }
@@ -1604,7 +1911,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           Text(
             label,
             style: TextStyle(
-              color: Colors.white.withValues(alpha:0.7),
+              color: Colors.white.withValues(alpha: 0.7),
               fontSize: 12,
             ),
           ),
@@ -1634,18 +1941,29 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               _isFollowed ? Symbols.check_rounded : Symbols.add_rounded,
               size: 16,
             ),
-            label: Text(_isFollowed ? context.l10n.userProfile_followed : context.l10n.userProfile_follow),
+            label: Text(
+              _isFollowed
+                  ? context.l10n.userProfile_followed
+                  : context.l10n.userProfile_follow,
+            ),
             style: TextButton.styleFrom(
-              backgroundColor: _isFollowed ? Colors.white.withValues(alpha:0.15) : Colors.white,
+              backgroundColor: _isFollowed
+                  ? Colors.white.withValues(alpha: 0.15)
+                  : Colors.white,
               foregroundColor: _isFollowed ? Colors.white : Colors.black87,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(18),
-                side: _isFollowed ? const BorderSide(color: Colors.white38) : BorderSide.none,
+                side: _isFollowed
+                    ? const BorderSide(color: Colors.white38)
+                    : BorderSide.none,
               ),
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 0),
               minimumSize: const Size(0, 32),
               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           );
   }
@@ -1704,7 +2022,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     final emoji = status.emoji;
     if (emoji == null || emoji.isEmpty) return const SizedBox.shrink();
 
-    final isEmojiName = emoji.contains(RegExp(r'[a-zA-Z0-9_]')) && !emoji.contains(RegExp(r'[^\x00-\x7F]'));
+    final isEmojiName =
+        emoji.contains(RegExp(r'[a-zA-Z0-9_]')) &&
+        !emoji.contains(RegExp(r'[^\x00-\x7F]'));
 
     if (isEmojiName) {
       final cleanName = emoji.replaceAll(':', '');
@@ -1719,10 +2039,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       );
     }
 
-    return Text(
-      emoji,
-      style: const TextStyle(fontSize: 16),
-    );
+    return Text(emoji, style: const TextStyle(fontSize: 16));
   }
 
   Widget _buildActionList(String filter) {
@@ -1765,7 +2082,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           children: [
             Icon(Symbols.inbox_rounded, size: 48, color: Colors.grey[400]),
             const SizedBox(height: 8),
-            Text(context.l10n.userProfile_noContent, style: TextStyle(color: Colors.grey[600])),
+            Text(
+              context.l10n.userProfile_noContent,
+              style: TextStyle(color: Colors.grey[600]),
+            ),
           ],
         ),
       );
@@ -1775,7 +2095,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       onNotification: (notification) {
         if (notification.metrics.axis == Axis.vertical) {
           final distance =
-              notification.metrics.maxScrollExtent - notification.metrics.pixels;
+              notification.metrics.maxScrollExtent -
+              notification.metrics.pixels;
           if (loadMoreCoordinator.shouldTriggerForDistance(distance)) {
             _loadMoreActions(filter);
           }
@@ -1816,23 +2137,39 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       children: [
         // 热门话题
         if (summary.topics.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.article_rounded, context.l10n.userProfile_topTopics),
+          _buildSectionHeader(
+            theme,
+            Symbols.article_rounded,
+            context.l10n.userProfile_topTopics,
+          ),
           const SizedBox(height: 8),
-          ...summary.topics.map((topic) => _buildSummaryTopicItem(theme, topic)),
+          ...summary.topics.map(
+            (topic) => _buildSummaryTopicItem(theme, topic),
+          ),
           const SizedBox(height: 20),
         ],
 
         // 热门回复
         if (summary.replies.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.chat_bubble_rounded, context.l10n.userProfile_topReplies),
+          _buildSectionHeader(
+            theme,
+            Symbols.chat_bubble_rounded,
+            context.l10n.userProfile_topReplies,
+          ),
           const SizedBox(height: 8),
-          ...summary.replies.map((reply) => _buildSummaryReplyItem(theme, reply)),
+          ...summary.replies.map(
+            (reply) => _buildSummaryReplyItem(theme, reply),
+          ),
           const SizedBox(height: 20),
         ],
 
         // 热门链接
         if (summary.links.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.link_rounded, context.l10n.userProfile_topLinks),
+          _buildSectionHeader(
+            theme,
+            Symbols.link_rounded,
+            context.l10n.userProfile_topLinks,
+          ),
           const SizedBox(height: 8),
           ...summary.links.map((link) => _buildSummaryLinkItem(theme, link)),
           const SizedBox(height: 20),
@@ -1840,7 +2177,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
         // 最多回复至
         if (summary.mostRepliedToUsers.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.reply_rounded, context.l10n.userProfile_mostRepliedTo),
+          _buildSectionHeader(
+            theme,
+            Symbols.reply_rounded,
+            context.l10n.userProfile_mostRepliedTo,
+          ),
           const SizedBox(height: 8),
           _buildUserChips(theme, summary.mostRepliedToUsers),
           const SizedBox(height: 20),
@@ -1848,7 +2189,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
         // 被谁赞的最多
         if (summary.mostLikedByUsers.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.favorite_rounded, context.l10n.userProfile_mostLikedBy),
+          _buildSectionHeader(
+            theme,
+            Symbols.favorite_rounded,
+            context.l10n.userProfile_mostLikedBy,
+          ),
           const SizedBox(height: 8),
           _buildUserChips(theme, summary.mostLikedByUsers),
           const SizedBox(height: 20),
@@ -1856,7 +2201,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
         // 赞最多
         if (summary.mostLikedUsers.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.thumb_up_rounded, context.l10n.userProfile_mostLiked),
+          _buildSectionHeader(
+            theme,
+            Symbols.thumb_up_rounded,
+            context.l10n.userProfile_mostLiked,
+          ),
           const SizedBox(height: 8),
           _buildUserChips(theme, summary.mostLikedUsers),
           const SizedBox(height: 20),
@@ -1864,15 +2213,25 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
         // 热门类别
         if (summary.topCategories.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.category_rounded, context.l10n.userProfile_topCategories),
+          _buildSectionHeader(
+            theme,
+            Symbols.category_rounded,
+            context.l10n.userProfile_topCategories,
+          ),
           const SizedBox(height: 8),
-          ...summary.topCategories.map((cat) => _buildSummaryCategoryItem(theme, cat)),
+          ...summary.topCategories.map(
+            (cat) => _buildSummaryCategoryItem(theme, cat),
+          ),
           const SizedBox(height: 20),
         ],
 
         // 热门徽章
         if (summary.badges.isNotEmpty) ...[
-          _buildSectionHeader(theme, Symbols.military_tech_rounded, context.l10n.userProfile_topBadges),
+          _buildSectionHeader(
+            theme,
+            Symbols.military_tech_rounded,
+            context.l10n.userProfile_topBadges,
+          ),
           const SizedBox(height: 8),
           _buildBadgeChips(theme, summary.badges),
           const SizedBox(height: 20),
@@ -1892,9 +2251,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               padding: const EdgeInsets.only(top: 80),
               child: Column(
                 children: [
-                  Icon(Symbols.summarize_rounded, size: 48, color: Colors.grey[400]),
+                  Icon(
+                    Symbols.summarize_rounded,
+                    size: 48,
+                    color: Colors.grey[400],
+                  ),
                   const SizedBox(height: 8),
-                  Text(context.l10n.userProfile_noSummary, style: TextStyle(color: Colors.grey[600])),
+                  Text(
+                    context.l10n.userProfile_noSummary,
+                    style: TextStyle(color: Colors.grey[600]),
+                  ),
                 ],
               ),
             ),
@@ -1927,12 +2293,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       margin: const EdgeInsets.only(bottom: 8),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(topicId: topic.id),
-          ),
-        ),
+        onTap: () => _openTopic(topicId: topic.id, initialTitle: topic.title),
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Row(
@@ -1949,7 +2310,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               ),
               if (topic.likeCount > 0) ...[
                 const SizedBox(width: 8),
-                Icon(Symbols.favorite_rounded, size: 14, color: theme.colorScheme.outline),
+                Icon(
+                  Symbols.favorite_rounded,
+                  size: 14,
+                  color: theme.colorScheme.outline,
+                ),
                 const SizedBox(width: 2),
                 Text(
                   '${topic.likeCount}',
@@ -1974,15 +2339,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: targetTopicId != null
-            ? () => Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => TopicDetailPage(
-                      topicId: targetTopicId,
-                      scrollToPostNumber: reply.postNumber,
-                    ),
-                  ),
-                )
+            ? () => _openTopic(
+                topicId: targetTopicId,
+                initialTitle: topic?.title,
+                scrollToPostNumber: reply.postNumber,
+              )
             : null,
         child: Padding(
           padding: const EdgeInsets.all(12),
@@ -1990,7 +2351,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
             children: [
               Expanded(
                 child: Text(
-                  topic?.title ?? context.l10n.userProfile_topicHash(targetTopicId.toString()),
+                  topic?.title ??
+                      context.l10n.userProfile_topicHash(
+                        targetTopicId.toString(),
+                      ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: theme.textTheme.bodyMedium?.copyWith(
@@ -2000,7 +2364,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               ),
               if (reply.likeCount > 0) ...[
                 const SizedBox(width: 8),
-                Icon(Symbols.favorite_rounded, size: 14, color: theme.colorScheme.outline),
+                Icon(
+                  Symbols.favorite_rounded,
+                  size: 14,
+                  color: theme.colorScheme.outline,
+                ),
                 const SizedBox(width: 2),
                 Text(
                   '${reply.likeCount}',
@@ -2023,14 +2391,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       child: InkWell(
         onTap: () {
           if (link.topic != null) {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => TopicDetailPage(
-                  topicId: link.topic!.id,
-                  scrollToPostNumber: link.postNumber,
-                ),
-              ),
+            _openTopic(
+              topicId: link.topic!.id,
+              initialTitle: link.topic!.title,
+              scrollToPostNumber: link.postNumber,
             );
           } else {
             launchUrl(Uri.parse(link.url));
@@ -2040,7 +2404,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
           padding: const EdgeInsets.all(12),
           child: Row(
             children: [
-              Icon(Symbols.open_in_new_rounded, size: 16, color: theme.colorScheme.outline),
+              Icon(
+                Symbols.open_in_new_rounded,
+                size: 16,
+                color: theme.colorScheme.outline,
+              ),
               const SizedBox(width: 8),
               Expanded(
                 child: Column(
@@ -2089,55 +2457,60 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
     return Wrap(
       spacing: 8,
       runSpacing: 8,
-      children: users.map((user) => InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => UserProfilePage(username: user.username),
-          ),
-        ),
-        borderRadius: BorderRadius.circular(20),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerLow,
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              SmartAvatar(
-                imageUrl: user.getAvatarUrl(size: 48),
-                radius: 12,
-                fallbackText: user.username,
-              ),
-              const SizedBox(width: 6),
-              Text(
-                user.name?.isNotEmpty == true ? user.name! : user.username,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-              const SizedBox(width: 4),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      children: users
+          .map(
+            (user) => InkWell(
+              onTap: () =>
+                  EmbeddedStackScope.openProfile(context, user.username),
+              borderRadius: BorderRadius.circular(20),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: theme.colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(10),
+                  color: theme.colorScheme.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(20),
                 ),
-                child: Text(
-                  '${user.count}',
-                  style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.colorScheme.onPrimaryContainer,
-                    fontWeight: FontWeight.w600,
-                    fontSize: 10,
-                  ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SmartAvatar(
+                      imageUrl: user.getAvatarUrl(size: 48),
+                      radius: 12,
+                      fallbackText: user.username,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      user.name?.isNotEmpty == true
+                          ? user.name!
+                          : user.username,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 1,
+                      ),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Text(
+                        '${user.count}',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 10,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ],
-          ),
-        ),
-      )).toList(),
+            ),
+          )
+          .toList(),
     );
   }
 
@@ -2199,18 +2572,14 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
         return GestureDetector(
           onTap: () => Navigator.push(
             context,
-            MaterialPageRoute(
-              builder: (_) => BadgePage(badgeId: badge.id),
-            ),
+            MaterialPageRoute(builder: (_) => BadgePage(badgeId: badge.id)),
           ),
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
             decoration: BoxDecoration(
               gradient: BadgeUIUtils.getBadgeGradient(context, badgeType),
               borderRadius: BorderRadius.circular(12),
-              border: Border.all(
-                color: color.withValues(alpha: 0.3),
-              ),
+              border: Border.all(color: color.withValues(alpha: 0.3)),
             ),
             child: Row(
               mainAxisSize: MainAxisSize.min,
@@ -2251,9 +2620,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Symbols.emoji_emotions_rounded, size: 48, color: Colors.grey[400]),
+            Icon(
+              Symbols.emoji_emotions_rounded,
+              size: 48,
+              color: Colors.grey[400],
+            ),
             const SizedBox(height: 8),
-            Text(context.l10n.userProfile_noReactions, style: TextStyle(color: Colors.grey[600])),
+            Text(
+              context.l10n.userProfile_noReactions,
+              style: TextStyle(color: Colors.grey[600]),
+            ),
           ],
         ),
       );
@@ -2263,8 +2639,11 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       onNotification: (notification) {
         if (notification.metrics.axis == Axis.vertical) {
           final distance =
-              notification.metrics.maxScrollExtent - notification.metrics.pixels;
-          if (_reactionsLoadMoreCoordinator.shouldTriggerForDistance(distance)) {
+              notification.metrics.maxScrollExtent -
+              notification.metrics.pixels;
+          if (_reactionsLoadMoreCoordinator.shouldTriggerForDistance(
+            distance,
+          )) {
             _loadMoreReactions();
           }
         }
@@ -2309,9 +2688,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Symbols.rocket_launch_rounded, size: 48, color: Colors.grey[400]),
+            Icon(
+              Symbols.rocket_launch_rounded,
+              size: 48,
+              color: Colors.grey[400],
+            ),
             const SizedBox(height: 8),
-            Text(context.l10n.userProfile_noBoosts, style: TextStyle(color: Colors.grey[600])),
+            Text(
+              context.l10n.userProfile_noBoosts,
+              style: TextStyle(color: Colors.grey[600]),
+            ),
           ],
         ),
       );
@@ -2321,7 +2707,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       onNotification: (notification) {
         if (notification.metrics.axis == Axis.vertical) {
           final distance =
-              notification.metrics.maxScrollExtent - notification.metrics.pixels;
+              notification.metrics.maxScrollExtent -
+              notification.metrics.pixels;
           if (_boostsLoadMoreCoordinator.shouldTriggerForDistance(distance)) {
             _loadMoreBoosts();
           }
@@ -2337,7 +2724,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
             if (index == boosts.length) {
               return PagedListFooter(
                 hasMore: hasMore,
-                isLoadingMore: _boostsLoadMoreCoordinator.isRunning && isLoading,
+                isLoadingMore:
+                    _boostsLoadMoreCoordinator.isRunning && isLoading,
                 isLoadMoreFailed: _boostsLoadMoreFailed,
                 onRetry: _loadMoreBoosts,
               );
@@ -2366,21 +2754,31 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Symbols.how_to_vote_rounded, size: 48, color: Colors.grey[400]),
+            Icon(
+              Symbols.how_to_vote_rounded,
+              size: 48,
+              color: Colors.grey[400],
+            ),
             const SizedBox(height: 8),
-            Text(context.l10n.userProfile_noVotes, style: TextStyle(color: Colors.grey[600])),
+            Text(
+              context.l10n.userProfile_noVotes,
+              style: TextStyle(color: Colors.grey[600]),
+            ),
           ],
         ),
       );
     }
 
-    final enableLongPress = ref.watch(preferencesProvider).longPressPreview;
+    final enableLongPress = ref.watch(
+      preferencesProvider.select((p) => p.longPressPreview),
+    );
 
     return NotificationListener<ScrollNotification>(
       onNotification: (notification) {
         if (notification.metrics.axis == Axis.vertical) {
           final distance =
-              notification.metrics.maxScrollExtent - notification.metrics.pixels;
+              notification.metrics.maxScrollExtent -
+              notification.metrics.pixels;
           if (_votesLoadMoreCoordinator.shouldTriggerForDistance(distance)) {
             _loadMoreVotes();
           }
@@ -2406,14 +2804,10 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               context: context,
               topic: topic,
               isSelected: false,
-              onTap: () => Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => TopicDetailPage(
-                    topicId: topic.id,
-                    scrollToPostNumber: topic.lastReadPostNumber,
-                  ),
-                ),
+              onTap: () => _openTopic(
+                topicId: topic.id,
+                initialTitle: topic.title,
+                scrollToPostNumber: topic.lastReadPostNumber,
               ),
               enableLongPress: enableLongPress,
             );
@@ -2440,9 +2834,16 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Symbols.check_circle_rounded, size: 48, color: Colors.grey[400]),
+            Icon(
+              Symbols.check_circle_rounded,
+              size: 48,
+              color: Colors.grey[400],
+            ),
             const SizedBox(height: 8),
-            Text(context.l10n.userProfile_noSolved, style: TextStyle(color: Colors.grey[600])),
+            Text(
+              context.l10n.userProfile_noSolved,
+              style: TextStyle(color: Colors.grey[600]),
+            ),
           ],
         ),
       );
@@ -2452,7 +2853,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
       onNotification: (notification) {
         if (notification.metrics.axis == Axis.vertical) {
           final distance =
-              notification.metrics.maxScrollExtent - notification.metrics.pixels;
+              notification.metrics.maxScrollExtent -
+              notification.metrics.pixels;
           if (_solvedLoadMoreCoordinator.shouldTriggerForDistance(distance)) {
             _loadMoreSolved();
           }
@@ -2468,7 +2870,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
             if (index == posts.length) {
               return PagedListFooter(
                 hasMore: hasMore,
-                isLoadingMore: _solvedLoadMoreCoordinator.isRunning && isLoading,
+                isLoadingMore:
+                    _solvedLoadMoreCoordinator.isRunning && isLoading,
                 isLoadMoreFailed: _solvedLoadMoreFailed,
                 onRetry: _loadMoreSolved,
               );
@@ -2486,19 +2889,12 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: boost.topicId,
-              scrollToPostNumber: boost.postNumber,
-            ),
-          ),
+        onTap: () => _openTopic(
+          topicId: boost.topicId,
+          scrollToPostNumber: boost.postNumber,
         ),
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -2516,7 +2912,9 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
-                      boostText.isNotEmpty ? boostText : context.l10n.userProfile_boosted,
+                      boostText.isNotEmpty
+                          ? boostText
+                          : context.l10n.userProfile_boosted,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: theme.textTheme.labelMedium?.copyWith(
@@ -2574,19 +2972,12 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: post.topicId,
-              scrollToPostNumber: post.postNumber,
-            ),
-          ),
+        onTap: () => _openTopic(
+          topicId: post.topicId,
+          scrollToPostNumber: post.postNumber,
         ),
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -2657,19 +3048,12 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: action.topicId,
-              scrollToPostNumber: action.postNumber,
-            ),
-          ),
+        onTap: () => _openTopic(
+          topicId: action.topicId,
+          scrollToPostNumber: action.postNumber,
         ),
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -2703,7 +3087,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                 ],
               ),
               const SizedBox(height: 12),
-              
+
               // 标题
               Text(
                 action.title,
@@ -2713,7 +3097,7 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                   fontWeight: FontWeight.w500,
                 ),
               ),
-              
+
               // 摘要
               if (action.excerpt != null && action.excerpt!.isNotEmpty) ...[
                 const SizedBox(height: 8),
@@ -2747,19 +3131,12 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(16),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: reaction.topicId,
-              scrollToPostNumber: reaction.postNumber,
-            ),
-          ),
+        onTap: () => _openTopic(
+          topicId: reaction.topicId,
+          scrollToPostNumber: reaction.postNumber,
         ),
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -2774,7 +3151,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
                       image: emojiImageProvider(emojiUrl),
                       width: 20,
                       height: 20,
-                      errorBuilder: (_, _, _) => const Icon(Symbols.emoji_emotions_rounded, size: 20),
+                      errorBuilder: (_, _, _) =>
+                          const Icon(Symbols.emoji_emotions_rounded, size: 20),
                     )
                   else
                     const Icon(Symbols.emoji_emotions_rounded, size: 20),
@@ -2799,7 +3177,8 @@ class _UserProfilePageState extends ConsumerState<UserProfilePage>
               const SizedBox(height: 12),
 
               // 话题标题
-              if (reaction.topicTitle != null && reaction.topicTitle!.isNotEmpty)
+              if (reaction.topicTitle != null &&
+                  reaction.topicTitle!.isNotEmpty)
                 Text(
                   reaction.topicTitle!,
                   maxLines: 2,

--- a/lib/providers/category_provider.dart
+++ b/lib/providers/category_provider.dart
@@ -64,6 +64,16 @@ final categoryNotificationOverridesProvider = StateProvider<Map<int, int>>(
 /// 侧边栏当前激活的分类 ID（仅用于桌面/平板导航高亮）
 final activeSidebarCategoryIdProvider = StateProvider<int?>((ref) => null);
 
+/// 侧边栏板块的「点击事件」。
+///
+/// 与 [activeSidebarCategoryIdProvider]（高亮状态，同值会被 StateProvider
+/// 去重）不同，**重选当前板块**也必须触发——首页靠它把深层平行视界收回
+/// 板块列表。nonce 单调递增保证连续点同一板块也能被 ref.listen 捕获
+/// （同 NavActionEvent 的做法）。
+final sidebarCategoryTapProvider = StateProvider<({int categoryId, int nonce})?>(
+  (ref) => null,
+);
+
 /// 热门标签列表 Provider
 final tagsProvider = FutureProvider<List<String>>((ref) async {
   final service = ref.watch(discourseServiceProvider);

--- a/lib/providers/message_bus/notification_providers.dart
+++ b/lib/providers/message_bus/notification_providers.dart
@@ -247,12 +247,18 @@ class NotificationAlertChannelNotifier extends Notifier<void> {
 
         debugPrint('[NotificationAlert] 发送系统通知: title=$title, body=$body, topicId=$topicId, postNumber=$postNumber');
 
+        final parsedType = notificationType != null
+            ? NotificationType.fromId(notificationType)
+            : null;
         LocalNotificationService().show(
           title: title,
           body: body,
           id: DateTime.now().millisecondsSinceEpoch.remainder(100000),
           topicId: topicId,
           postNumber: postNumber,
+          isPrivateMessage:
+              parsedType == NotificationType.privateMessage ||
+              parsedType == NotificationType.invitedToPrivateMessage,
         );
       }
     }

--- a/lib/providers/seeking_provider.dart
+++ b/lib/providers/seeking_provider.dart
@@ -407,7 +407,9 @@ class SeekingNotifier extends StateNotifier<SeekingState>
 
   Future<void> _fetchUser(String username) async {
     // 第一段：只花 1 个请求看在线状态有没有变
-    final user = await _pacedRequest(() => _service.getUser(username));
+    final user = await _pacedRequest(
+      () => _service.getUser(username, isSilent: true),
+    );
     final old = state.profiles[username];
     final profile = SeekingUserProfile(
       lastSeenAt: user.lastSeenAt,
@@ -437,10 +439,14 @@ class SeekingNotifier extends StateNotifier<SeekingState>
     }
 
     final actions = await optional(
-      () => _service.getUserActions(username, filter: '1,4,5'),
+      () => _service.getUserActions(username, filter: '1,4,5', isSilent: true),
     );
-    final reactions = await optional(() => _service.getUserReactions(username));
-    final boosts = await optional(() => _service.getUserBoostsGiven(username));
+    final reactions = await optional(
+      () => _service.getUserReactions(username, isSilent: true),
+    );
+    final boosts = await optional(
+      () => _service.getUserBoostsGiven(username, isSilent: true),
+    );
 
     final merged = <SeekingActivity>[];
     if (actions is UserActionResponse) {

--- a/lib/providers/seeking_provider.dart
+++ b/lib/providers/seeking_provider.dart
@@ -1,0 +1,524 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
+// ignore: depend_on_referenced_packages
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/seeking.dart';
+import '../models/user_action.dart';
+import '../services/discourse/discourse_service.dart';
+import 'discourse_providers.dart';
+import 'theme_provider.dart';
+
+/// 追觅（监控用户动态）状态。
+///
+/// 移植自 BestLINUXDO 扩展的 seeking.js：
+/// - 两段式省请求：先看 /u/{u}.json 的 last_seen_at 有没有变，没变收工；
+/// - 流动化刷新：每步只刷「最久未刷」的一名用户；
+/// - 请求间隔由用户选择高/中/低三档；
+/// - 429/403 → 挂起到下一分钟整点后谨慎重启。
+class SeekingState {
+  const SeekingState({
+    this.enabled = false,
+    this.users = const [],
+    this.data = const {},
+    this.profiles = const {},
+    this.unread = const {},
+    this.holdUntil,
+    this.refreshing,
+    this.paceSeconds = SeekingNotifier.defaultPaceSeconds,
+  });
+
+  final bool enabled;
+
+  /// 每个请求之间的间隔秒数（10/30/60 三档，用户可选）
+  final int paceSeconds;
+
+  /// 监控用户名列表（顺序即展示顺序）
+  final List<String> users;
+
+  /// username → 最新动态（每人最多 [SeekingNotifier.logLimitPerUser] 条）
+  final Map<String, List<SeekingActivity>> data;
+
+  /// username → 轻量资料
+  final Map<String, SeekingUserProfile> profiles;
+
+  /// username → 未读条数
+  final Map<String, int> unread;
+
+  /// 限流挂起截止时间（null = 流动中）
+  final DateTime? holdUntil;
+
+  /// 当前正在刷新的用户名（UI 转圈用）
+  final String? refreshing;
+
+  int get totalUnread => unread.values.fold(0, (sum, n) => sum + n);
+
+  /// 全部用户动态按时间倒序合并
+  List<SeekingActivity> get timeline {
+    final all = <SeekingActivity>[for (final list in data.values) ...list];
+    all.sort((a, b) {
+      final ta = a.createdAt?.millisecondsSinceEpoch ?? 0;
+      final tb = b.createdAt?.millisecondsSinceEpoch ?? 0;
+      return tb.compareTo(ta);
+    });
+    return all;
+  }
+
+  SeekingState copyWith({
+    bool? enabled,
+    List<String>? users,
+    Map<String, List<SeekingActivity>>? data,
+    Map<String, SeekingUserProfile>? profiles,
+    Map<String, int>? unread,
+    Object? holdUntil = _unset,
+    Object? refreshing = _unset,
+    int? paceSeconds,
+  }) {
+    return SeekingState(
+      enabled: enabled ?? this.enabled,
+      users: users ?? this.users,
+      data: data ?? this.data,
+      profiles: profiles ?? this.profiles,
+      unread: unread ?? this.unread,
+      holdUntil: identical(holdUntil, _unset)
+          ? this.holdUntil
+          : holdUntil as DateTime?,
+      refreshing: identical(refreshing, _unset)
+          ? this.refreshing
+          : refreshing as String?,
+      paceSeconds: paceSeconds ?? this.paceSeconds,
+    );
+  }
+
+  static const Object _unset = Object();
+}
+
+class SeekingNotifier extends StateNotifier<SeekingState>
+    with WidgetsBindingObserver {
+  SeekingNotifier(this._prefs, this._service) : super(const SeekingState()) {
+    WidgetsBinding.instance.addObserver(this);
+    _load();
+  }
+
+  /// 应用是否在前台。后台/最小化时暂停轮询：省电、省限流额度，
+  /// 也避免多窗口/多实例场景下不可见实例白白抢请求。
+  bool _appActive = true;
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    _appActive = state == AppLifecycleState.resumed;
+  }
+
+  static const int maxUsers = 50;
+  static const int logLimitPerUser = 10;
+
+  /// 请求频率三档：高 10s / 中 30s / 低 60s（每档一个请求的最小间隔）
+  static const List<int> paceOptions = [10, 30, 60];
+  static const int defaultPaceSeconds = 30;
+
+  static const String _configKey = 'seeking_config';
+  static const String _enabledKey = 'seeking_enabled';
+  static const String _paceKey = 'seeking_pace_seconds';
+
+  final SharedPreferences _prefs;
+  final DiscourseService _service;
+
+  /// username → 最新一条动态的 uid（新增检测基准），持久化
+  final Map<String, String> _lastIds = {};
+
+  /// username → 上次刷新时刻（挑「最久未刷」的依据）
+  final Map<String, DateTime> _lastFetchedAt = {};
+
+  /// username → 上次完整拉取动态的时刻。last_seen_at 不能代表点赞、回应、
+  /// Boost 等所有活动，因此即使在线时间未变化也必须周期性完整校验。
+  final Map<String, DateTime> _lastFullFetchedAt = {};
+  static const Duration _fullRefreshInterval = Duration(minutes: 5);
+
+  Timer? _timer;
+  bool _busy = false;
+  DateTime _lastFlowAt = DateTime.fromMillisecondsSinceEpoch(0);
+  DateTime? _lastRequestAt;
+  Future<void> _requestTail = Future<void>.value();
+
+  Duration get _pace => Duration(seconds: state.paceSeconds);
+
+  /// 所有追觅请求共享同一串行队列和节拍：距上一个请求发出不足 [_pace]
+  /// 时先等待。把「1 + 3 并发」的突发拉平成慢速串行流，避免周期性
+  /// 密集 XHR 触发 CF 行为检测反复弹盾。
+  Future<T> _pacedRequest<T>(Future<T> Function() request) {
+    final completer = Completer<T>();
+    final previous = _requestTail;
+    _requestTail = () async {
+      await previous;
+      final last = _lastRequestAt;
+      if (last != null) {
+        final remaining = _pace - DateTime.now().difference(last);
+        if (remaining > Duration.zero) {
+          await Future<void>.delayed(remaining);
+        }
+      }
+      _lastRequestAt = DateTime.now();
+      try {
+        completer.complete(await request());
+      } catch (error, stackTrace) {
+        completer.completeError(error, stackTrace);
+      }
+    }();
+    return completer.future;
+  }
+
+  // ── 持久化 ──────────────────────────────────
+
+  void _load() {
+    final enabled = _prefs.getBool(_enabledKey) ?? false;
+    var users = <String>[];
+    final raw = _prefs.getString(_configKey);
+    if (raw != null && raw.isNotEmpty) {
+      try {
+        final cfg = jsonDecode(raw) as Map<String, dynamic>;
+        users = (cfg['users'] as List? ?? const [])
+            .map((u) => u.toString())
+            .toList();
+        (cfg['lastIds'] as Map<String, dynamic>? ?? const {}).forEach(
+          (k, v) => _lastIds[k] = v.toString(),
+        );
+      } catch (e) {
+        debugPrint('[Seeking] 配置解析失败: $e');
+      }
+    }
+    final unread = <String, int>{};
+    final rawUnread = _prefs.getString('$_configKey.unread');
+    if (rawUnread != null && rawUnread.isNotEmpty) {
+      try {
+        (jsonDecode(rawUnread) as Map<String, dynamic>).forEach((k, v) {
+          final n = v is int ? v : int.tryParse(v.toString()) ?? 0;
+          if (n > 0) unread[k] = n;
+        });
+      } catch (_) {}
+    }
+    final paceSeconds = _prefs.getInt(_paceKey) ?? defaultPaceSeconds;
+    state = state.copyWith(
+      enabled: enabled,
+      users: users,
+      unread: unread,
+      paceSeconds: paceOptions.contains(paceSeconds)
+          ? paceSeconds
+          : defaultPaceSeconds,
+    );
+    _syncTimer();
+  }
+
+  Future<void> _save() async {
+    await _prefs.setString(
+      _configKey,
+      jsonEncode({'users': state.users, 'lastIds': _lastIds}),
+    );
+    await _prefs.setString('$_configKey.unread', jsonEncode(state.unread));
+  }
+
+  // ── 名单管理 ─────────────────────────────────
+
+  Future<String?> addUser(String username) async {
+    final name = username.trim();
+    if (name.isEmpty) return null;
+    if (state.users.any((u) => u.toLowerCase() == name.toLowerCase())) {
+      return 'exists';
+    }
+    if (state.users.length >= maxUsers) return 'full';
+
+    // 添加前立即验证用户，避免把不存在的用户名静默放进轮询队列。
+    // 同时复用这次请求得到的头像和在线时间，不额外浪费首轮请求。
+    try {
+      final user = await _pacedRequest(() => _service.getUser(name));
+      final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
+        ..[name] = SeekingUserProfile(
+          lastSeenAt: user.lastSeenAt,
+          avatarTemplate: user.avatarTemplate,
+        );
+      state = state.copyWith(users: [name, ...state.users], profiles: profiles);
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 404) return 'notFound';
+      return 'failed';
+    } catch (_) {
+      return 'failed';
+    }
+    // 新用户插队首：无 lastFetchedAt 记录自动优先被刷
+    await _save();
+    _syncTimer();
+    return null;
+  }
+
+  Future<void> removeUser(String username) async {
+    final users = state.users.where((u) => u != username).toList();
+    final data = Map<String, List<SeekingActivity>>.of(state.data)
+      ..remove(username);
+    final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
+      ..remove(username);
+    final unread = Map<String, int>.of(state.unread)..remove(username);
+    _lastIds.remove(username);
+    _lastFetchedAt.remove(username);
+    _lastFullFetchedAt.remove(username);
+    state = state.copyWith(
+      users: users,
+      data: data,
+      profiles: profiles,
+      unread: unread,
+    );
+    await _save();
+    _syncTimer();
+  }
+
+  /// 同步关注列表到监控名单（增量导入，不移除既有用户）。
+  /// 返回新增数量，-1 表示失败。
+  Future<int> syncFollowing() async {
+    try {
+      final username = await _service.getUsername();
+      if (username == null) return -1;
+      final following = await _pacedRequest(
+        () => _service.getFollowing(username),
+      );
+      var added = 0;
+      final users = List<String>.of(state.users);
+      for (final user in following) {
+        final name = user.username;
+        if (users.any((u) => u.toLowerCase() == name.toLowerCase())) continue;
+        if (users.length >= maxUsers) break;
+        users.insert(0, name);
+        added++;
+      }
+      if (added > 0) {
+        state = state.copyWith(users: users);
+        await _save();
+        _syncTimer();
+      }
+      return added;
+    } catch (e) {
+      debugPrint('[Seeking] 同步关注失败: $e');
+      return -1;
+    }
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    if (state.enabled == enabled) return;
+    state = state.copyWith(enabled: enabled);
+    await _prefs.setBool(_enabledKey, enabled);
+    _syncTimer();
+  }
+
+  Future<void> setPaceSeconds(int seconds) async {
+    if (!paceOptions.contains(seconds) || state.paceSeconds == seconds) return;
+    state = state.copyWith(paceSeconds: seconds);
+    await _prefs.setInt(_paceKey, seconds);
+    // 切换档位后从当前时刻重新计算间隔，避免连续发出两个请求。
+    _lastFlowAt = DateTime.now();
+  }
+
+  Future<void> markAllRead() async {
+    if (state.unread.isEmpty) return;
+    state = state.copyWith(unread: const {});
+    await _save();
+  }
+
+  // ── 流动化刷新 ────────────────────────────────
+
+  void _syncTimer() {
+    final shouldRun = state.enabled && state.users.isNotEmpty;
+    if (shouldRun && _timer == null) {
+      // 1s 轮询定时器只做门控判断，真正出手由 _lastFlowAt + 自适应节拍决定
+      _timer = Timer.periodic(const Duration(seconds: 1), (_) => _tick());
+    } else if (!shouldRun) {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  Future<void> _tick() async {
+    if (_busy || !_appActive || !state.enabled || state.users.isEmpty) return;
+    final now = DateTime.now();
+    final holdUntil = state.holdUntil;
+    if (holdUntil != null) {
+      if (now.isBefore(holdUntil)) return;
+      state = state.copyWith(holdUntil: null);
+    }
+    if (now.difference(_lastFlowAt) < _pace) return;
+
+    // 挑「最久未刷」的用户；从未刷过的（新导入）优先。
+    // 时间戳在未来 = 退避中（如 404），直接跳过。
+    String? target;
+    DateTime? oldest;
+    for (final user in state.users) {
+      final at = _lastFetchedAt[user];
+      if (at == null) {
+        target = user;
+        break;
+      }
+      if (at.isAfter(now)) continue;
+      if (oldest == null || at.isBefore(oldest)) {
+        oldest = at;
+        target = user;
+      }
+    }
+    if (target == null) return;
+
+    _busy = true;
+    _lastFlowAt = now;
+    state = state.copyWith(refreshing: target);
+    try {
+      await _fetchUser(target);
+    } on DioException catch (e) {
+      final status = e.response?.statusCode ?? 0;
+      if (status == 429 || status == 403) {
+        _holdToNextMinute();
+        _lastFetchedAt[target] = DateTime.now();
+      } else if (status == 404) {
+        // 用户不存在/被匿名化：长退避，避免每一圈都浪费一个请求。
+        // 时间戳写到未来即可让「最久未刷」选择器长期跳过它。
+        debugPrint('[Seeking] 用户 $target 不存在(404)，退避 30 分钟');
+        _lastFetchedAt[target] = DateTime.now().add(
+          const Duration(minutes: 30),
+        );
+      } else {
+        debugPrint('[Seeking] 刷新 $target 失败: $e');
+        _lastFetchedAt[target] = DateTime.now();
+      }
+    } catch (e) {
+      debugPrint('[Seeking] 刷新 $target 异常: $e');
+      _lastFetchedAt[target] = DateTime.now();
+    } finally {
+      _busy = false;
+      if (mounted) state = state.copyWith(refreshing: null);
+    }
+  }
+
+  /// 限流/过盾 → 挂起到下一分钟整点（加少量抖动）。
+  void _holdToNextMinute() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final hold = (now ~/ 60000 + 1) * 60000 + math.Random().nextInt(1500);
+    state = state.copyWith(
+      holdUntil: DateTime.fromMillisecondsSinceEpoch(hold),
+    );
+    debugPrint('[Seeking] 触发限流，挂起到下一分钟');
+  }
+
+  Future<void> _fetchUser(String username) async {
+    // 第一段：只花 1 个请求看在线状态有没有变
+    final user = await _pacedRequest(() => _service.getUser(username));
+    final old = state.profiles[username];
+    final profile = SeekingUserProfile(
+      lastSeenAt: user.lastSeenAt,
+      avatarTemplate: user.avatarTemplate ?? old?.avatarTemplate,
+    );
+    final changed = old == null || old.lastSeenAt != user.lastSeenAt;
+    final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
+      ..[username] = profile;
+    state = state.copyWith(profiles: profiles);
+    _lastFetchedAt[username] = DateTime.now();
+
+    final hasData = (state.data[username] ?? const []).isNotEmpty;
+    final lastFullFetchedAt = _lastFullFetchedAt[username];
+    final fullRefreshDue =
+        lastFullFetchedAt == null ||
+        DateTime.now().difference(lastFullFetchedAt) >= _fullRefreshInterval;
+    if (!changed && hasData && !fullRefreshDue) return;
+
+    // 第二段：按节拍串行拉三路动态（个别失败不影响整体）
+    Future<Object?> optional(Future<Object?> Function() request) async {
+      try {
+        return await _pacedRequest(request);
+      } catch (e) {
+        _rethrowIfRateLimited(e);
+        return null;
+      }
+    }
+
+    final actions = await optional(
+      () => _service.getUserActions(username, filter: '1,4,5'),
+    );
+    final reactions = await optional(() => _service.getUserReactions(username));
+    final boosts = await optional(() => _service.getUserBoostsGiven(username));
+
+    final merged = <SeekingActivity>[];
+    if (actions is UserActionResponse) {
+      merged.addAll(
+        actions.actions
+            .take(logLimitPerUser)
+            .map((a) => SeekingActivity.fromUserAction(username, a)),
+      );
+    }
+    if (reactions is UserReactionsResponse) {
+      merged.addAll(
+        reactions.reactions
+            .take(logLimitPerUser)
+            .map((r) => SeekingActivity.fromReaction(username, r)),
+      );
+    }
+    if (boosts is UserBoostsResponse) {
+      merged.addAll(
+        boosts.boosts
+            .take(logLimitPerUser)
+            .map((b) => SeekingActivity.fromBoost(username, b)),
+      );
+    }
+    _lastFullFetchedAt[username] = DateTime.now();
+    if (merged.isEmpty) return;
+
+    merged.sort((a, b) {
+      final ta = a.createdAt?.millisecondsSinceEpoch ?? 0;
+      final tb = b.createdAt?.millisecondsSinceEpoch ?? 0;
+      return tb.compareTo(ta);
+    });
+    final latest = merged.take(logLimitPerUser).toList(growable: false);
+
+    // 新增检测：从头 diff 到上次记录的最新 uid 为止
+    final latestId = latest.first.uid;
+    final lastSavedId = _lastIds[username];
+    var freshCount = 0;
+    if (lastSavedId == null) {
+      _lastIds[username] = latestId;
+    } else if (latestId != lastSavedId) {
+      for (final activity in latest) {
+        if (activity.uid == lastSavedId) break;
+        freshCount++;
+      }
+      _lastIds[username] = latestId;
+    }
+
+    final data = Map<String, List<SeekingActivity>>.of(state.data)
+      ..[username] = latest;
+    var unread = state.unread;
+    if (freshCount > 0) {
+      unread = Map<String, int>.of(state.unread)
+        ..[username] = (state.unread[username] ?? 0) + freshCount;
+    }
+    state = state.copyWith(data: data, unread: unread);
+    await _save();
+  }
+
+  /// 三路并发里出现限流必须冒泡给 _tick 的挂起逻辑，其余错误各自吞掉
+  void _rethrowIfRateLimited(Object e) {
+    if (e is DioException) {
+      final status = e.response?.statusCode ?? 0;
+      if (status == 429 || status == 403) throw e;
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _timer?.cancel();
+    super.dispose();
+  }
+}
+
+final seekingProvider = StateNotifierProvider<SeekingNotifier, SeekingState>((
+  ref,
+) {
+  final prefs = ref.watch(sharedPreferencesProvider);
+  final service = ref.watch(discourseServiceProvider);
+  return SeekingNotifier(prefs, service);
+});

--- a/lib/providers/seeking_provider.dart
+++ b/lib/providers/seeking_provider.dart
@@ -140,6 +140,18 @@ class SeekingNotifier extends StateNotifier<SeekingState>
   final Map<String, DateTime> _lastFullFetchedAt = {};
   static const Duration _fullRefreshInterval = Duration(minutes: 5);
 
+  /// 实际生效的完整校验周期。
+  ///
+  /// 固定 5 分钟在名单一大（一轮遍历耗时 N × pace 超过 5 分钟，约 >10 人）
+  /// 时会让 fullRefreshDue 恒真——两段式省请求彻底失效，每人每轮都发满
+  /// 4 个请求。取「3 轮遍历」与 5 分钟的较大者：大名单下平均每 3 次访问
+  /// 才做 1 次全量（预算 ~2 请求/次），小名单仍保持 5 分钟的校验频率。
+  Duration get _effectiveFullRefreshInterval {
+    final cycle = Duration(seconds: state.users.length * state.paceSeconds);
+    final scaled = cycle * 3;
+    return scaled > _fullRefreshInterval ? scaled : _fullRefreshInterval;
+  }
+
   Timer? _timer;
   bool _busy = false;
   DateTime _lastFlowAt = DateTime.fromMillisecondsSinceEpoch(0);
@@ -234,8 +246,12 @@ class SeekingNotifier extends StateNotifier<SeekingState>
 
     // 添加前立即验证用户，避免把不存在的用户名静默放进轮询队列。
     // 同时复用这次请求得到的头像和在线时间，不额外浪费首轮请求。
+    //
+    // 不排 _pacedRequest：那是给后台轮询流的节拍，用户主动点「添加」
+    // 排在轮询后面，低速档（60s）下可能干等几分钟且毫无反馈。单次
+    // 用户交互请求与正常浏览页面无异，不构成 CF 行为检测风险。
     try {
-      final user = await _pacedRequest(() => _service.getUser(name));
+      final user = await _service.getUser(name);
       final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
         ..[name] = SeekingUserProfile(
           lastSeenAt: user.lastSeenAt,
@@ -280,9 +296,8 @@ class SeekingNotifier extends StateNotifier<SeekingState>
     try {
       final username = await _service.getUsername();
       if (username == null) return -1;
-      final following = await _pacedRequest(
-        () => _service.getFollowing(username),
-      );
+      // 同 addUser：用户主动触发的同步不排后台轮询节拍队列
+      final following = await _service.getFollowing(username);
       var added = 0;
       final users = List<String>.of(state.users);
       for (final user in following) {
@@ -415,22 +430,30 @@ class SeekingNotifier extends StateNotifier<SeekingState>
     final user = await _pacedRequest(
       () => _service.getUser(username, isSilent: true),
     );
+    // 请求在途期间用户可能已被移出名单（或 notifier 已销毁）：此时任何
+    // state / _lastIds 写回都会让已删用户的数据复活并被持久化。
+    if (!mounted || !state.users.contains(username)) return;
     final old = state.profiles[username];
     final profile = SeekingUserProfile(
       lastSeenAt: user.lastSeenAt,
       avatarTemplate: user.avatarTemplate ?? old?.avatarTemplate,
     );
     final changed = old == null || old.lastSeenAt != user.lastSeenAt;
-    final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
-      ..[username] = profile;
-    state = state.copyWith(profiles: profiles);
+    // 资料没变就别重建 map——state 一换整个页面跟着重建,timeline 还要
+    // 全量重排,轮询节拍下这是常态路径,省下来很可观。
+    if (old != profile) {
+      final profiles = Map<String, SeekingUserProfile>.of(state.profiles)
+        ..[username] = profile;
+      state = state.copyWith(profiles: profiles);
+    }
     _lastFetchedAt[username] = DateTime.now();
 
     final hasData = (state.data[username] ?? const []).isNotEmpty;
     final lastFullFetchedAt = _lastFullFetchedAt[username];
     final fullRefreshDue =
         lastFullFetchedAt == null ||
-        DateTime.now().difference(lastFullFetchedAt) >= _fullRefreshInterval;
+        DateTime.now().difference(lastFullFetchedAt) >=
+            _effectiveFullRefreshInterval;
     if (!changed && hasData && !fullRefreshDue) return;
 
     // 第二段：按节拍串行拉三路动态（个别失败不影响整体）
@@ -475,6 +498,8 @@ class SeekingNotifier extends StateNotifier<SeekingState>
             .map((b) => SeekingActivity.fromBoost(username, b)),
       );
     }
+    // 三路请求在途期间同样可能被移出名单，写回前再验一次
+    if (!mounted || !state.users.contains(username)) return;
     _lastFullFetchedAt[username] = DateTime.now();
     if (merged.isEmpty) return;
 

--- a/lib/providers/seeking_provider.dart
+++ b/lib/providers/seeking_provider.dart
@@ -106,13 +106,18 @@ class SeekingNotifier extends StateNotifier<SeekingState>
     _load();
   }
 
-  /// 应用是否在前台。后台/最小化时暂停轮询：省电、省限流额度，
-  /// 也避免多窗口/多实例场景下不可见实例白白抢请求。
+  /// 应用是否在前台。真正退到后台/最小化（hidden/paused）时暂停轮询：
+  /// 省电、省限流额度，也避免多窗口/多实例场景下不可见实例白白抢请求。
   bool _appActive = true;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    _appActive = state == AppLifecycleState.resumed;
+    // inactive 不算离开：桌面端窗口失焦（仍可见）就是 inactive——追觅的
+    // 意义恰恰是「一边干别的一边盯着」，失焦即停等于桌面上基本不工作。
+    // 移动端 inactive 只是权限弹窗/任务切换器等瞬态，放行无妨。
+    _appActive =
+        state == AppLifecycleState.resumed ||
+        state == AppLifecycleState.inactive;
   }
 
   static const int maxUsers = 50;

--- a/lib/providers/seeking_provider.dart
+++ b/lib/providers/seeking_provider.dart
@@ -11,6 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/seeking.dart';
 import '../models/user_action.dart';
 import '../services/discourse/discourse_service.dart';
+import '../services/network/exceptions/api_exception.dart';
 import 'discourse_providers.dart';
 import 'theme_provider.dart';
 
@@ -372,7 +373,11 @@ class SeekingNotifier extends StateNotifier<SeekingState>
       await _fetchUser(target);
     } on DioException catch (e) {
       final status = e.response?.statusCode ?? 0;
-      if (status == 429 || status == 403) {
+      // CF 拦截器对静默请求直接 reject 一个**没有 response** 的
+      // DioException（error 里才是 CfChallengeException），只看
+      // statusCode 会把撞盾当普通失败、按原节拍继续轰——持续给 CF
+      // 行为检测喂数据，盾更难消，还连累前台请求。
+      if (status == 429 || status == 403 || e.error is CfChallengeException) {
         _holdToNextMinute();
         _lastFetchedAt[target] = DateTime.now();
       } else if (status == 404) {
@@ -505,11 +510,13 @@ class SeekingNotifier extends StateNotifier<SeekingState>
     await _save();
   }
 
-  /// 三路并发里出现限流必须冒泡给 _tick 的挂起逻辑，其余错误各自吞掉
+  /// 三路并发里出现限流/CF 盾必须冒泡给 _tick 的挂起逻辑，其余错误各自吞掉
   void _rethrowIfRateLimited(Object e) {
     if (e is DioException) {
       final status = e.response?.statusCode ?? 0;
-      if (status == 429 || status == 403) throw e;
+      if (status == 429 || status == 403 || e.error is CfChallengeException) {
+        throw e;
+      }
     }
   }
 

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -1,57 +1,336 @@
+import 'package:flutter/material.dart' show MaterialPageRoute;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:uuid/uuid.dart';
+import '../pages/settings_page.dart';
+import '../pages/user_profile_page.dart';
 
-/// 当前选中的话题（用于 Master-Detail 模式）
-class SelectedTopicState {
-  const SelectedTopicState({
-    this.topicId,
+/// 平行视界导航栈里一层的内容种类。栈里可以混插话题层和个人资料层
+/// （比如：话题 -> 点头像 -> 资料 -> 点资料里的链接 -> 另一个话题）。
+enum PaneKind { topic, profile, settings }
+
+/// 平行视界导航栈里的一层。
+class PaneEntry {
+  const PaneEntry.topic({
+    required this.topicId,
     this.initialTitle,
     this.scrollToPostNumber,
     this.instanceId,
-  });
+    this.highlightBoostUsername,
+    this.initialRevisionPostNumber,
+    this.initialRevisionNumber,
+  }) : kind = PaneKind.topic,
+       username = null;
 
+  const PaneEntry.profile({required this.username})
+    : kind = PaneKind.profile,
+      topicId = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null;
+
+  const PaneEntry.settings()
+    : kind = PaneKind.settings,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null;
+
+  final PaneKind kind;
   final int? topicId;
+  final String? username;
   final String? initialTitle;
   final int? scrollToPostNumber;
+
   /// provider 实例 ID，用于布局切换时复用同一个 provider
   final String? instanceId;
+  final String? highlightBoostUsername;
+  final int? initialRevisionPostNumber;
+  final int? initialRevisionNumber;
+}
 
-  bool get hasSelection => topicId != null;
+/// 平行视界（Master-Detail 模式）的导航栈状态。
+///
+/// - 从列表点开话题：[SelectedTopicNotifier.select] 清空栈重新开始，
+///   跟以前单选逻辑一致。
+/// - 在话题内容里点内部链接（跳到另一个话题/私信）：
+///   [SelectedTopicNotifier.push] 压栈，不影响之前的层；栈深度 > 1 时
+///   UI 层（[MasterDetailLayout] 消费方）应把列表区滑出隐藏，只显示
+///   当前顶层内容。
+/// - 关闭当前层：[SelectedTopicNotifier.pop] 退回上一层，栈空后等效于
+///   [SelectedTopicNotifier.clear]（列表区域恢复显示）。
+class SelectedTopicState {
+  const SelectedTopicState({this.stack = const []});
 
-  SelectedTopicState copyWith({
-    int? topicId,
-    String? initialTitle,
-    int? scrollToPostNumber,
-    String? instanceId,
-    bool clearSelection = false,
-  }) {
-    if (clearSelection) {
-      return const SelectedTopicState();
-    }
-    return SelectedTopicState(
-      topicId: topicId ?? this.topicId,
-      initialTitle: initialTitle ?? this.initialTitle,
-      scrollToPostNumber: scrollToPostNumber ?? this.scrollToPostNumber,
-      instanceId: instanceId ?? this.instanceId,
-    );
-  }
+  final List<PaneEntry> stack;
+
+  PaneEntry? get _top => stack.isEmpty ? null : stack.last;
+
+  /// 栈顶层完整数据，供 UI 层按 [PaneEntry.kind] 分发到具体面板组件。
+  PaneEntry? get topEntry => _top;
+
+  bool get hasSelection => stack.isNotEmpty;
+
+  /// 栈深度 > 1：当前是通过内部链接跳转堆上来的，不是列表直接选中的。
+  bool get isStacked => stack.length > 1;
+
+  PaneKind? get kind => _top?.kind;
+  int? get topicId => _top?.topicId;
+  String? get username => _top?.username;
+  String? get initialTitle => _top?.initialTitle;
+  int? get scrollToPostNumber => _top?.scrollToPostNumber;
+  String? get instanceId => _top?.instanceId;
+  String? get highlightBoostUsername => _top?.highlightBoostUsername;
+  int? get initialRevisionPostNumber => _top?.initialRevisionPostNumber;
+  int? get initialRevisionNumber => _top?.initialRevisionNumber;
 }
 
 class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
   SelectedTopicNotifier() : super(const SelectedTopicState());
 
+  /// 从列表选中话题：清空栈重新开始（点了另一个话题，不是内部链接跳转）。
   void select({
     required int topicId,
     String? initialTitle,
     int? scrollToPostNumber,
     String? instanceId,
+    String? highlightBoostUsername,
+    int? initialRevisionPostNumber,
+    int? initialRevisionNumber,
   }) {
     state = SelectedTopicState(
-      topicId: topicId,
-      initialTitle: initialTitle,
-      scrollToPostNumber: scrollToPostNumber,
-      instanceId: instanceId,
+      stack: [
+        PaneEntry.topic(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+          // 最初从列表进入的这一层也必须持有稳定实例 ID。否则它在
+          // 平行视界里从 detail 搬到 master 时会生成新的 provider key，
+          // 已加载的分页数据会全部失配并重新请求。
+          instanceId: instanceId ?? const Uuid().v4(),
+          highlightBoostUsername: highlightBoostUsername,
+          initialRevisionPostNumber: initialRevisionPostNumber,
+          initialRevisionNumber: initialRevisionNumber,
+        ),
+      ],
     );
+  }
+
+  /// 话题内容里点内部链接跳转到另一个话题：压栈，保留之前的层。
+  ///
+  /// instanceId 不传时在这里当场生成一个、永久绑定在这个栈层上——
+  /// [topicDetailProvider] 用 (topicId, instanceId) 做 family key，且自带
+  /// 30 秒 keepAlive 缓存宽限期，本来应该做到"退栈几秒内返回不用重新
+  /// 请求"。但之前 instanceId 是靠调用方（topics_screen.dart 的
+  /// `_getOrCreateInstanceId`）一个只记得"最后一个话题"的单槽缓存去猜，
+  /// 只要中途看过别的话题就会把之前的 instanceId 忘掉，退栈时生成一个
+  /// 全新的、从没被缓存过的 instanceId——30 秒缓存形同虚设，永远命中不上，
+  /// 表现为"平行视界一变动就完全重新请求"。在这里当场生成并让它跟着
+  /// PaneEntry 一起被保留在栈里，才能保证同一层的话题从头到尾都是同一个
+  /// provider key。
+  void push({
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+    String? instanceId,
+    String? highlightBoostUsername,
+    int? initialRevisionPostNumber,
+    int? initialRevisionNumber,
+  }) {
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack,
+        PaneEntry.topic(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+          instanceId: instanceId ?? const Uuid().v4(),
+          highlightBoostUsername: highlightBoostUsername,
+          initialRevisionPostNumber: initialRevisionPostNumber,
+          initialRevisionNumber: initialRevisionNumber,
+        ),
+      ],
+    );
+  }
+
+  /// 列表项点击跳话题：替换栈顶，不新增层。
+  ///
+  /// 跟 [push] 的区别是语义来源不同——[push] 对应"正文里点内部链接"，
+  /// 每次都是新内容，理应压栈；这个对应"在某个列表（比如个人资料页的
+  /// 话题/回复列表）里连续点开不同项"，用户心智是"看列表里的另一项"，
+  /// 不该每点一次就多叠一层，不然逛几个列表项平行视界就没法收场了。
+  /// 栈为空时退化成 [push]。
+  void replaceTop({
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+    String? instanceId,
+  }) {
+    if (state.stack.isEmpty) {
+      push(
+        topicId: topicId,
+        initialTitle: initialTitle,
+        scrollToPostNumber: scrollToPostNumber,
+        instanceId: instanceId,
+      );
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.topic(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+          instanceId: instanceId ?? const Uuid().v4(),
+        ),
+      ],
+    );
+  }
+
+  /// master 面板"上一层预览"里点开新内容：截断掉当前栈顶（右侧 detail
+  /// 正显示的那层），保留预览这一层本身，再压入新内容——效果是"替换
+  /// 右边"，而不是在已经很深的栈上继续叠层，也不是脱离栈变成全屏。
+  /// 栈深度 < 2（没有"上一层"可言）时退化成 [push]。
+  void pushTruncating({
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+    String? instanceId,
+  }) {
+    if (state.stack.length < 2) {
+      push(
+        topicId: topicId,
+        initialTitle: initialTitle,
+        scrollToPostNumber: scrollToPostNumber,
+        instanceId: instanceId,
+      );
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.topic(
+          topicId: topicId,
+          initialTitle: initialTitle,
+          scrollToPostNumber: scrollToPostNumber,
+          instanceId: instanceId ?? const Uuid().v4(),
+        ),
+      ],
+    );
+  }
+
+  /// 更新栈顶话题的恢复信息，但保留整个平行视界历史。
+  ///
+  /// 窗口由宽变窄时，栈顶话题会临时以全屏路由继续浏览；再次变宽时只需
+  /// 把最新标题、楼层和 provider 实例写回栈顶，不能调用 [select] 把此前
+  /// 的话题/资料层全部清掉。
+  void updateTopTopic({
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+    String? instanceId,
+  }) {
+    final current = state.topEntry;
+    if (current == null ||
+        current.kind != PaneKind.topic ||
+        current.topicId != topicId) {
+      return;
+    }
+
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.topic(
+          topicId: topicId,
+          initialTitle: initialTitle ?? current.initialTitle,
+          scrollToPostNumber: scrollToPostNumber ?? current.scrollToPostNumber,
+          instanceId: instanceId ?? current.instanceId,
+          highlightBoostUsername: current.highlightBoostUsername,
+          initialRevisionPostNumber: current.initialRevisionPostNumber,
+          initialRevisionNumber: current.initialRevisionNumber,
+        ),
+      ],
+    );
+  }
+
+  /// 点用户名/头像跳个人资料：压栈，保留之前的层（话题不退出，资料显示
+  /// 在右侧顶替）。
+  void pushProfile(String username) {
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack,
+        PaneEntry.profile(username: username),
+      ],
+    );
+  }
+
+  /// 从搜索结果直接选择用户资料：清空旧搜索详情栈，以该资料作为第一层。
+  void selectProfile(String username) {
+    state = SelectedTopicState(stack: [PaneEntry.profile(username: username)]);
+  }
+
+  /// 打开设置：压栈，保留之前的层。
+  void pushSettings() {
+    state = SelectedTopicState(
+      stack: [...state.stack, const PaneEntry.settings()],
+    );
+  }
+
+  /// master 面板"上一层预览"里点头像/用户名跳资料：截断当前栈顶后压入，
+  /// 语义同 [pushTruncating]。
+  void pushProfileTruncating(String username) {
+    if (state.stack.length < 2) {
+      pushProfile(username);
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.profile(username: username),
+      ],
+    );
+  }
+
+  /// master 面板"上一层预览"里打开设置：截断当前栈顶后压入，语义同
+  /// [pushTruncating]。
+  void pushSettingsTruncating() {
+    if (state.stack.length < 2) {
+      pushSettings();
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        const PaneEntry.settings(),
+      ],
+    );
+  }
+
+  /// 关闭当前层，退回上一层。栈已空时是 no-op。
+  void pop() {
+    if (state.stack.isEmpty) return;
+    state = SelectedTopicState(
+      stack: state.stack.sublist(0, state.stack.length - 1),
+    );
+  }
+
+  /// 左栏切换到信息流、分类或标签时，保留右侧当前内容，但丢弃已经被
+  /// 左栏替换掉的历史层。否则 [isStacked] 仍为 true，布局会继续用倒数
+  /// 第二层覆盖左栏，让用户点击分类后看起来毫无反应。
+  void collapseToTop() {
+    final top = state.topEntry;
+    if (top == null || state.stack.length == 1) return;
+    state = SelectedTopicState(stack: [top]);
   }
 
   void clear() {
@@ -59,12 +338,155 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
   }
 }
 
-final selectedTopicProvider =
-    StateNotifierProvider<SelectedTopicNotifier, SelectedTopicState>((ref) {
+typedef SelectedTopicProvider =
+    StateNotifierProvider<SelectedTopicNotifier, SelectedTopicState>;
+
+/// 首页话题列表的导航栈。
+final selectedTopicProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
-/// 嵌入式详情页的当前浏览位置（按 topicId 索引）
-/// 用于布局切换时恢复滚动位置
+/// 私信列表的导航栈——跟首页话题列表各自独立一份状态，切 tab 互不干扰，
+/// 但复用同一套 push/pop/select/clear 语义。
+final selectedMessageProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
+
+/// 搜索页自己的平行视界导航栈，与首页话题、私信历史完全隔离。
+final selectedSearchProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
+
+/// 追觅（视奸）面板自己的平行视界栈。不能复用首页或搜索栈，否则切换
+/// 导航项时两个页面会互相继承对方正在查看的话题/资料。
+final selectedSeekingProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
+
+/// 标记"当前 context 处在哪个平行视界嵌入面板里"，内部链接点击时靠它
+/// 判断该压到哪个栈（首页话题栈还是私信栈）。
+///
+/// 用 InheritedWidget 而不是全局可变状态（早期版本用过
+/// `StateProvider<SelectedTopicProvider?>`，靠 initState/dispose 设置/
+/// 清除全局唯一值）——IndexedStack 里首页跟私信的嵌入面板经常同时挂载
+/// （切 tab 不销毁），两边的 initState 各自的 postFrameCallback 会互相
+/// 覆盖那个全局值，导致"私信详情里点链接却被当成了首页的嵌入面板"这类
+/// 错乱（实测复现：私信内点话题链接直接全屏打开，而不是压栈）。
+/// InheritedWidget 按 widget 树最近祖先解析，天然按面板隔离，不会互相
+/// 踩踏。
+class EmbeddedStackScope extends InheritedWidget {
+  const EmbeddedStackScope({
+    super.key,
+    required this.stackProvider,
+    this.truncateOnPush = false,
+    required super.child,
+  });
+
+  final SelectedTopicProvider stackProvider;
+
+  /// true = 这份内容是 master 面板里的"上一层预览"，不是当前可交互的
+  /// 栈顶。这一层触发的 push/openProfile/openSettings 应该"替换右侧
+  /// 正显示的那层"（截断栈顶后压入），而不是在已经很深的栈上继续叠层。
+  final bool truncateOnPush;
+
+  /// 找不到祖先（不在任何嵌入面板里，如全屏 Navigator push 出来的详情页）
+  /// 时返回 null。不订阅重建（一次性读取，跟 ref.read 语义一致）。
+  static SelectedTopicProvider? maybeOf(BuildContext context) {
+    return _maybeScopeOf(context)?.stackProvider;
+  }
+
+  /// 当前 context 是否处在 master 面板"上一层预览"里——[UserProfilePage]
+  /// 等页面自己手写的列表点击逻辑（区分"替换我自己上次点开的" vs
+  /// "新压一层"）需要靠这个短路成统一的截断替换语义。
+  static bool isTruncating(BuildContext context) =>
+      _maybeScopeOf(context)?.truncateOnPush ?? false;
+
+  static EmbeddedStackScope? _maybeScopeOf(BuildContext context) {
+    final element = context
+        .getElementForInheritedWidgetOfExactType<EmbeddedStackScope>();
+    return element?.widget as EmbeddedStackScope?;
+  }
+
+  @override
+  bool updateShouldNotify(EmbeddedStackScope oldWidget) =>
+      stackProvider != oldWidget.stackProvider ||
+      truncateOnPush != oldWidget.truncateOnPush;
+
+  /// 在嵌入面板里打开话题时压入当前平行视界栈。
+  ///
+  /// 返回 `true` 表示已经由面板栈接管；返回 `false` 时调用方应按普通全屏
+  /// 页面处理。这里只负责状态，不依赖具体页面类，避免导航基础层反向依赖
+  /// 话题详情页面。
+  static bool maybePushTopic(
+    BuildContext context, {
+    required int topicId,
+    String? initialTitle,
+    int? scrollToPostNumber,
+  }) {
+    final scope = _maybeScopeOf(context);
+    if (scope == null) return false;
+    final container = ProviderScope.containerOf(context, listen: false);
+    final notifier = container.read(scope.stackProvider.notifier);
+    if (scope.truncateOnPush) {
+      notifier.pushTruncating(
+        topicId: topicId,
+        initialTitle: initialTitle,
+        scrollToPostNumber: scrollToPostNumber,
+      );
+    } else {
+      notifier.push(
+        topicId: topicId,
+        initialTitle: initialTitle,
+        scrollToPostNumber: scrollToPostNumber,
+      );
+    }
+    return true;
+  }
+
+  /// 打开用户资料的统一入口：在嵌入面板里（头像/用户名点击）就压栈显示
+  /// 平行视界，不在（比如设置页、独立弹窗）就照旧全屏 push。所有点头像
+  /// /用户名跳资料页的地方都应该走这个，别再各自手写 Navigator.push。
+  static void openProfile(BuildContext context, String username) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushProfileTruncating(username);
+      } else {
+        notifier.pushProfile(username);
+      }
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
+    );
+  }
+
+  /// 打开设置的统一入口：嵌入面板里压栈显示平行视界，不在就全屏 push。
+  static void openSettings(BuildContext context) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushSettingsTruncating();
+      } else {
+        notifier.pushSettings();
+      }
+      return;
+    }
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const SettingsPage()));
+  }
+}
+
+typedef DetailScrollPositionKey = ({int topicId, String instanceId});
+
+/// 嵌入式详情页的当前浏览位置。
+///
+/// 必须与 [topicDetailProvider] 一样按 `(topicId, instanceId)` 隔离；只按
+/// topicId 会让同一话题的不同平行视界层互相覆盖位置。
 final detailScrollPositionProvider =
-    StateProvider.family<int?, int>((ref, topicId) => null);
+    StateProvider.family<int?, DetailScrollPositionKey>((ref, key) => null);

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:uuid/uuid.dart';
 import '../pages/settings_page.dart';
 import '../pages/user_profile_page.dart';
+import '../widgets/layout/auto_restore_master_detail_route.dart';
 
 /// 平行视界导航栈里一层的内容种类。栈里可以混插话题层和个人资料层
 /// （比如：话题 -> 点头像 -> 资料 -> 点资料里的链接 -> 另一个话题）。
@@ -363,6 +364,30 @@ final selectedSeekingProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
+/// 窄屏临时路由携带的平行视界恢复上下文。
+class FullScreenPaneRestoreScope extends InheritedWidget {
+  const FullScreenPaneRestoreScope({
+    super.key,
+    required this.stackProvider,
+    required this.restoreCurrentPane,
+    required super.child,
+  });
+
+  final SelectedTopicProvider stackProvider;
+  final VoidCallback restoreCurrentPane;
+
+  static FullScreenPaneRestoreScope? maybeOf(BuildContext context) {
+    final element = context
+        .getElementForInheritedWidgetOfExactType<FullScreenPaneRestoreScope>();
+    return element?.widget as FullScreenPaneRestoreScope?;
+  }
+
+  @override
+  bool updateShouldNotify(FullScreenPaneRestoreScope oldWidget) =>
+      stackProvider != oldWidget.stackProvider ||
+      restoreCurrentPane != oldWidget.restoreCurrentPane;
+}
+
 /// 标记"当前 context 处在哪个平行视界嵌入面板里"，内部链接点击时靠它
 /// 判断该压到哪个栈（首页话题栈还是私信栈）。
 ///
@@ -447,6 +472,40 @@ class EmbeddedStackScope extends InheritedWidget {
   /// 平行视界，不在（比如设置页、独立弹窗）就照旧全屏 push。所有点头像
   /// /用户名跳资料页的地方都应该走这个，别再各自手写 Navigator.push。
   static void openProfile(BuildContext context, String username) {
+    final restoreScope = FullScreenPaneRestoreScope.maybeOf(context);
+    if (restoreScope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(restoreScope.stackProvider.notifier);
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (routeContext) {
+            void restoreProfilePane() {
+              restoreScope.restoreCurrentPane();
+              notifier.pushProfile(username);
+            }
+
+            void restoreProfileRoute() {
+              final route = ModalRoute.of(routeContext);
+              final navigator = Navigator.of(routeContext);
+              restoreProfilePane();
+              if (route == null || !route.isActive) return;
+              navigator.removeRoute(route);
+            }
+
+            return AutoRestoreMasterDetailRoute(
+              onRestore: restoreProfilePane,
+              child: FullScreenPaneRestoreScope(
+                stackProvider: restoreScope.stackProvider,
+                restoreCurrentPane: restoreProfileRoute,
+                child: UserProfilePage(username: username),
+              ),
+            );
+          },
+        ),
+      );
+      return;
+    }
+
     final scope = _maybeScopeOf(context);
     if (scope != null) {
       final container = ProviderScope.containerOf(context, listen: false);

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -4,13 +4,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:uuid/uuid.dart';
+import '../pages/drafts_page.dart';
 import '../pages/settings_page.dart';
 import '../pages/user_profile_page.dart';
 import '../widgets/layout/auto_restore_master_detail_route.dart';
 
 /// 平行视界导航栈里一层的内容种类。栈里可以混插话题层和个人资料层
 /// （比如：话题 -> 点头像 -> 资料 -> 点资料里的链接 -> 另一个话题）。
-enum PaneKind { topic, profile, settings }
+enum PaneKind { topic, profile, settings, drafts }
 
 /// 平行视界导航栈里的一层。
 class PaneEntry {
@@ -22,6 +23,8 @@ class PaneEntry {
     this.highlightBoostUsername,
     this.initialRevisionPostNumber,
     this.initialRevisionNumber,
+    this.autoOpenReply = false,
+    this.autoReplyToPostNumber,
   }) : kind = PaneKind.topic,
        username = null;
 
@@ -33,7 +36,22 @@ class PaneEntry {
       instanceId = null,
       highlightBoostUsername = null,
       initialRevisionPostNumber = null,
-      initialRevisionNumber = null;
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null;
+
+  const PaneEntry.drafts()
+    : kind = PaneKind.drafts,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null;
 
   const PaneEntry.settings()
     : kind = PaneKind.settings,
@@ -44,7 +62,9 @@ class PaneEntry {
       instanceId = null,
       highlightBoostUsername = null,
       initialRevisionPostNumber = null,
-      initialRevisionNumber = null;
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null;
 
   final PaneKind kind;
   final int? topicId;
@@ -57,6 +77,13 @@ class PaneEntry {
   final String? highlightBoostUsername;
   final int? initialRevisionPostNumber;
   final int? initialRevisionNumber;
+
+  /// 进入这一层后自动弹出回复框——草稿列表点进来时用（草稿的意义就是
+  /// 接着写，不该让用户再手点一次回复）。
+  final bool autoOpenReply;
+
+  /// 自动弹出的回复框回复的目标楼层（null = 回复整个话题）。
+  final int? autoReplyToPostNumber;
 }
 
 /// 平行视界（Master-Detail 模式）的导航栈状态。
@@ -107,10 +134,14 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     String? highlightBoostUsername,
     int? initialRevisionPostNumber,
     int? initialRevisionNumber,
+    bool autoOpenReply = false,
+    int? autoReplyToPostNumber,
   }) {
     state = SelectedTopicState(
       stack: [
         PaneEntry.topic(
+          autoOpenReply: autoOpenReply,
+          autoReplyToPostNumber: autoReplyToPostNumber,
           topicId: topicId,
           initialTitle: initialTitle,
           scrollToPostNumber: scrollToPostNumber,
@@ -146,11 +177,15 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     String? highlightBoostUsername,
     int? initialRevisionPostNumber,
     int? initialRevisionNumber,
+    bool autoOpenReply = false,
+    int? autoReplyToPostNumber,
   }) {
     state = SelectedTopicState(
       stack: [
         ...state.stack,
         PaneEntry.topic(
+          autoOpenReply: autoOpenReply,
+          autoReplyToPostNumber: autoReplyToPostNumber,
           topicId: topicId,
           initialTitle: initialTitle,
           scrollToPostNumber: scrollToPostNumber,
@@ -207,6 +242,8 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     String? initialTitle,
     int? scrollToPostNumber,
     String? instanceId,
+    bool autoOpenReply = false,
+    int? autoReplyToPostNumber,
   }) {
     if (state.stack.length < 2) {
       push(
@@ -214,6 +251,8 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
         initialTitle: initialTitle,
         scrollToPostNumber: scrollToPostNumber,
         instanceId: instanceId,
+        autoOpenReply: autoOpenReply,
+        autoReplyToPostNumber: autoReplyToPostNumber,
       );
       return;
     }
@@ -221,6 +260,8 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
       stack: [
         ...state.stack.take(state.stack.length - 1),
         PaneEntry.topic(
+          autoOpenReply: autoOpenReply,
+          autoReplyToPostNumber: autoReplyToPostNumber,
           topicId: topicId,
           initialTitle: initialTitle,
           scrollToPostNumber: scrollToPostNumber,
@@ -259,6 +300,8 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
           highlightBoostUsername: current.highlightBoostUsername,
           initialRevisionPostNumber: current.initialRevisionPostNumber,
           initialRevisionNumber: current.initialRevisionNumber,
+          autoOpenReply: current.autoOpenReply,
+          autoReplyToPostNumber: current.autoReplyToPostNumber,
         ),
       ],
     );
@@ -278,6 +321,33 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
   /// 从搜索结果直接选择用户资料：清空旧搜索详情栈，以该资料作为第一层。
   void selectProfile(String username) {
     state = SelectedTopicState(stack: [PaneEntry.profile(username: username)]);
+  }
+
+  /// 打开草稿列表：压栈显示在右栏。语义同 pushSettings ——
+  /// 草稿页是平行视界的一层内容，不是自成一套分栏。
+  void pushDrafts() {
+    // 草稿**占据**右栏，不是叠在别人上面：右边已经有话题时顶替掉它，
+    // 左边保持信息流/私信列表。所以整栈重置成单层草稿，而不是 append
+    // —— append 会让"栈里两个草稿"和"草稿压在话题上"两种烂状态都成立。
+    if (state.stack.length == 1 && state.stack.single.kind == PaneKind.drafts) {
+      return; // 已经就是它，别白重建一次状态
+    }
+    state = const SelectedTopicState(stack: [PaneEntry.drafts()]);
+  }
+
+  /// master 面板"上一层预览"里打开草稿：截断栈顶后压入。
+  void pushDraftsTruncating() {
+    if (state.stack.length < 2) {
+      pushDrafts();
+      return;
+    }
+    // 同 [pushDrafts]：草稿层唯一，截断后若下面还压着一个草稿就别再加
+    final kept = state.stack
+        .take(state.stack.length - 1)
+        .where((e) => e.kind != PaneKind.drafts);
+    state = SelectedTopicState(
+      stack: [...kept, const PaneEntry.drafts()],
+    );
   }
 
   /// 打开设置：压栈，保留之前的层。
@@ -334,6 +404,46 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     state = SelectedTopicState(stack: [top]);
   }
 
+  /// 消费掉栈顶的"自动打开回复框"意图。
+  ///
+  /// 这个标记必须**用一次就清**：它挂在 PaneEntry 上，只要还是 true，
+  /// 任何导致话题面板重建的事（草稿层被抽掉、栈变动、tab 切换）都会让
+  /// 它再触发一次 —— 实测发完私信回复框又自己弹出来。页面里的
+  /// `_autoOpenReplyHandled` 是 State 字段，面板一重建就跟着重置，
+  /// 拦不住，所以得在状态源头清。
+  void consumeAutoOpenReply() {
+    final top = state.topEntry;
+    if (top == null || top.kind != PaneKind.topic) return;
+    if (!top.autoOpenReply && top.autoReplyToPostNumber == null) return;
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.topic(
+          topicId: top.topicId!,
+          initialTitle: top.initialTitle,
+          scrollToPostNumber: top.scrollToPostNumber,
+          instanceId: top.instanceId,
+          highlightBoostUsername: top.highlightBoostUsername,
+          initialRevisionPostNumber: top.initialRevisionPostNumber,
+          initialRevisionNumber: top.initialRevisionNumber,
+          // 就是这里：清掉，别再弹第二次
+        ),
+      ],
+    );
+  }
+
+  /// 抽掉栈中某一类层，其余层保持相对顺序。
+  ///
+  /// 草稿栏用:草稿全部处理完之后，草稿这一层要从栈里消失，但**右边的
+  /// 话题/私信必须留着** —— 所以不能用 pop(那会关掉栈顶的话题)。
+  /// 抽掉后 `[草稿, 话题]` 变成 `[话题]`，左栏自然退回信息流/私信列表。
+  void removeEntriesOfKind(PaneKind kind) {
+    if (!state.stack.any((e) => e.kind == kind)) return;
+    state = SelectedTopicState(
+      stack: state.stack.where((e) => e.kind != kind).toList(),
+    );
+  }
+
   void clear() {
     state = const SelectedTopicState();
   }
@@ -350,6 +460,37 @@ final selectedTopicProvider = SelectedTopicProvider((ref) {
 /// 私信列表的导航栈——跟首页话题列表各自独立一份状态，切 tab 互不干扰，
 /// 但复用同一套 push/pop/select/clear 语义。
 final selectedMessageProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
+
+/// 把草稿和某条话题/私信一起放进栈：`[草稿, 内容]`。
+///
+/// 这是"处理草稿"的标准形态 —— 左栏草稿处理栏、右栏正在处理的那条。
+/// 处理完最后一条时 [SelectedTopicNotifier.removeEntriesOfKind] 抽掉草稿
+/// 层，栈剩 `[内容]`，左栏自然退回该内容对应的列表（信息流 / 私信列表）。
+extension DraftHandoff on SelectedTopicNotifier {
+  void openDraftTarget({
+    required int topicId,
+    int? scrollToPostNumber,
+    bool autoOpenReply = true,
+    int? autoReplyToPostNumber,
+  }) {
+    pushDrafts(); // 栈重置成 [草稿]
+    push(
+      topicId: topicId,
+      scrollToPostNumber: scrollToPostNumber,
+      autoOpenReply: autoOpenReply,
+      autoReplyToPostNumber: autoReplyToPostNumber,
+    ); // → [草稿, 内容]
+  }
+}
+
+/// 「我的」页右栏的平行视界栈。
+///
+/// 「我的」在宽屏是"左资料 + 右卡片"的双栏,右栏这一半可以被压进来的
+/// 内容(草稿列表 / 设置)顶替 —— 这样从「我的」点草稿就是右半边显示
+/// 草稿列表,而不是整屏跳走。
+final selectedProfilePaneProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
@@ -442,27 +583,36 @@ class EmbeddedStackScope extends InheritedWidget {
   /// 返回 `true` 表示已经由面板栈接管；返回 `false` 时调用方应按普通全屏
   /// 页面处理。这里只负责状态，不依赖具体页面类，避免导航基础层反向依赖
   /// 话题详情页面。
+  /// [replaceTop] = 用新内容**替换**右栏当前层而不是叠一层。草稿列表点
+  /// 某条草稿属于"在列表里看另一项",不该每点一次就多叠一层。
   static bool maybePushTopic(
     BuildContext context, {
     required int topicId,
     String? initialTitle,
     int? scrollToPostNumber,
+    bool autoOpenReply = false,
+    int? autoReplyToPostNumber,
+    bool replaceTop = false,
   }) {
     final scope = _maybeScopeOf(context);
     if (scope == null) return false;
     final container = ProviderScope.containerOf(context, listen: false);
     final notifier = container.read(scope.stackProvider.notifier);
-    if (scope.truncateOnPush) {
+    if (scope.truncateOnPush || replaceTop) {
       notifier.pushTruncating(
         topicId: topicId,
         initialTitle: initialTitle,
         scrollToPostNumber: scrollToPostNumber,
+        autoOpenReply: autoOpenReply,
+        autoReplyToPostNumber: autoReplyToPostNumber,
       );
     } else {
       notifier.push(
         topicId: topicId,
         initialTitle: initialTitle,
         scrollToPostNumber: scrollToPostNumber,
+        autoOpenReply: autoOpenReply,
+        autoReplyToPostNumber: autoReplyToPostNumber,
       );
     }
     return true;
@@ -520,6 +670,25 @@ class EmbeddedStackScope extends InheritedWidget {
     Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
     );
+  }
+
+  /// 打开草稿列表的统一入口：嵌入面板里压栈（右栏显示草稿列表），
+  /// 不在就全屏 push。
+  static void openDrafts(BuildContext context) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushDraftsTruncating();
+      } else {
+        notifier.pushDrafts();
+      }
+      return;
+    }
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const DraftsPage()));
   }
 
   /// 打开设置的统一入口：嵌入面板里压栈显示平行视界，不在就全屏 push。

--- a/lib/providers/shortcut_provider.dart
+++ b/lib/providers/shortcut_provider.dart
@@ -319,11 +319,18 @@ class ShortcutScopeBinding {
     BuildContext context,
     Map<ShortcutAction, VoidCallback> callbacks,
   ) {
+    registerForRoute(ModalRoute.of(context), callbacks);
+  }
+
+  void registerForRoute(
+    Route<dynamic>? route,
+    Map<ShortcutAction, VoidCallback> callbacks,
+  ) {
     if (_disposed) return;
     _registry.register(
       scope: scope,
       owner: _owner,
-      route: ModalRoute.of(context),
+      route: route,
       callbacks: callbacks,
     );
   }

--- a/lib/providers/topic_list/topic_list_provider.dart
+++ b/lib/providers/topic_list/topic_list_provider.dart
@@ -47,12 +47,17 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
     // 优化：如果是 latest 列表且没有筛选条件且没有自定义排序，优先同步使用预加载数据
     // 这样可以避免显示 loading 状态
-    if (currentFilter == TopicListFilter.latest && filter.isEmpty && orderParam == null) {
+    if (currentFilter == TopicListFilter.latest &&
+        filter.isEmpty &&
+        orderParam == null) {
       final preloadedService = PreloadedDataService();
       final preloadedData = preloadedService.getInitialTopicListSync();
       if (preloadedData != null) {
         final result = _paginationHelper.processRefresh(
-          PaginationResult(items: preloadedData.topics, moreUrl: preloadedData.moreTopicsUrl),
+          PaginationResult(
+            items: preloadedData.topics,
+            moreUrl: preloadedData.moreTopicsUrl,
+          ),
         );
         return completePagedRefresh(PagedPage.fromPagination(result));
       }
@@ -60,7 +65,10 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
         final asyncPreloaded = await preloadedService.getInitialTopicList();
         if (asyncPreloaded != null) {
           final result = _paginationHelper.processRefresh(
-            PaginationResult(items: asyncPreloaded.topics, moreUrl: asyncPreloaded.moreTopicsUrl),
+            PaginationResult(
+              items: asyncPreloaded.topics,
+              moreUrl: asyncPreloaded.moreTopicsUrl,
+            ),
           );
           return completePagedRefresh(PagedPage.fromPagination(result));
         }
@@ -69,7 +77,15 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
     // 如果没有预加载数据，走正常的异步流程
     final service = ref.read(discourseServiceProvider);
-    final response = await _fetchTopics(service, currentFilter, 0, filter, order: orderParam, ascending: ascendingParam, subset: subset);
+    final response = await _fetchTopics(
+      service,
+      currentFilter,
+      0,
+      filter,
+      order: orderParam,
+      ascending: ascendingParam,
+      subset: subset,
+    );
 
     final result = _paginationHelper.processRefresh(
       PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
@@ -106,17 +122,38 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
     // 无筛选条件，使用原有方法
     switch (filter) {
       case TopicListFilter.latest:
-        return service.getLatestTopics(page: page, order: order, ascending: ascending);
+        return service.getLatestTopics(
+          page: page,
+          order: order,
+          ascending: ascending,
+        );
       case TopicListFilter.newTopics:
-        return service.getNewTopics(page: page, order: order, ascending: ascending, subset: subset);
+        return service.getNewTopics(
+          page: page,
+          order: order,
+          ascending: ascending,
+          subset: subset,
+        );
       case TopicListFilter.unread:
-        return service.getUnreadTopics(page: page, order: order, ascending: ascending);
+        return service.getUnreadTopics(
+          page: page,
+          order: order,
+          ascending: ascending,
+        );
       case TopicListFilter.unseen:
-        return service.getUnseenTopics(page: page, order: order, ascending: ascending);
+        return service.getUnseenTopics(
+          page: page,
+          order: order,
+          ascending: ascending,
+        );
       case TopicListFilter.top:
         return service.getTopTopics();
       case TopicListFilter.hot:
-        return service.getHotTopics(page: page, order: order, ascending: ascending);
+        return service.getHotTopics(
+          page: page,
+          order: order,
+          ascending: ascending,
+        );
     }
   }
 
@@ -157,7 +194,9 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
   (String?, bool?) _currentSortParams() {
     final sortOrder = ref.read(topicSortOrderProvider);
     final orderParam = sortOrder.apiValue;
-    final ascendingParam = orderParam != null ? ref.read(topicSortAscendingProvider) : null;
+    final ascendingParam = orderParam != null
+        ? ref.read(topicSortAscendingProvider)
+        : null;
     return (orderParam, ascendingParam);
   }
 
@@ -170,10 +209,21 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
       final subset = _currentFilter == TopicListFilter.newTopics
           ? ref.read(topicNewSubsetProvider).apiValue
           : null;
-      final response = await _fetchTopics(service, _currentFilter, 0, filterParams, order: order, ascending: ascending, subset: subset);
+      final response = await _fetchTopics(
+        service,
+        _currentFilter,
+        0,
+        filterParams,
+        order: order,
+        ascending: ascending,
+        subset: subset,
+      );
 
       final result = _paginationHelper.processRefresh(
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
       return PagedPage.fromPagination(result);
     });
@@ -188,10 +238,21 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
         ? ref.read(topicNewSubsetProvider).apiValue
         : null;
     try {
-      final response = await _fetchTopics(service, _currentFilter, 0, filterParams, order: order, ascending: ascending, subset: subset);
+      final response = await _fetchTopics(
+        service,
+        _currentFilter,
+        0,
+        filterParams,
+        order: order,
+        ascending: ascending,
+        subset: subset,
+      );
 
       final result = _paginationHelper.processRefresh(
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
       state = AsyncValue.data(
         completePagedRefresh(PagedPage.fromPagination(result)),
@@ -221,7 +282,9 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
       // 移除列表中已存在的同 ID 话题（刷新重复项，与网页版 removeValuesFromArray 一致）
       final newTopicIds = newTopics.map((t) => t.id).toSet();
-      final remaining = currentTopics.where((t) => !newTopicIds.contains(t.id)).toList();
+      final remaining = currentTopics
+          .where((t) => !newTopicIds.contains(t.id))
+          .toList();
       // 将新话题全部插入列表顶部
       state = AsyncValue.data([...newTopics, ...remaining]);
       return newTopics.map((t) => t.id).toList();
@@ -240,12 +303,23 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
       final subset = _currentFilter == TopicListFilter.newTopics
           ? ref.read(topicNewSubsetProvider).apiValue
           : null;
-      final response = await _fetchTopics(service, _currentFilter, nextPage, filterParams, order: order, ascending: ascending, subset: subset);
+      final response = await _fetchTopics(
+        service,
+        _currentFilter,
+        nextPage,
+        filterParams,
+        order: order,
+        ascending: ascending,
+        subset: subset,
+      );
 
       final currentState = PaginationState(items: currentTopics);
       final paginationResult = _paginationHelper.processLoadMore(
         currentState,
-        PaginationResult(items: response.topics, moreUrl: response.moreTopicsUrl),
+        PaginationResult(
+          items: response.topics,
+          moreUrl: response.moreTopicsUrl,
+        ),
       );
 
       return PagedPage.fromPagination(
@@ -329,7 +403,8 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
     } else if (filter == TopicListFilter.unread) {
       await service.dismissUnreadTopics(categoryId: _categoryId);
       // 同步更新追踪状态计数
-      ref.read(topicTrackingStateProvider.notifier)
+      ref
+          .read(topicTrackingStateProvider.notifier)
           .dismissUnreadTopics(categoryId: _categoryId);
     }
     state = AsyncValue.data(
@@ -339,7 +414,7 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
     );
   }
 
-  void updateSeen(int topicId, int highestSeen) {
+  void updateSeen(int topicId, int highestSeen, {bool updateTracking = true}) {
     final topics = state.value;
     if (topics == null) return;
 
@@ -351,7 +426,10 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
     if (highestSeen <= currentRead) return;
 
-    final newUnread = (topic.highestPostNumber - highestSeen).clamp(0, topic.highestPostNumber);
+    final newUnread = (topic.highestPostNumber - highestSeen).clamp(
+      0,
+      topic.highestPostNumber,
+    );
 
     final updated = Topic(
       id: topic.id,
@@ -383,15 +461,19 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
     newList[index] = updated;
     state = AsyncValue.data(newList);
 
-    // 同步更新追踪状态计数（阅读后减少 new/unread 计数）
-    ref.read(topicTrackingStateProvider.notifier)
-        .updateTopicRead(topicId, highestSeen, topic.highestPostNumber);
+    if (updateTracking) {
+      // 同步更新追踪状态计数（阅读后减少 new/unread 计数）
+      ref
+          .read(topicTrackingStateProvider.notifier)
+          .updateTopicRead(topicId, highestSeen, topic.highestPostNumber);
+    }
   }
 }
 
-final topicListProvider = AsyncNotifierProvider.family<TopicListNotifier, List<Topic>, int?>(
-  TopicListNotifier.new,
-);
+final topicListProvider =
+    AsyncNotifierProvider.family<TopicListNotifier, List<Topic>, int?>(
+      TopicListNotifier.new,
+    );
 
 /// 热门话题 Provider
 final topTopicsProvider = FutureProvider<TopicListResponse>((ref) async {

--- a/lib/services/background/ios_background_fetch.dart
+++ b/lib/services/background/ios_background_fetch.dart
@@ -126,11 +126,17 @@ void callbackDispatcher() {
             body = username;
           }
 
+          final parsedType = notificationType != null
+              ? NotificationType.fromId(notificationType)
+              : null;
           await LocalNotificationService().show(
             title: title,
             body: body,
             topicId: topicId,
             postNumber: postNumber,
+            isPrivateMessage:
+                parsedType == NotificationType.privateMessage ||
+                parsedType == NotificationType.invitedToPrivateMessage,
           );
         }
       }

--- a/lib/services/discourse/_drafts.dart
+++ b/lib/services/discourse/_drafts.dart
@@ -91,9 +91,14 @@ mixin _DraftsMixin on _DiscourseServiceBase {
         '/drafts/$draftKey.json',
         queryParameters: {'sequence': sequence},
       );
+      // 发送/舍弃都经这里 —— 通知草稿列表把这条去掉（见 DraftsSignal）
+      DraftsSignal.notifyChanged();
     } on DioException catch (e) {
-      // 忽略 404（草稿已不存在）
-      if (e.response?.statusCode == 404) return;
+      // 忽略 404（草稿已不存在）：服务端也没有了，同样要通知
+      if (e.response?.statusCode == 404) {
+        DraftsSignal.notifyChanged();
+        return;
+      }
       _throwApiError(e);
     }
   }

--- a/lib/services/discourse/_users.dart
+++ b/lib/services/discourse/_users.dart
@@ -2,6 +2,21 @@ part of 'discourse_service.dart';
 
 /// 用户相关
 mixin _UsersMixin on _DiscourseServiceBase {
+  /// 后台用户请求走现有调度器的低优先级静默通道。
+  ///
+  /// 仍复用主站 Dio、Cookie、代理和 CF 会话，只让前台普通请求在排队时
+  /// 优先执行，避免创建第二套网络身份。
+  Options? _userRequestOptions(bool isSilent) {
+    if (!isSilent) return null;
+    return Options(
+      extra: const {
+        'isSilent': true,
+        'requestLane': 'seeking',
+        '_networkLogFields': {'requestLane': 'seeking'},
+      },
+    );
+  }
+
   /// 获取缓存的用户名
   Future<String?> getUsername() async {
     if (_username != null && _username!.isNotEmpty) return _username;
@@ -28,12 +43,12 @@ mixin _UsersMixin on _DiscourseServiceBase {
   }
 
   /// 获取用户信息
-  Future<User> getUser(String username) async {
+  Future<User> getUser(String username, {bool isSilent = false}) async {
     final activeRequest = _activeUserRequests[username];
     if (activeRequest != null) return activeRequest;
 
     late final Future<User> request;
-    request = _fetchUser(username).whenComplete(() {
+    request = _fetchUser(username, isSilent: isSilent).whenComplete(() {
       if (identical(_activeUserRequests[username], request)) {
         _activeUserRequests.remove(username);
       }
@@ -42,8 +57,11 @@ mixin _UsersMixin on _DiscourseServiceBase {
     return request;
   }
 
-  Future<User> _fetchUser(String username) async {
-    final response = await _dio.get('/u/$username.json');
+  Future<User> _fetchUser(String username, {required bool isSilent}) async {
+    final response = await _dio.get(
+      '/u/$username.json',
+      options: _userRequestOptions(isSilent),
+    );
     final data = response.data as Map<String, dynamic>;
     return User.fromJson(data['user'] ?? data);
   }
@@ -136,6 +154,7 @@ mixin _UsersMixin on _DiscourseServiceBase {
     String username, {
     String? filter,
     int offset = 0,
+    bool isSilent = false,
   }) async {
     final queryParams = <String, dynamic>{
       'username': username,
@@ -147,6 +166,7 @@ mixin _UsersMixin on _DiscourseServiceBase {
     final response = await _dio.get(
       '/user_actions.json',
       queryParameters: queryParams,
+      options: _userRequestOptions(isSilent),
     );
     return UserActionResponse.fromJson(response.data);
   }
@@ -155,6 +175,7 @@ mixin _UsersMixin on _DiscourseServiceBase {
   Future<UserReactionsResponse> getUserReactions(
     String username, {
     int? beforeReactionUserId,
+    bool isSilent = false,
   }) async {
     final queryParams = <String, dynamic>{'username': username};
     if (beforeReactionUserId != null) {
@@ -163,6 +184,7 @@ mixin _UsersMixin on _DiscourseServiceBase {
     final response = await _dio.get(
       '/discourse-reactions/posts/reactions.json',
       queryParameters: queryParams,
+      options: _userRequestOptions(isSilent),
     );
     return UserReactionsResponse.fromJson(response.data);
   }
@@ -171,12 +193,14 @@ mixin _UsersMixin on _DiscourseServiceBase {
   Future<UserBoostsResponse> getUserBoostsGiven(
     String username, {
     int? beforeBoostId,
+    bool isSilent = false,
   }) async {
     final response = await _dio.get(
       '/discourse-boosts/users/$username/boosts-given.json',
       queryParameters: beforeBoostId != null
           ? {'before_boost_id': beforeBoostId}
           : null,
+      options: _userRequestOptions(isSilent),
     );
     return UserBoostsResponse.fromJson(response.data as Map<String, dynamic>);
   }

--- a/lib/services/discourse/discourse_service.dart
+++ b/lib/services/discourse/discourse_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart' hide Category;
+import '../drafts_signal.dart';
 import 'package:flutter/material.dart' hide Badge;
 import 'dart:async';
 import 'dart:convert';

--- a/lib/services/drafts_signal.dart
+++ b/lib/services/drafts_signal.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+
+/// 草稿变更信号。
+///
+/// 草稿列表需要在**发送**或**舍弃**之后自动去掉那一条,但这两件事都不
+/// 发生在草稿页里(发送在回复框、舍弃也在回复框),页面自己无从知晓。
+///
+/// 服务层的 `deleteDraft` 恰好是两者的**唯一出口**(reply_sheet 发送成功
+/// 与主动舍弃都调它),所以在那里 bump 一次,草稿页监听即可 —— 不用轮询,
+/// 也不用给每条发帖路径都挂回调。
+class DraftsSignal {
+  DraftsSignal._();
+
+  /// 每次草稿被删除(发送/舍弃)自增。
+  static final ValueNotifier<int> revision = ValueNotifier<int>(0);
+
+  static void notifyChanged() => revision.value++;
+}

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -5,6 +5,7 @@ import '../l10n/s.dart';
 import '../navigation/nav_action_bus.dart';
 import '../pages/topic_detail_page/topic_detail_page.dart';
 import '../providers/selected_topic_provider.dart';
+import '../widgets/layout/master_detail_layout.dart';
 
 /// 全局 NavigatorKey，用于通知点击时导航
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -80,11 +81,16 @@ class LocalNotificationService {
       '[LocalNotification] 跳转到${isMessage ? "私信" : "话题"}: $topicId, 帖子: $postNumber',
     );
 
-    // 优先走平行视界(跟应用内点通知/点列表一致的左右栏表现);
-    // 拿不到 context(比如冷启动时通知先于根 widget 树就绪)才退化成
-    // 独立全屏路由——好过完全打不开。
+    // 宽屏走平行视界(跟应用内点通知/点列表一致的左右栏表现)。
+    // 两种情况退化成独立全屏路由:
+    // - 拿不到 context(冷启动时通知先于根 widget 树就绪);
+    // - 窄屏单栏——select() 写栈后没有任何东西会推出详情页
+    //   (TopicsScreen 只在宽→窄切换/tab 重新激活时补 push,已在目标
+    //   tab 上时 requestNavDestination 又是 no-op),必须直接开全屏页。
     final context = navigatorKey.currentContext;
-    if (context != null && context.mounted) {
+    if (context != null &&
+        context.mounted &&
+        MasterDetailLayout.canShowBothPanesFor(context)) {
       final container = ProviderScope.containerOf(context);
       if (isMessage) {
         container
@@ -113,6 +119,11 @@ class LocalNotificationService {
         builder: (_) => TopicDetailPage(
           topicId: topicId,
           scrollToPostNumber: postNumber,
+          // 中途拉宽窗口时自动收回对应的平行视界栈,私信必须回私信栏
+          autoSwitchToMasterDetail: true,
+          stackProvider: isMessage
+              ? selectedMessageProvider
+              : selectedTopicProvider,
         ),
       ),
     );

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/s.dart';
+import '../navigation/nav_action_bus.dart';
 import '../pages/topic_detail_page/topic_detail_page.dart';
+import '../providers/selected_topic_provider.dart';
 
 /// 全局 NavigatorKey，用于通知点击时导航
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -64,24 +67,55 @@ class LocalNotificationService {
     final payload = response.payload;
     if (payload == null || payload.isEmpty) return;
 
-    // payload 格式: "topic:{topicId}" 或 "topic:{topicId}:{postNumber}"
-    if (payload.startsWith('topic:')) {
-      final parts = payload.substring(6).split(':');
-      final topicId = int.tryParse(parts[0]);
-      final postNumber = parts.length > 1 ? int.tryParse(parts[1]) : null;
+    // payload 格式: "topic:{topicId}[:{postNumber}]" 或
+    // "message:{topicId}[:{postNumber}]"(私信,走私信平行视界栈)。
+    final isMessage = payload.startsWith('message:');
+    if (!isMessage && !payload.startsWith('topic:')) return;
+    final parts = payload.substring(isMessage ? 8 : 6).split(':');
+    final topicId = int.tryParse(parts[0]);
+    final postNumber = parts.length > 1 ? int.tryParse(parts[1]) : null;
+    if (topicId == null) return;
 
-      if (topicId != null) {
-        debugPrint('[LocalNotification] 跳转到话题: $topicId, 帖子: $postNumber');
-        navigatorKey.currentState?.push(
-          MaterialPageRoute(
-            builder: (_) => TopicDetailPage(
-              topicId: topicId,
-              scrollToPostNumber: postNumber,
-            ),
-          ),
-        );
+    debugPrint(
+      '[LocalNotification] 跳转到${isMessage ? "私信" : "话题"}: $topicId, 帖子: $postNumber',
+    );
+
+    // 优先走平行视界(跟应用内点通知/点列表一致的左右栏表现);
+    // 拿不到 context(比如冷启动时通知先于根 widget 树就绪)才退化成
+    // 独立全屏路由——好过完全打不开。
+    final context = navigatorKey.currentContext;
+    if (context != null && context.mounted) {
+      final container = ProviderScope.containerOf(context);
+      if (isMessage) {
+        container
+            .read(selectedMessageProvider.notifier)
+            .select(topicId: topicId, scrollToPostNumber: postNumber);
+        container.read(navDestinationRequestProvider.notifier).state =
+            NavDestinationRequest(
+              targetId: NavEntryIds.messages,
+              nonce: DateTime.now().millisecondsSinceEpoch,
+            );
+      } else {
+        container
+            .read(selectedTopicProvider.notifier)
+            .select(topicId: topicId, scrollToPostNumber: postNumber);
+        container.read(navDestinationRequestProvider.notifier).state =
+            NavDestinationRequest(
+              targetId: NavEntryIds.home,
+              nonce: DateTime.now().millisecondsSinceEpoch,
+            );
       }
+      return;
     }
+
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (_) => TopicDetailPage(
+          topicId: topicId,
+          scrollToPostNumber: postNumber,
+        ),
+      ),
+    );
   }
 
   /// 请求通知权限
@@ -106,6 +140,7 @@ class LocalNotificationService {
     int? id,
     int? topicId,
     int? postNumber,
+    bool isPrivateMessage = false,
   }) async {
     if (!_initialized) {
       await initialize();
@@ -135,10 +170,14 @@ class LocalNotificationService {
 
     final notificationId = id ?? DateTime.now().millisecondsSinceEpoch.remainder(100000);
     
-    // 构建 payload 用于点击回调
+    // 构建 payload 用于点击回调:私信用 message: 前缀,走私信自己的
+    // 平行视界栈,不能跟普通话题共用 topic: 前缀(否则左栏会显示信息流)。
     String? payload;
     if (topicId != null) {
-      payload = postNumber != null ? 'topic:$topicId:$postNumber' : 'topic:$topicId';
+      final prefix = isPrivateMessage ? 'message' : 'topic';
+      payload = postNumber != null
+          ? '$prefix:$topicId:$postNumber'
+          : '$prefix:$topicId';
     }
     
     await _plugin.show(id: notificationId, title: title, body: body, notificationDetails: details, payload: payload);

--- a/lib/utils/discourse_url_parser.dart
+++ b/lib/utils/discourse_url_parser.dart
@@ -4,11 +4,7 @@ class TopicLinkInfo {
   final String? slug;
   final int? postNumber;
 
-  const TopicLinkInfo({
-    required this.topicId,
-    this.slug,
-    this.postNumber,
-  });
+  const TopicLinkInfo({required this.topicId, this.slug, this.postNumber});
 }
 
 /// 用户链接解析结果
@@ -16,6 +12,13 @@ class UserLinkInfo {
   final String username;
 
   const UserLinkInfo({required this.username});
+}
+
+/// 分类链接解析结果。
+class CategoryLinkInfo {
+  const CategoryLinkInfo({required this.categoryId});
+
+  final int categoryId;
 }
 
 class DiscourseUrlParser {
@@ -41,10 +44,14 @@ class DiscourseUrlParser {
   );
 
   /// 用户链接格式：/u/username
-  static final _userRegex = RegExp(
-    r'/u/([^/?#]+)',
+  static final _userRegex = RegExp(r'/u/([^/?#]+)', caseSensitive: false);
+
+  static final _categoryRegex = RegExp(
+    r'/c/(?:[^/?#]+/)?(\d+)(?:[/?#]|$)',
     caseSensitive: false,
   );
+
+  static final _tagRegex = RegExp(r'/tag/([^/?#]+)', caseSensitive: false);
 
   /// 解析话题链接，返回 [TopicLinkInfo] 或 null
   ///
@@ -93,6 +100,26 @@ class DiscourseUrlParser {
       return UserLinkInfo(username: match.group(1)!);
     }
     return null;
+  }
+
+  static CategoryLinkInfo? parseCategory(String url) {
+    final match = _categoryRegex.firstMatch(url);
+    final id = int.tryParse(match?.group(1) ?? '');
+    return id == null ? null : CategoryLinkInfo(categoryId: id);
+  }
+
+  static String? parseTag(String url) {
+    final match = _tagRegex.firstMatch(url);
+    final encoded = match?.group(1);
+    return encoded == null ? null : Uri.decodeComponent(encoded);
+  }
+
+  static bool isHomepage(String url) {
+    final resolved = Uri.tryParse(url);
+    if (resolved == null) return false;
+    return (resolved.path.isEmpty || resolved.path == '/') &&
+        resolved.query.isEmpty &&
+        resolved.fragment.isEmpty;
   }
 
   /// 是否是用户链接（用于快速判断）

--- a/lib/utils/fluxdo_render_callbacks.dart
+++ b/lib/utils/fluxdo_render_callbacks.dart
@@ -281,7 +281,7 @@ class FluxdoRenderCallbacks {
         initialTitle: topicSlug,
         scrollToPostNumber: postNumber,
       ),
-    );
+    ));
   }
 
   // ==========================================================================

--- a/lib/utils/fluxdo_render_callbacks.dart
+++ b/lib/utils/fluxdo_render_callbacks.dart
@@ -20,10 +20,10 @@ import 'package:m3e_ui/m3e_ui.dart';
 import '../l10n/s.dart';
 import '../pages/image_viewer_page.dart';
 import '../pages/mermaid_viewer_page.dart';
-import '../pages/user_profile_page.dart';
 import '../pages/topic_detail_page/topic_detail_page.dart';
 import '../models/topic.dart' show Post, MentionedUser, LinkCount;
 import '../providers/download_provider.dart';
+import '../providers/selected_topic_provider.dart';
 import '../services/discourse/discourse_service.dart';
 import '../services/discourse_cache_manager.dart';
 import '../services/emoji_handler.dart';
@@ -255,21 +255,31 @@ class FluxdoRenderCallbacks {
     DiscourseService().trackClick(url: url, postId: postId, topicId: topicId);
   }
 
-  /// 默认内部链接点击 —— push 一个新的 TopicDetailPage。
+  /// 默认内部链接点击。
   /// 供 [linkHandler] 在调用方未定制 onInternalLinkTap 时兜底。
+  ///
+  /// 平行视界中的正文链接进入当前面板栈；普通全屏页面维持 Navigator
+  /// 跳转。必须通过 [EmbeddedStackScope.maybePushTopic]，才能同时遵守
+  /// master 预览里的“截断并替换右栏”语义。
   static void _defaultInternalLinkTap(
     BuildContext ctx,
     int topicId,
     String? topicSlug,
     int? postNumber,
   ) {
-    Navigator.of(ctx).push(
-      MaterialPageRoute(
-        builder: (_) => TopicDetailPage(
-          topicId: topicId,
-          initialTitle: topicSlug,
-          scrollToPostNumber: postNumber,
-        ),
+    if (EmbeddedStackScope.maybePushTopic(
+      ctx,
+      topicId: topicId,
+      initialTitle: topicSlug,
+      scrollToPostNumber: postNumber,
+    )) {
+      return;
+    }
+    Navigator.of(ctx).push(MaterialPageRoute(
+      builder: (_) => TopicDetailPage(
+        topicId: topicId,
+        initialTitle: topicSlug,
+        scrollToPostNumber: postNumber,
       ),
     );
   }
@@ -311,15 +321,11 @@ class FluxdoRenderCallbacks {
     return RepaintBoundary(child: image);
   };
 
-  /// Mention chip 点击 → 跳用户资料页。
+  /// Mention chip 点击 → 在当前平行视界栈或普通导航中打开用户资料。
   static MentionTapHandler get _mentionTapHandler => (ctx, username, href) {
     // 优先 href 解析(group/user 路由不同);兜底走 username
     final user = DiscourseUrlParser.parseUser(href);
-    Navigator.of(ctx).push(
-      MaterialPageRoute(
-        builder: (_) => UserProfilePage(username: user?.username ?? username),
-      ),
-    );
+    EmbeddedStackScope.openProfile(ctx, user?.username ?? username);
   };
 
   /// 代码块高亮:走 HighlighterService(mermaid 不会到这里 ——

--- a/lib/utils/frame_jank_monitor.dart
+++ b/lib/utils/frame_jank_monitor.dart
@@ -318,8 +318,12 @@ class FrameJankMonitor {
   /// 统一事件入口:打印到 Logcat 并汇入诊断时间轴。
   /// NAV 事件同时驱动掉帧行的导航归因。监控未启用时为空操作
   /// (release 关闭态零输出零开销)。
-  static void logEvent(String tag, String message) {
-    if (!_started) return;
+  static void logEvent(
+    String tag,
+    String message, {
+    bool persistWhenStopped = false,
+  }) {
+    if (!_started && !persistWhenStopped) return;
     if (tag == 'NAV') {
       _lastNav = DateTime.now();
       _lastNavDesc = message;

--- a/lib/utils/link_launcher.dart
+++ b/lib/utils/link_launcher.dart
@@ -8,12 +8,14 @@ import 'package:url_launcher/url_launcher.dart';
 import '../config/site_customization.dart';
 import '../constants.dart';
 import '../pages/image_viewer_page.dart';
-import '../pages/user_profile_page.dart';
 import '../pages/webview_page.dart';
 import '../providers/preferences_provider.dart';
+import '../providers/category_provider.dart';
+import '../providers/selected_topic_provider.dart';
 import '../services/discourse/discourse_service.dart';
 import '../widgets/common/external_link_confirm_dialog.dart';
 import '../widgets/content/discourse_html_content/image_utils.dart';
+import '../widgets/layout/home_workspace_scope.dart';
 import 'discourse_url_parser.dart';
 import 'link_security.dart';
 import 'url_helper.dart';
@@ -95,15 +97,16 @@ Future<void> launchExternalLink(BuildContext context, String url) async {
     }
   }
 
+  // 安全确认对话框关闭时，原帖子/页面可能已经被滚动回收或导航销毁。
+  if (!context.mounted) return;
+
   final prefs = ProviderScope.containerOf(
-    // ignore: use_build_context_synchronously
     context,
     listen: false,
   ).read(preferencesProvider);
   final preferInApp = prefs.openExternalLinksInAppBrowser;
 
   if (preferInApp && (uri.scheme == 'http' || uri.scheme == 'https')) {
-    // ignore: use_build_context_synchronously
     WebViewPage.open(context, url);
     return;
   }
@@ -126,28 +129,59 @@ Future<void> launchExternalLink(BuildContext context, String url) async {
 Future<void> launchContentLink(
   BuildContext context,
   String url, {
-  void Function(int topicId, String? topicSlug, int? postNumber)? onInternalLinkTap,
+  void Function(int topicId, String? topicSlug, int? postNumber)?
+  onInternalLinkTap,
   void Function(String url)? onDownloadAttachment,
 }) async {
   if (url.isEmpty) return;
   if (url.startsWith('upload://')) {
     url = await DiscourseService().resolveShortUrlForLink(url) ?? url;
+    // 短链解析期间列表项可能已离开缓存范围并被销毁，不能再使用旧 context。
+    if (!context.mounted) return;
   }
 
   // 1. 识别用户链接 /u/username
   final userInfo = DiscourseUrlParser.parseUser(url);
   if (userInfo != null && isInternalUrlString(url)) {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => UserProfilePage(username: userInfo.username)),
-    );
+    EmbeddedStackScope.openProfile(context, userInfo.username);
     return;
+  }
+
+  // 首页平行视界中的站点首页、分类和标签链接直接替换左栏，不再打开
+  // WebView。正文链接与话题头部 Badge 使用同一套行为。
+  final workspace = HomeWorkspaceScope.maybeOf(context);
+  if (workspace != null && isInternalUrlString(url)) {
+    if (DiscourseUrlParser.isHomepage(url)) {
+      workspace.onShowFeed();
+      return;
+    }
+    final categoryInfo = DiscourseUrlParser.parseCategory(url);
+    if (categoryInfo != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final category = container
+          .read(categoryMapProvider)
+          .value?[categoryInfo.categoryId];
+      if (category != null) {
+        workspace.onShowCategory(category);
+        return;
+      }
+    }
+    final tag = DiscourseUrlParser.parseTag(url);
+    if (tag != null && tag.isNotEmpty) {
+      workspace.onShowTag(tag);
+      return;
+    }
   }
 
   // 2. 解析话题链接
   final topicInfo = DiscourseUrlParser.parseTopic(url);
   if (topicInfo != null && isInternalUrlString(url)) {
     if (onInternalLinkTap != null) {
-      onInternalLinkTap(topicInfo.topicId, topicInfo.slug, topicInfo.postNumber);
+      onInternalLinkTap(
+        topicInfo.topicId,
+        topicInfo.slug,
+        topicInfo.postNumber,
+      );
       return;
     }
     // 没有回调时用 WebView 打开
@@ -214,10 +248,9 @@ Future<bool> launchInExternalBrowser(String url) async {
 
   if (Platform.isAndroid) {
     try {
-      final result = await _browserChannel.invokeMethod<bool>(
-        'openInBrowser',
-        {'url': url},
-      );
+      final result = await _browserChannel.invokeMethod<bool>('openInBrowser', {
+        'url': url,
+      });
       return result ?? false;
     } catch (e) {
       debugPrint('[LinkLauncher] Failed to launch browser: $e');

--- a/lib/utils/notification_navigation.dart
+++ b/lib/utils/notification_navigation.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/notification.dart';
+import '../navigation/nav_action_bus.dart';
 import '../providers/discourse_providers.dart';
-import '../pages/topic_detail_page/topic_detail_page.dart';
-import '../pages/user_profile_page.dart';
+import '../providers/selected_topic_provider.dart';
 import '../pages/badge_page.dart';
 import '../services/local_notification_service.dart';
 
@@ -14,6 +14,38 @@ NavigatorState? _rootNavigator(BuildContext context) {
 
 void _pushOnRootNavigator(BuildContext context, Widget page) {
   _rootNavigator(context)?.push(MaterialPageRoute(builder: (_) => page));
+}
+
+void _showHomeWorkspace(BuildContext context, WidgetRef ref) {
+  ref.requestNavDestination(NavEntryIds.home);
+  final route = ModalRoute.of(context);
+  final navigator = _rootNavigator(context);
+  // “全部通知”是盖在主工作区上的独立路由，需要移除；快捷通知面板只是
+  // OverlayEntry，根路由本身不可 pop，不会误关主页。
+  if (route?.isCurrent == true && navigator?.canPop() == true) {
+    navigator!.pop();
+  }
+}
+
+void _openTopicInWorkspace(
+  BuildContext context,
+  WidgetRef ref, {
+  required int topicId,
+  int? postNumber,
+  String? highlightBoostUsername,
+  int? initialRevisionPostNumber,
+  int? initialRevisionNumber,
+}) {
+  ref
+      .read(selectedTopicProvider.notifier)
+      .select(
+        topicId: topicId,
+        scrollToPostNumber: postNumber,
+        highlightBoostUsername: highlightBoostUsername,
+        initialRevisionPostNumber: initialRevisionPostNumber,
+        initialRevisionNumber: initialRevisionNumber,
+      );
+  _showHomeWorkspace(context, ref);
 }
 
 /// 处理通知点击：标记已读 + 按类型跳转
@@ -42,10 +74,10 @@ void handleNotificationTap(
     case NotificationType.inviteeAccepted:
     case NotificationType.following:
       if (notification.username != null) {
-        _pushOnRootNavigator(
-          context,
-          UserProfilePage(username: notification.username!),
-        );
+        ref
+            .read(selectedTopicProvider.notifier)
+            .selectProfile(notification.username!);
+        _showHomeWorkspace(context, ref);
       }
       break;
 
@@ -68,13 +100,12 @@ void handleNotificationTap(
 
     case NotificationType.boost:
       if (notification.topicId != null) {
-        _pushOnRootNavigator(
+        _openTopicInWorkspace(
           context,
-          TopicDetailPage(
-            topicId: notification.topicId!,
-            scrollToPostNumber: notification.postNumber,
-            highlightBoostUsername: notification.data.displayUsername,
-          ),
+          ref,
+          topicId: notification.topicId!,
+          postNumber: notification.postNumber,
+          highlightBoostUsername: notification.data.displayUsername,
         );
       }
       break;
@@ -83,26 +114,24 @@ void handleNotificationTap(
       // 帖子被编辑通知:跳转到对应话题 + 打开编辑历史 modal 到指定 revision。
       // 对齐 discourse 网页版 `edited.js` 的 `setLastEditNotificationClick` 逻辑。
       if (notification.topicId != null) {
-        _pushOnRootNavigator(
+        _openTopicInWorkspace(
           context,
-          TopicDetailPage(
-            topicId: notification.topicId!,
-            scrollToPostNumber: notification.postNumber,
-            initialRevisionPostNumber: notification.postNumber,
-            initialRevisionNumber: notification.data.revisionNumber,
-          ),
+          ref,
+          topicId: notification.topicId!,
+          postNumber: notification.postNumber,
+          initialRevisionPostNumber: notification.postNumber,
+          initialRevisionNumber: notification.data.revisionNumber,
         );
       }
       break;
 
     default:
       if (notification.topicId != null) {
-        _pushOnRootNavigator(
+        _openTopicInWorkspace(
           context,
-          TopicDetailPage(
-            topicId: notification.topicId!,
-            scrollToPostNumber: notification.postNumber,
-          ),
+          ref,
+          topicId: notification.topicId!,
+          postNumber: notification.postNumber,
         );
       }
       break;

--- a/lib/utils/notification_navigation.dart
+++ b/lib/utils/notification_navigation.dart
@@ -7,7 +7,10 @@ import '../providers/discourse_providers.dart';
 import '../providers/selected_topic_provider.dart';
 import '../providers/topic_detail_provider.dart';
 import '../pages/badge_page.dart';
+import '../pages/topic_detail_page/topic_detail_page.dart';
+import '../pages/user_profile_page.dart';
 import '../services/local_notification_service.dart';
+import '../widgets/layout/master_detail_layout.dart';
 
 NavigatorState? _rootNavigator(BuildContext context) {
   return navigatorKey.currentState ??
@@ -33,6 +36,14 @@ void _showHomeWorkspace(BuildContext context, WidgetRef ref) {
   _showWorkspace(context, ref, NavEntryIds.home);
 }
 
+/// 窄屏（单栏）没有「工作区栈写入 → 打开全屏详情」这座桥：TopicsScreen
+/// 只在宽→窄布局切换或 tab 重新激活时才补 push 全屏路由，而已经在目标
+/// tab 上时 [NavActionDispatch.requestNavDestination] 是 no-op——select()
+/// 只会静默写栈，用户看不到任何跳转。所以窄屏必须走全屏路由入口，
+/// 只有真能同屏摆下双栏时才交给平行视界栈。
+bool _useWorkspaceNavigation(BuildContext context) =>
+    MasterDetailLayout.canShowBothPanesFor(context);
+
 /// 私信类通知专用:走 [selectedMessageProvider]（私信栏自己的平行视界栈），
 /// 并切到"私信" tab——不能像普通话题通知那样落进 [selectedTopicProvider]/
 /// 首页信息流栈，否则左栏会显示信息流而不是私信列表，跟从私信列表点进去
@@ -44,6 +55,20 @@ void _openMessageInWorkspace(
   int? postNumber,
   String? instanceId,
 }) {
+  if (!_useWorkspaceNavigation(context)) {
+    _pushOnRootNavigator(
+      context,
+      TopicDetailPage(
+        topicId: topicId,
+        scrollToPostNumber: postNumber,
+        instanceId: instanceId,
+        // 中途拉宽窗口时自动收回私信栏的平行视界，而不是留在全屏页
+        autoSwitchToMasterDetail: true,
+        stackProvider: selectedMessageProvider,
+      ),
+    );
+    return;
+  }
   ref
       .read(selectedMessageProvider.notifier)
       .select(
@@ -97,6 +122,22 @@ Future<void> _openTopicOrMessageInWorkspace(
     return;
   }
 
+  if (!_useWorkspaceNavigation(context)) {
+    _pushOnRootNavigator(
+      context,
+      TopicDetailPage(
+        topicId: topicId,
+        scrollToPostNumber: postNumber,
+        instanceId: instanceId, // 命中上面预取的 topicDetailProvider 缓存
+        highlightBoostUsername: highlightBoostUsername,
+        initialRevisionPostNumber: initialRevisionPostNumber,
+        initialRevisionNumber: initialRevisionNumber,
+        autoSwitchToMasterDetail: true,
+      ),
+    );
+    return;
+  }
+
   ref
       .read(selectedTopicProvider.notifier)
       .select(
@@ -136,6 +177,13 @@ void handleNotificationTap(
     case NotificationType.inviteeAccepted:
     case NotificationType.following:
       if (notification.username != null) {
+        if (!_useWorkspaceNavigation(context)) {
+          _pushOnRootNavigator(
+            context,
+            UserProfilePage(username: notification.username!),
+          );
+          break;
+        }
         ref
             .read(selectedTopicProvider.notifier)
             .selectProfile(notification.username!);

--- a/lib/utils/notification_navigation.dart
+++ b/lib/utils/notification_navigation.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
 import '../models/notification.dart';
 import '../navigation/nav_action_bus.dart';
 import '../providers/discourse_providers.dart';
 import '../providers/selected_topic_provider.dart';
+import '../providers/topic_detail_provider.dart';
 import '../pages/badge_page.dart';
 import '../services/local_notification_service.dart';
 
@@ -16,8 +18,8 @@ void _pushOnRootNavigator(BuildContext context, Widget page) {
   _rootNavigator(context)?.push(MaterialPageRoute(builder: (_) => page));
 }
 
-void _showHomeWorkspace(BuildContext context, WidgetRef ref) {
-  ref.requestNavDestination(NavEntryIds.home);
+void _showWorkspace(BuildContext context, WidgetRef ref, String targetId) {
+  ref.requestNavDestination(targetId);
   final route = ModalRoute.of(context);
   final navigator = _rootNavigator(context);
   // “全部通知”是盖在主工作区上的独立路由，需要移除；快捷通知面板只是
@@ -27,7 +29,41 @@ void _showHomeWorkspace(BuildContext context, WidgetRef ref) {
   }
 }
 
-void _openTopicInWorkspace(
+void _showHomeWorkspace(BuildContext context, WidgetRef ref) {
+  _showWorkspace(context, ref, NavEntryIds.home);
+}
+
+/// 私信类通知专用:走 [selectedMessageProvider]（私信栏自己的平行视界栈），
+/// 并切到"私信" tab——不能像普通话题通知那样落进 [selectedTopicProvider]/
+/// 首页信息流栈，否则左栏会显示信息流而不是私信列表，跟从私信列表点进去
+/// 的表现不一致。
+void _openMessageInWorkspace(
+  BuildContext context,
+  WidgetRef ref, {
+  required int topicId,
+  int? postNumber,
+  String? instanceId,
+}) {
+  ref
+      .read(selectedMessageProvider.notifier)
+      .select(
+        topicId: topicId,
+        scrollToPostNumber: postNumber,
+        instanceId: instanceId,
+      );
+  _showWorkspace(context, ref, NavEntryIds.messages);
+}
+
+/// 通知类型本身（除 privateMessage/invitedToPrivateMessage 外）不带
+/// "这条通知挂的话题是不是私信"这个信息——posted/boost/edited/liked 等
+/// 通用类型，只要发生在私信话题下，都得走私信栏而不是信息流栈，否则
+/// 信息流的平行视界栈里会混进私信话题（连带把栈里的"上次读到这里"分界线
+/// 之类的定位逻辑也搞乱）。
+///
+/// 这里现取一次话题详情判断 [TopicDetail.isPrivateMessage]，并把生成的
+/// instanceId 一并传给 select()——真正打开的 [TopicDetailPage] 用同一个
+/// instanceId 命中 [topicDetailProvider] 的 30 秒缓存，不会二次请求。
+Future<void> _openTopicOrMessageInWorkspace(
   BuildContext context,
   WidgetRef ref, {
   required int topicId,
@@ -35,12 +71,38 @@ void _openTopicInWorkspace(
   String? highlightBoostUsername,
   int? initialRevisionPostNumber,
   int? initialRevisionNumber,
-}) {
+}) async {
+  final instanceId = const Uuid().v4();
+  var isPrivateMessage = false;
+  try {
+    final detail = await ref.read(
+      topicDetailProvider(
+        TopicDetailParams(topicId, instanceId: instanceId),
+      ).future,
+    );
+    isPrivateMessage = detail.isPrivateMessage;
+  } catch (e) {
+    debugPrint('[通知跳转] 预取话题详情失败,按普通话题处理: $e');
+  }
+  if (!context.mounted) return;
+
+  if (isPrivateMessage) {
+    _openMessageInWorkspace(
+      context,
+      ref,
+      topicId: topicId,
+      postNumber: postNumber,
+      instanceId: instanceId,
+    );
+    return;
+  }
+
   ref
       .read(selectedTopicProvider.notifier)
       .select(
         topicId: topicId,
         scrollToPostNumber: postNumber,
+        instanceId: instanceId,
         highlightBoostUsername: highlightBoostUsername,
         initialRevisionPostNumber: initialRevisionPostNumber,
         initialRevisionNumber: initialRevisionNumber,
@@ -98,9 +160,23 @@ void handleNotificationTap(
     case NotificationType.membershipRequestAccepted:
       break;
 
+    case NotificationType.privateMessage:
+    case NotificationType.invitedToPrivateMessage:
+      // 这两个类型只在"创建/受邀入私信"时发一次，能确定就是私信，不用
+      // 再多一趟话题详情请求确认 archetype。
+      if (notification.topicId != null) {
+        _openMessageInWorkspace(
+          context,
+          ref,
+          topicId: notification.topicId!,
+          postNumber: notification.postNumber,
+        );
+      }
+      break;
+
     case NotificationType.boost:
       if (notification.topicId != null) {
-        _openTopicInWorkspace(
+        _openTopicOrMessageInWorkspace(
           context,
           ref,
           topicId: notification.topicId!,
@@ -114,7 +190,7 @@ void handleNotificationTap(
       // 帖子被编辑通知:跳转到对应话题 + 打开编辑历史 modal 到指定 revision。
       // 对齐 discourse 网页版 `edited.js` 的 `setLastEditNotificationClick` 逻辑。
       if (notification.topicId != null) {
-        _openTopicInWorkspace(
+        _openTopicOrMessageInWorkspace(
           context,
           ref,
           topicId: notification.topicId!,
@@ -126,8 +202,10 @@ void handleNotificationTap(
       break;
 
     default:
+      // posted(私信内新回复)、liked、reaction 等通用类型都落在这里——
+      // 通知类型本身不带"是不是私信"的信息，必须实际查一下话题。
       if (notification.topicId != null) {
-        _openTopicInWorkspace(
+        _openTopicOrMessageInWorkspace(
           context,
           ref,
           topicId: notification.topicId!,

--- a/lib/widgets/bookmark/bookmarks_workspace_tab_bar.dart
+++ b/lib/widgets/bookmark/bookmarks_workspace_tab_bar.dart
@@ -12,6 +12,7 @@ class BookmarksWorkspaceTabBar extends StatefulWidget {
     required this.activeTabId,
     required this.topicTabs,
     required this.bookmarksLabel,
+    this.onBack,
     this.onSearchTap,
     this.isSearchMode = false,
     required this.onBookmarksTap,
@@ -23,6 +24,10 @@ class BookmarksWorkspaceTabBar extends StatefulWidget {
   final String activeTabId;
   final List<BookmarkWorkspaceTopicTab> topicTabs;
   final String bookmarksLabel;
+
+  /// 退出书签工作区(pop 整个书签页路由)。桌面工作区模式下 AppBar 被
+  /// 标签栏取代,没有它用户会被困在本页。null 时不显示返回按钮。
+  final VoidCallback? onBack;
   final VoidCallback? onSearchTap;
   final bool isSearchMode;
   final VoidCallback onBookmarksTap;
@@ -116,6 +121,17 @@ class _BookmarksWorkspaceTabBarState extends State<BookmarksWorkspaceTabBar> {
         height: 48,
         child: Row(
           children: [
+            if (widget.onBack != null)
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: IconButton(
+                  key: const ValueKey('bookmark-workspace-back-button'),
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+                  visualDensity: VisualDensity.compact,
+                  onPressed: widget.onBack,
+                  icon: const Icon(Symbols.arrow_back_rounded),
+                ),
+              ),
             Expanded(
               child: Listener(
                 key: const ValueKey('bookmark-workspace-tabs-wheel-region'),

--- a/lib/widgets/common/grain_gradient_background.dart
+++ b/lib/widgets/common/grain_gradient_background.dart
@@ -6,7 +6,10 @@ import 'package:paper_shaders/paper_shaders.dart';
 /// 包含 corners 形状的 shader 动画 + 3 层径向渐变辉光。
 /// 颜色从 [Theme.of(context).colorScheme] 动态获取。
 class GrainGradientBackground extends StatelessWidget {
-  const GrainGradientBackground({super.key});
+  const GrainGradientBackground({super.key, this.animated = true});
+
+  /// 是否持续播放 shader 动画；关闭只固定时间轴，不降低渲染质量。
+  final bool animated;
 
   @override
   Widget build(BuildContext context) {
@@ -27,6 +30,7 @@ class GrainGradientBackground extends StatelessWidget {
           softness: 1.0,
           intensity: 0.9,
           noise: 0.5,
+          animated: animated,
         ),
         // 径向渐变辉光（叠在 shader 上方）
         DecoratedBox(
@@ -34,7 +38,10 @@ class GrainGradientBackground extends StatelessWidget {
             gradient: RadialGradient(
               center: const Alignment(-0.6, -0.7),
               radius: 1.5,
-              colors: [colorScheme.primary.withValues(alpha: 0.25), colorScheme.primary.withValues(alpha: 0)],
+              colors: [
+                colorScheme.primary.withValues(alpha: 0.25),
+                colorScheme.primary.withValues(alpha: 0),
+              ],
               stops: const [0.0, 0.6],
             ),
           ),
@@ -44,7 +51,10 @@ class GrainGradientBackground extends StatelessWidget {
             gradient: RadialGradient(
               center: const Alignment(0.4, -0.5),
               radius: 1.3,
-              colors: [colorScheme.tertiary.withValues(alpha: 0.22), colorScheme.tertiary.withValues(alpha: 0)],
+              colors: [
+                colorScheme.tertiary.withValues(alpha: 0.22),
+                colorScheme.tertiary.withValues(alpha: 0),
+              ],
               stops: const [0.0, 0.55],
             ),
           ),
@@ -54,7 +64,10 @@ class GrainGradientBackground extends StatelessWidget {
             gradient: RadialGradient(
               center: const Alignment(0.1, 0.4),
               radius: 1.2,
-              colors: [colorScheme.secondary.withValues(alpha: 0.18), colorScheme.secondary.withValues(alpha: 0)],
+              colors: [
+                colorScheme.secondary.withValues(alpha: 0.18),
+                colorScheme.secondary.withValues(alpha: 0),
+              ],
               stops: const [0.0, 0.6],
             ),
           ),

--- a/lib/widgets/common/smart_avatar.dart
+++ b/lib/widgets/common/smart_avatar.dart
@@ -32,6 +32,28 @@ class SmartAvatar extends StatefulWidget {
   State<SmartAvatar> createState() => _SmartAvatarState();
 }
 
+/// linux.do 站点定制:该账号头像方形化(站点主题 CSS 规则:
+/// `img.avatar[src^=".../user_avatar/linux.do/neo/"]{border-radius:10% !important}`,
+/// 只精确针对这一个用户名,不是站点级/AI persona 通用规则)。
+/// 头像 URL 路径本身带用户名(`/user_avatar/<site>/<username>/...`),
+/// 不需要额外传 username 参数,直接从 URL 判断即可对齐。
+///
+/// 公开(而非 [SmartAvatar] 内部私有判断):凡是自己另起炉灶画头像、不走
+/// [SmartAvatar] 的地方(画布直绘的话题卡片、头像外层单独套边框/背景的
+/// 容器)都得调这个同一份判断，不然会出现"图是方的、外层裁切/边框还是圆
+/// 的"这种两层对不上的错位。
+final RegExp _avatarUsernamePattern = RegExp(r'/user_avatar/[^/]+/([^/]+)/');
+const Set<String> _squareAvatarUsernames = {'neo'};
+
+bool isSquareAvatarUrl(String? url) {
+  if (url == null || url.isEmpty) return false;
+  final username = _avatarUsernamePattern
+      .firstMatch(url)
+      ?.group(1)
+      ?.toLowerCase();
+  return username != null && _squareAvatarUsernames.contains(username);
+}
+
 class _SmartAvatarState extends State<SmartAvatar> {
   /// SVG 探测结果的全局记忆(URL → svg 内容,null = 已确认非 SVG)。
   ///
@@ -229,25 +251,36 @@ class _SmartAvatarState extends State<SmartAvatar> {
       );
     }
 
+    final isSquare = isSquareAvatarUrl(widget.imageUrl);
+    final innerDecoration = isSquare
+        ? BoxDecoration(
+            color: bgColor,
+            borderRadius: BorderRadius.circular(innerRadius * 0.2),
+          )
+        : BoxDecoration(color: bgColor, shape: BoxShape.circle);
+
     // 使用 BoxDecoration + shape: circle 确保 Hero 动画时保持圆形
     // ClipOval 在 Hero 飞行时不会被正确应用
     Widget avatar = Container(
       width: innerRadius * 2,
       height: innerRadius * 2,
-      decoration: BoxDecoration(color: bgColor, shape: BoxShape.circle),
+      decoration: innerDecoration,
       clipBehavior: Clip.antiAlias,
       child: child,
     );
 
     // 如果有边框，在外层添加，总尺寸保持 radius * 2
     if (widget.border != null) {
+      final outerDecoration = isSquare
+          ? BoxDecoration(
+              borderRadius: BorderRadius.circular(widget.radius * 0.2),
+              border: widget.border,
+            )
+          : BoxDecoration(shape: BoxShape.circle, border: widget.border);
       avatar = Container(
         width: widget.radius * 2,
         height: widget.radius * 2,
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: widget.border,
-        ),
+        decoration: outerDecoration,
         alignment: Alignment.center,
         child: avatar,
       );
@@ -273,12 +306,9 @@ class _SmartAvatarState extends State<SmartAvatar> {
     // 静态灰底占位 — 头像 loading 时间极短,
     // 用 CircularProgressIndicator 会带来 60fps 自转 + InheritedTheme 查询,
     // 在列表多头像同时占位时是热点开销。
-    return Container(
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: fgColor.withValues(alpha: 0.08),
-      ),
-    );
+    // 不在这里加自己的 shape:外层 Container 已经按圆形/方形裁切,这里
+    // 铺满矩形即可,否则方形头像 loading 时会露出"圆形补丁"的错位。
+    return Container(color: fgColor.withValues(alpha: 0.08));
   }
 
   Widget _buildFallback(Color fgColor, double radius) {

--- a/lib/widgets/content/discourse_html_content/builders/onebox/user_onebox_builder.dart
+++ b/lib/widgets/content/discourse_html_content/builders/onebox/user_onebox_builder.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
-import '../../../../../pages/user_profile_page.dart';
+import '../../../../../providers/selected_topic_provider.dart';
 import 'onebox_base.dart';
 
 /// 构建用户 onebox 卡片
@@ -40,13 +40,7 @@ Widget buildUserOnebox({
   return OneboxContainer(
     borderRadius: 12,
     onTap: username.isNotEmpty
-        ? () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => UserProfilePage(username: username),
-              ),
-            );
-          }
+        ? () => EmbeddedStackScope.openProfile(context, username)
         : null,
     child: Row(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/widgets/content/discourse_html_content/builders/policy_builder.dart
+++ b/lib/widgets/content/discourse_html_content/builders/policy_builder.dart
@@ -3,7 +3,7 @@ import 'package:app_icons/app_icons.dart';
 import 'package:html/dom.dart' as dom;
 
 import '../../../../models/topic.dart';
-import '../../../../pages/user_profile_page.dart';
+import '../../../../providers/selected_topic_provider.dart';
 import '../../../../services/discourse/discourse_service.dart';
 import '../../../../services/toast_service.dart';
 import '../../../../widgets/common/smart_avatar.dart';
@@ -474,11 +474,7 @@ class _PolicyWidgetState extends State<_PolicyWidget> {
           if (index < users.length) {
             final u = users[index];
             return GestureDetector(
-              onTap: () {
-                Navigator.of(context).push(MaterialPageRoute(
-                  builder: (_) => UserProfilePage(username: u.username),
-                ));
-              },
+              onTap: () => EmbeddedStackScope.openProfile(context, u.username),
               child: SmartAvatar(
                 imageUrl: u.getAvatarUrl(size: 48),
                 radius: 12,

--- a/lib/widgets/layout/adaptive_scaffold.dart
+++ b/lib/widgets/layout/adaptive_scaffold.dart
@@ -95,12 +95,15 @@ class AdaptiveScaffold extends ConsumerWidget {
                       CategoryShortcuts(
                         extended: extendedRail,
                         onCategorySelected: (categoryId) {
-                          // 再次点击当前板块也必须形成一次明确导航事件，让
-                          // 首页有机会从深层平行视界退回板块列表。
-                          if (sidebarCategoryController.state == categoryId) {
-                            sidebarCategoryController.state = null;
-                          }
                           sidebarCategoryController.state = categoryId;
+                          // 再次点击当前板块也必须形成一次明确导航事件（高亮
+                          // 状态 provider 同值会被去重），首页靠 tap 事件从
+                          // 深层平行视界退回板块列表。
+                          final tap = ref.read(sidebarCategoryTapProvider);
+                          ref.read(sidebarCategoryTapProvider.notifier).state = (
+                            categoryId: categoryId,
+                            nonce: (tap?.nonce ?? 0) + 1,
+                          );
                           if (selectedIndex != 0) {
                             onDestinationSelected(0);
                           }

--- a/lib/widgets/layout/adaptive_scaffold.dart
+++ b/lib/widgets/layout/adaptive_scaffold.dart
@@ -32,6 +32,7 @@ class AdaptiveScaffold extends ConsumerWidget {
     this.railLeading,
     this.railBottomLeading,
     this.extendedRail = false,
+    this.hideNavigationRail = false,
   });
 
   final int selectedIndex;
@@ -43,9 +44,14 @@ class AdaptiveScaffold extends ConsumerWidget {
   final Widget? railBottomLeading;
   final bool extendedRail;
 
+  /// 二级平行视界中两侧都属于内容页时隐藏最外层全局侧栏，释放横向空间。
+  /// 手机底栏不受影响。
+  final bool hideNavigationRail;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final showRail = Responsive.showNavigationRail(context);
+    final showRail =
+        Responsive.showNavigationRail(context) && !hideNavigationRail;
     final sidebarCategoryController = ref.read(
       activeSidebarCategoryIdProvider.notifier,
     );
@@ -137,7 +143,7 @@ class AdaptiveScaffold extends ConsumerWidget {
             ],
           ),
           floatingActionButton: floatingActionButton,
-          bottomNavigationBar: showRail
+          bottomNavigationBar: showRail || hideNavigationRail
               ? null
               : _AnimatedBottomNav(
                   selectedIndex: selectedIndex,
@@ -163,8 +169,7 @@ class AdaptiveScaffold extends ConsumerWidget {
             if (selectedIndex != 0) {
               onDestinationSelected(0);
             }
-            ref.read(currentTabCategoryIdProvider.notifier).state =
-                category.id;
+            ref.read(currentTabCategoryIdProvider.notifier).state = category.id;
           },
         ),
       ],

--- a/lib/widgets/layout/adaptive_scaffold.dart
+++ b/lib/widgets/layout/adaptive_scaffold.dart
@@ -95,6 +95,11 @@ class AdaptiveScaffold extends ConsumerWidget {
                       CategoryShortcuts(
                         extended: extendedRail,
                         onCategorySelected: (categoryId) {
+                          // 再次点击当前板块也必须形成一次明确导航事件，让
+                          // 首页有机会从深层平行视界退回板块列表。
+                          if (sidebarCategoryController.state == categoryId) {
+                            sidebarCategoryController.state = null;
+                          }
                           sidebarCategoryController.state = categoryId;
                           if (selectedIndex != 0) {
                             onDestinationSelected(0);

--- a/lib/widgets/layout/auto_restore_master_detail_route.dart
+++ b/lib/widgets/layout/auto_restore_master_detail_route.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import 'master_detail_layout.dart';
+
+/// 窄屏下临时顶替平行视界的全屏页面。
+///
+/// 窗口重新变宽后，精确移除当前临时路由，露出下方仍保留完整导航栈的
+/// Master-Detail 页面。使用 [NavigatorState.removeRoute] 而不是简单 pop，
+/// 避免临时路由上方还有用户主动打开的页面时误关掉错误的路由。
+class AutoRestoreMasterDetailRoute extends StatefulWidget {
+  const AutoRestoreMasterDetailRoute({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<AutoRestoreMasterDetailRoute> createState() =>
+      _AutoRestoreMasterDetailRouteState();
+}
+
+class _AutoRestoreMasterDetailRouteState
+    extends State<AutoRestoreMasterDetailRoute> {
+  bool _removeScheduled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final canShowBothPanes = MasterDetailLayout.canShowBothPanesFor(context);
+    if (!canShowBothPanes) {
+      _removeScheduled = false;
+      return widget.child;
+    }
+
+    if (!_removeScheduled) {
+      _removeScheduled = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final route = ModalRoute.of(context);
+        if (route == null || !route.isActive) return;
+        Navigator.of(context).removeRoute(route);
+      });
+    }
+
+    return widget.child;
+  }
+}

--- a/lib/widgets/layout/auto_restore_master_detail_route.dart
+++ b/lib/widgets/layout/auto_restore_master_detail_route.dart
@@ -8,9 +8,18 @@ import 'master_detail_layout.dart';
 /// Master-Detail 页面。使用 [NavigatorState.removeRoute] 而不是简单 pop，
 /// 避免临时路由上方还有用户主动打开的页面时误关掉错误的路由。
 class AutoRestoreMasterDetailRoute extends StatefulWidget {
-  const AutoRestoreMasterDetailRoute({super.key, required this.child});
+  const AutoRestoreMasterDetailRoute({
+    super.key,
+    required this.child,
+    this.onRestore,
+    this.masterWidth = MasterDetailLayout.defaultMasterWidth,
+    this.minDetailWidth = MasterDetailLayout.defaultMinDetailWidth,
+  });
 
   final Widget child;
+  final VoidCallback? onRestore;
+  final double masterWidth;
+  final double minDetailWidth;
 
   @override
   State<AutoRestoreMasterDetailRoute> createState() =>
@@ -23,7 +32,11 @@ class _AutoRestoreMasterDetailRouteState
 
   @override
   Widget build(BuildContext context) {
-    final canShowBothPanes = MasterDetailLayout.canShowBothPanesFor(context);
+    final canShowBothPanes = MasterDetailLayout.canShowBothPanesFor(
+      context,
+      masterWidth: widget.masterWidth,
+      minDetailWidth: widget.minDetailWidth,
+    );
     if (!canShowBothPanes) {
       _removeScheduled = false;
       return widget.child;
@@ -34,8 +47,13 @@ class _AutoRestoreMasterDetailRouteState
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         final route = ModalRoute.of(context);
-        if (route == null || !route.isActive) return;
-        Navigator.of(context).removeRoute(route);
+        if (route == null || !route.isCurrent) {
+          _removeScheduled = false;
+          return;
+        }
+        final navigator = Navigator.of(context);
+        widget.onRestore?.call();
+        if (route.isActive) navigator.removeRoute(route);
       });
     }
 

--- a/lib/widgets/layout/full_screen_pane_stack.dart
+++ b/lib/widgets/layout/full_screen_pane_stack.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/selected_topic_provider.dart';
+
+typedef FullScreenPaneBuilder =
+    Widget Function(BuildContext context, PaneEntry entry, VoidCallback onBack);
+
+/// 单栏模式下承载平行视界栈顶内容，并保持与双栏模式一致的返回语义。
+class FullScreenPaneStack extends ConsumerWidget {
+  const FullScreenPaneStack({
+    super.key,
+    required this.stackProvider,
+    required this.builder,
+  });
+
+  final SelectedTopicProvider stackProvider;
+  final FullScreenPaneBuilder builder;
+
+  void _handleBack(BuildContext context, WidgetRef ref) {
+    final selected = ref.read(stackProvider);
+    if (selected.isStacked) {
+      ref.read(stackProvider.notifier).pop();
+      return;
+    }
+    Navigator.of(context).maybePop();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = ref.watch(stackProvider);
+    final entry = selected.topEntry;
+    if (entry == null) return const SizedBox.shrink();
+
+    return PopScope(
+      canPop: !selected.isStacked,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          ref.read(stackProvider.notifier).clear();
+          return;
+        }
+        _handleBack(context, ref);
+      },
+      child: builder(context, entry, () => _handleBack(context, ref)),
+    );
+  }
+}

--- a/lib/widgets/layout/home_workspace_scope.dart
+++ b/lib/widgets/layout/home_workspace_scope.dart
@@ -16,12 +16,15 @@ class HomeWorkspaceScope extends InheritedWidget {
   final ValueChanged<Category> onShowCategory;
   final ValueChanged<String> onShowTag;
 
-  static HomeWorkspaceScope? maybeOf(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<HomeWorkspaceScope>();
+  /// 不订阅重建（一次性读取，跟 ref.read 语义一致，同 EmbeddedStackScope）：
+  /// 调用方都在点击回调里取回调用，订阅只会让宿主重建时闭包身份变化
+  /// 引发无意义的依赖重建。
+  static HomeWorkspaceScope? maybeOf(BuildContext context) {
+    final element = context
+        .getElementForInheritedWidgetOfExactType<HomeWorkspaceScope>();
+    return element?.widget as HomeWorkspaceScope?;
+  }
 
   @override
-  bool updateShouldNotify(HomeWorkspaceScope oldWidget) =>
-      onShowFeed != oldWidget.onShowFeed ||
-      onShowCategory != oldWidget.onShowCategory ||
-      onShowTag != oldWidget.onShowTag;
+  bool updateShouldNotify(HomeWorkspaceScope oldWidget) => false;
 }

--- a/lib/widgets/layout/home_workspace_scope.dart
+++ b/lib/widgets/layout/home_workspace_scope.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/widgets.dart';
+
+import '../../models/category.dart';
+
+/// 首页平行视界的左栏内容控制器。
+class HomeWorkspaceScope extends InheritedWidget {
+  const HomeWorkspaceScope({
+    super.key,
+    required this.onShowFeed,
+    required this.onShowCategory,
+    required this.onShowTag,
+    required super.child,
+  });
+
+  final VoidCallback onShowFeed;
+  final ValueChanged<Category> onShowCategory;
+  final ValueChanged<String> onShowTag;
+
+  static HomeWorkspaceScope? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<HomeWorkspaceScope>();
+
+  @override
+  bool updateShouldNotify(HomeWorkspaceScope oldWidget) =>
+      onShowFeed != oldWidget.onShowFeed ||
+      onShowCategory != oldWidget.onShowCategory ||
+      onShowTag != oldWidget.onShowTag;
+}

--- a/lib/widgets/layout/master_detail_layout.dart
+++ b/lib/widgets/layout/master_detail_layout.dart
@@ -16,6 +16,22 @@ class MasterDetailLayout extends StatefulWidget {
   static const double minMasterWidth = 280;
   static const double maxMasterWidth = 520;
 
+  /// master 栏宽度占比下限——不管 master 里放的是列表还是"平行视界"
+  /// 上一层内容，都不能拖到比这更窄。
+  static const double defaultMinMasterRatio = 0.2;
+
+  /// master 栏宽度占比上限：默认 0.3，对应 master 是真正的列表（信息流/
+  /// 私信列表）场景——列表不需要太宽。平行视界压栈时 master 显示的是
+  /// "上一层"内容（不是列表），应该放宽到接近对半分（见
+  /// [PaneMasterDetailLayout] 或调用方传更大的 maxMasterRatio，比如 0.8），
+  /// 这样才是真正的"平行视界"而不是"列表+详情"。
+  static const double defaultMaxMasterRatio = 0.3;
+
+  /// master 栏绝对最小宽度（像素）。窗口整体较窄时按比例算出的宽度可能
+  /// 只有一百来像素，头像+徽章这类定宽内容根本塞不下，会撑出 RenderFlex
+  /// 溢出条纹——所以下限必须是"比例下限"和"绝对像素下限"取较大值。
+  static const double minPaneAbsoluteWidth = 240;
+
   const MasterDetailLayout({
     super.key,
     required this.master,
@@ -25,6 +41,9 @@ class MasterDetailLayout extends StatefulWidget {
     this.masterWidth = defaultMasterWidth,
     this.minDetailWidth = defaultMinDetailWidth,
     this.showDivider = true,
+    this.minMasterRatio = defaultMinMasterRatio,
+    this.maxMasterRatio = defaultMaxMasterRatio,
+    this.preferredMasterRatio,
   });
 
   /// 主列表（左侧）
@@ -47,6 +66,20 @@ class MasterDetailLayout extends StatefulWidget {
 
   /// 是否显示分隔线
   final bool showDivider;
+
+  /// master 栏宽度占比下限（默认 20%）
+  final double minMasterRatio;
+
+  /// master 栏宽度占比上限：master 是列表时默认 30%；平行视界压栈、
+  /// master 显示"上一层"内容时调用方应传更大的值（如 0.8），允许两栏
+  /// 接近对半分。
+  final double maxMasterRatio;
+
+  /// master 栏默认宽度占比：不传时退回 [minMasterRatio]（列表场景，20%）。
+  /// 平行视界压栈、两侧都不是"列表"时调用方应传 0.5，让两栏默认对半分
+  /// （而不是只把 [maxMasterRatio] 放宽到 0.8——那只是允许用户拖到多宽，
+  /// 不代表默认就该那么宽，两者是分开的语义）。
+  final double? preferredMasterRatio;
 
   /// 是否显示双栏布局
   static bool canShowBothPanesFor(
@@ -80,6 +113,18 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
   bool _hasUserResized = false;
 
   @override
+  void didUpdateWidget(covariant MasterDetailLayout oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // master 复用同一个 State（见类注释），列表态<->压栈态切换时
+    // preferredMasterRatio 会变（0.25 <-> 0.5）。如果之前手动拖拽过一次，
+    // _hasUserResized 会一直锁定旧宽度，导致新模式的默认比例永远生效不了
+    // ——切模式时重置，让新默认值重新起作用；同一模式内的手动拖拽不受影响。
+    if (oldWidget.preferredMasterRatio != widget.preferredMasterRatio) {
+      _hasUserResized = false;
+    }
+  }
+
+  @override
   void initState() {
     super.initState();
     _currentMasterWidth = widget.masterWidth;
@@ -87,22 +132,20 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
 
   double _preferredMasterWidth(double totalWidth) {
     if (_hasUserResized) return _currentMasterWidth;
-
-    final proportionalWidth =
-        totalWidth * MasterDetailLayout.desktopMasterWidthRatio;
-    return proportionalWidth.clamp(
-      widget.masterWidth,
-      MasterDetailLayout.maxMasterWidth,
-    );
+    final ratio = widget.preferredMasterRatio ?? widget.minMasterRatio;
+    return totalWidth * ratio;
   }
 
   double _clampMasterWidth(double width, double totalWidth) {
-    final maxAllowed = totalWidth - widget.minDetailWidth;
-    final upperBound = maxAllowed.clamp(
-      MasterDetailLayout.minMasterWidth,
-      MasterDetailLayout.maxMasterWidth,
-    );
-    return width.clamp(MasterDetailLayout.minMasterWidth, upperBound);
+    final ratioLower = totalWidth * widget.minMasterRatio;
+    final lowerBound = ratioLower < MasterDetailLayout.minPaneAbsoluteWidth
+        ? MasterDetailLayout.minPaneAbsoluteWidth
+        : ratioLower;
+    final ratioUpper = totalWidth * widget.maxMasterRatio;
+    final spaceUpper = totalWidth - widget.minDetailWidth;
+    var upperBound = ratioUpper < spaceUpper ? ratioUpper : spaceUpper;
+    if (upperBound < lowerBound) upperBound = lowerBound;
+    return width.clamp(lowerBound, upperBound);
   }
 
   @override
@@ -164,12 +207,20 @@ class _MasterDetailLayoutState extends State<MasterDetailLayout> {
               child: DraggableDivider(
                 onResizeStart: () => _dragStartWidth = masterWidth,
                 onResizeUpdate: (globalX, startX) {
+                  final desired = _dragStartWidth! + (globalX - startX);
+                  final clamped = _clampMasterWidth(desired, totalWidth);
+                  // 拖拽事件频率很高（鼠标高轮询率下每秒上百次），每次都
+                  // setState 会让内容区（图片等按可用宽度算尺寸的东西）
+                  // 跟着抖动式反复重算——量化到 8px 网格，拖拽视觉上无感，
+                  // 但大幅减少宽度变化次数，避免图片频繁按新尺寸重新请求
+                  // （有 429 风险）。
+                  const snapGrid = 8.0;
+                  final snapped = (clamped / snapGrid).round() * snapGrid;
+                  if (snapped == _currentMasterWidth && _hasUserResized) {
+                    return;
+                  }
                   setState(() {
-                    final desired = _dragStartWidth! + (globalX - startX);
-                    _currentMasterWidth = _clampMasterWidth(
-                      desired,
-                      totalWidth,
-                    );
+                    _currentMasterWidth = snapped;
                     _hasUserResized = true;
                   });
                 },

--- a/lib/widgets/nested/nested_post_card.dart
+++ b/lib/widgets/nested/nested_post_card.dart
@@ -6,8 +6,8 @@ import '../../models/nested_topic.dart';
 import '../../models/topic.dart';
 import '../../providers/nested_topic_provider.dart';
 import '../../providers/preferences_provider.dart';
+import '../../providers/selected_topic_provider.dart';
 import '../../providers/topic_session_provider.dart';
-import '../../pages/user_profile_page.dart';
 import '../../utils/blocked_user_filter.dart';
 import '../../utils/fluxdo_render_callbacks.dart';
 import '../../utils/responsive.dart';
@@ -616,12 +616,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
         // 移动端内联头像（点击进主页，长按弹径向操作菜单）
         if (isMobile) ...[
           RadialLongPressMenu(
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => UserProfilePage(username: post.username),
-              ),
-            ),
+            onTap: () => EmbeddedStackScope.openProfile(context, post.username),
             itemsBuilder: () => buildAvatarMenuItems(
               context,
               username: post.username,
@@ -658,12 +653,7 @@ class _NestedPostCardState extends ConsumerState<NestedPostCard> {
         ],
         // 用户名（可点击）
         GestureDetector(
-          onTap: () => Navigator.push(
-            context,
-            MaterialPageRoute(
-              builder: (_) => UserProfilePage(username: post.username),
-            ),
-          ),
+          onTap: () => EmbeddedStackScope.openProfile(context, post.username),
           child: Text(
             post.username,
             style: theme.textTheme.labelMedium?.copyWith(

--- a/lib/widgets/post/post_boost/boost_actions.dart
+++ b/lib/widgets/post/post_boost/boost_actions.dart
@@ -3,8 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../l10n/s.dart';
 import '../../../models/topic.dart';
-import '../../../pages/user_profile_page.dart';
 import '../../../providers/discourse_providers.dart';
+import '../../../providers/selected_topic_provider.dart';
 import '../../../services/discourse/discourse_service.dart';
 import '../../../services/app_error_handler.dart';
 import '../../../services/toast_service.dart';
@@ -157,13 +157,7 @@ class BoostActions {
           postNumber: post.postNumber,
         );
       case BoostAuthorPopoverAction.profile:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (_) =>
-                UserProfilePage(username: resolvedBoost.user.username),
-          ),
-        );
+        EmbeddedStackScope.openProfile(context, resolvedBoost.user.username);
       case BoostAuthorPopoverAction.flag:
         _showFlagSheet(
           context: context,

--- a/lib/widgets/topic/painted_topic_card.dart
+++ b/lib/widgets/topic/painted_topic_card.dart
@@ -8,6 +8,7 @@ import '../../services/discourse_cache_manager.dart';
 import '../../services/emoji_handler.dart';
 import '../../utils/relative_time_clock.dart';
 import '../common/animated_avatar_overlay.dart';
+import '../common/smart_avatar.dart' show isSquareAvatarUrl;
 import 'topic_card.dart' show TopicCardInteractiveSurface;
 import 'topic_card_layout.dart';
 
@@ -218,7 +219,18 @@ class _RenderTopicCard extends RenderBox
             bucket: BlobImageCache.avatarBucket);
     if (avatar != null) {
       canvas.save();
-      canvas.clipPath(Path()..addOval(avatarRect));
+      // linux.do 站点定制:个别账号头像方形化,画布直绘不走 SmartAvatar,
+      // 得同一份 isSquareAvatarUrl 判断,不然图是方的、这里裁切还是圆的。
+      final clipPath = isSquareAvatarUrl(l.avatarUrl)
+          ? (Path()
+              ..addRRect(
+                RRect.fromRectAndRadius(
+                  avatarRect,
+                  Radius.circular(avatarRect.shortestSide * 0.1),
+                ),
+              ))
+          : (Path()..addOval(avatarRect));
+      canvas.clipPath(clipPath);
       canvas.drawImageRect(
         avatar,
         Rect.fromLTWH(0, 0, avatar.width.toDouble(), avatar.height.toDouble()),

--- a/lib/widgets/user/avatar_action_menu.dart
+++ b/lib/widgets/user/avatar_action_menu.dart
@@ -4,9 +4,9 @@ import 'package:app_icons/app_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/s.dart';
-import '../../pages/user_profile_page.dart';
 import '../../providers/discourse_providers.dart';
 import '../../providers/preferences_provider.dart';
+import '../../providers/selected_topic_provider.dart';
 import '../../services/toast_service.dart';
 import '../../utils/share_utils.dart';
 import '../common/radial_long_press_menu.dart';
@@ -88,11 +88,7 @@ List<RadialMenuItem> buildAvatarMenuItems(
     RadialMenuItem(
       icon: Symbols.account_circle_rounded,
       label: S.current.avatarMenu_viewProfile,
-      onSelected: () {
-        Navigator.of(context).push(
-          MaterialPageRoute(builder: (_) => UserProfilePage(username: username)),
-        );
-      },
+      onSelected: () => EmbeddedStackScope.openProfile(context, username),
     ),
     if (canMessage)
       RadialMenuItem(

--- a/lib/widgets/user/user_card.dart
+++ b/lib/widgets/user/user_card.dart
@@ -8,7 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../l10n/s.dart';
 import '../../models/user.dart';
 import '../../providers/discourse_providers.dart';
-import '../../pages/user_profile_page.dart';
+import '../../providers/selected_topic_provider.dart';
 import '../../services/app_error_handler.dart';
 import '../../services/discourse_cache_manager.dart';
 import '../../services/preloaded_data_service.dart';
@@ -495,9 +495,7 @@ class _UserCardContentState extends ConsumerState<_UserCardContent> {
 
   void _openProfile() {
     widget.onClose();
-    Navigator.of(widget.anchorContext).push(
-      MaterialPageRoute(builder: (_) => UserProfilePage(username: widget.username)),
-    );
+    EmbeddedStackScope.openProfile(widget.anchorContext, widget.username);
   }
 
   void _composeMessage() {

--- a/packages/paper_shaders/lib/src/grain_gradient_widget.dart
+++ b/packages/paper_shaders/lib/src/grain_gradient_widget.dart
@@ -40,6 +40,7 @@ class GrainGradient extends StatefulWidget {
     this.noise = 0.1,
     this.shape = GrainGradientShape.sphere,
     this.speed = 1.0,
+    this.animated = true,
     this.scale = 1.0,
     this.rotation = 0.0,
     this.offsetX = 0.0,
@@ -67,6 +68,12 @@ class GrainGradient extends StatefulWidget {
 
   /// 动画速度倍数
   final double speed;
+
+  /// 是否持续推进 shader 时间轴。
+  ///
+  /// 关闭后仍使用同一套 GPU shader 和噪声纹理，只固定渲染当前帧，适合
+  /// 个人主页背景等不需要常驻动画、但仍需保留完整视觉质量的场景。
+  final bool animated;
 
   /// 整体缩放 (0.01-4)
   final double scale;
@@ -98,8 +105,22 @@ class _GrainGradientState extends State<GrainGradient>
   @override
   void initState() {
     super.initState();
-    _ticker = createTicker(_onTick)..start();
+    _ticker = createTicker(_onTick);
+    if (widget.animated) {
+      _ticker.start();
+    }
     _loadResources();
+  }
+
+  @override
+  void didUpdateWidget(GrainGradient oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.animated == widget.animated) return;
+    if (widget.animated) {
+      _ticker.start();
+    } else {
+      _ticker.stop();
+    }
   }
 
   Future<void> _loadResources() async {

--- a/test/models/draft_archetype_test.dart
+++ b/test/models/draft_archetype_test.dart
@@ -1,0 +1,69 @@
+/// 草稿的私信判据。
+///
+/// 用的是 `/drafts.json` 的**真实**返回（回复一个已有私信的草稿）。
+/// 关键陷阱：`data.archetypeId` 是 `"regular"`，只有顶层 `archetype`
+/// 才是 `"private_message"` —— 拿 data 里那个判私信必然失效。
+library;
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/draft.dart';
+
+void main() {
+  // linux.do/drafts.json?offset=0&limit=30 实际返回的一行
+  const rawPmReply = '''
+{
+  "excerpt": "aaaaaaaaaaaaa",
+  "created_at": "2026-07-20T11:35:47.259Z",
+  "draft_key": "topic_2612595",
+  "sequence": 577,
+  "avatar_template": "/user_avatar/linux.do/is_hp/{size}/836735_2.png",
+  "data": "{\\"reply\\":\\"aaaaaaaaaaaaa\\",\\"action\\":\\"reply\\",\\"categoryId\\":null,\\"tags\\":[],\\"archetypeId\\":\\"regular\\",\\"composerTime\\":2911,\\"typingTime\\":400}",
+  "topic_id": 2612595,
+  "username": "is_hp",
+  "title": "Let's chat!ver5.0",
+  "archetype": "private_message"
+}
+''';
+
+  test('回复已有私信:顶层 archetype 认私信,data.archetypeId 是 regular', () {
+    final d = Draft.fromJson(jsonDecode(rawPmReply) as Map<String, dynamic>);
+
+    expect(d.archetype, 'private_message');
+    expect(d.isPrivateMessage, isTrue);
+    expect(d.topicId, 2612595);
+
+    // 这一条是**反例护栏**:说明为什么不能用 data.archetypeId
+    expect(d.data.archetypeId, 'regular',
+        reason: 'composer 原型对私信回复也是 regular —— 拿它判私信会漏判');
+  });
+
+  test('普通话题回复:不是私信', () {
+    final d = Draft.fromJson({
+      'draft_key': 'topic_123',
+      'topic_id': 123,
+      'data': '{"reply":"x","archetypeId":"regular"}',
+      'archetype': 'regular',
+    });
+    expect(d.isPrivateMessage, isFalse);
+  });
+
+  test('顶层 archetype 缺失:不误判成私信', () {
+    final d = Draft.fromJson({
+      'draft_key': 'topic_123',
+      'topic_id': 123,
+      'data': '{"reply":"x"}',
+    });
+    expect(d.archetype, isNull);
+    expect(d.isPrivateMessage, isFalse);
+  });
+
+  test('新建私信草稿:按 key 前缀也认', () {
+    final d = Draft.fromJson({
+      'draft_key': 'new_private_message_1737000000000',
+      'data': '{"reply":"x","recipients":["a"]}',
+    });
+    expect(d.isPrivateMessage, isTrue);
+  });
+}

--- a/test/models/seeking_test.dart
+++ b/test/models/seeking_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/models/seeking.dart';
+import 'package:fluxdo/models/user_action.dart';
+import 'package:fluxdo/providers/seeking_provider.dart';
+
+void main() {
+  group('SeekingState', () {
+    test('合并多名用户动态后按时间倒序排列', () {
+      final state = SeekingState(
+        data: {
+          'alice': [
+            SeekingActivity(
+              uid: 'alice-old',
+              username: 'alice',
+              type: SeekingActivityType.reply,
+              topicId: 1,
+              title: '较早动态',
+              createdAt: DateTime.utc(2026, 7, 16, 1),
+            ),
+          ],
+          'bob': [
+            SeekingActivity(
+              uid: 'bob-new',
+              username: 'bob',
+              type: SeekingActivityType.post,
+              topicId: 2,
+              title: '最新动态',
+              createdAt: DateTime.utc(2026, 7, 16, 3),
+            ),
+            SeekingActivity(
+              uid: 'bob-middle',
+              username: 'bob',
+              type: SeekingActivityType.like,
+              topicId: 3,
+              title: '中间动态',
+              createdAt: DateTime.utc(2026, 7, 16, 2),
+            ),
+          ],
+        },
+      );
+
+      expect(state.timeline.map((activity) => activity.uid), [
+        'bob-new',
+        'bob-middle',
+        'alice-old',
+      ]);
+    });
+  });
+
+  group('SeekingActivity', () {
+    test('将用户操作映射为对应的追觅动态类型', () {
+      SeekingActivity fromAction(int actionType) {
+        return SeekingActivity.fromUserAction(
+          'alice',
+          UserAction(
+            actionType: actionType,
+            topicId: 42,
+            postNumber: 3,
+            title: '测试话题',
+          ),
+        );
+      }
+
+      expect(
+        fromAction(UserActionType.newTopic).type,
+        SeekingActivityType.post,
+      );
+      expect(fromAction(UserActionType.like).type, SeekingActivityType.like);
+      expect(fromAction(UserActionType.reply).type, SeekingActivityType.reply);
+    });
+  });
+}

--- a/test/pages/parallel_pages_test.dart
+++ b/test/pages/parallel_pages_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/pages/search_page.dart';
+import 'package:fluxdo/pages/settings_page.dart';
+
+Widget _layoutProbe(Size size) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(size: size),
+      child: Builder(
+        builder: (context) => Column(
+          children: [
+            Text('search:${SearchPage.canShowParallelFor(context)}'),
+            Text('settings:${SettingsPage.canShowParallelFor(context)}'),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  test('搜索框标准化无协议的 L 站链接', () {
+    expect(
+      normalizeDirectSearchLink('linux.do/t/topic/123/4'),
+      'https://linux.do/t/topic/123/4',
+    );
+    expect(
+      normalizeDirectSearchLink('www.linux.do/u/alice'),
+      'https://www.linux.do/u/alice',
+    );
+    expect(normalizeDirectSearchLink('/t/123'), '/t/123');
+    expect(normalizeDirectSearchLink('普通关键词'), '普通关键词');
+  });
+
+  testWidgets('宽屏搜索与设置启用平行视界', (tester) async {
+    await tester.pumpWidget(_layoutProbe(const Size(1280, 800)));
+
+    expect(find.text('search:true'), findsOneWidget);
+    expect(find.text('settings:true'), findsOneWidget);
+  });
+
+  testWidgets('窄屏搜索与设置保持单页导航', (tester) async {
+    await tester.pumpWidget(_layoutProbe(const Size(700, 800)));
+
+    expect(find.text('search:false'), findsOneWidget);
+    expect(find.text('settings:false'), findsOneWidget);
+  });
+}

--- a/test/providers/selected_topic_provider_test.dart
+++ b/test/providers/selected_topic_provider_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluxdo/providers/selected_topic_provider.dart';
+
+void main() {
+  test('从列表选中的首层会立即绑定稳定 instanceId', () {
+    final notifier = SelectedTopicNotifier()..select(topicId: 1);
+    final instanceId = notifier.state.instanceId;
+
+    expect(instanceId, isNotNull);
+
+    notifier.push(topicId: 2);
+
+    expect(notifier.state.stack.first.instanceId, instanceId);
+  });
+
+  test('同一话题的不同面板实例分别保存浏览位置', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    const first = (topicId: 1, instanceId: 'first');
+    const second = (topicId: 1, instanceId: 'second');
+
+    container.read(detailScrollPositionProvider(first).notifier).state = 120;
+
+    expect(container.read(detailScrollPositionProvider(first)), 120);
+    expect(container.read(detailScrollPositionProvider(second)), isNull);
+  });
+
+  group('SelectedTopicNotifier.updateTopTopic', () {
+    test('更新栈顶话题时保留此前的平行视界历史', () {
+      final notifier = SelectedTopicNotifier()
+        ..select(topicId: 1, initialTitle: '第一层')
+        ..pushProfile('alice')
+        ..push(topicId: 2, initialTitle: '旧标题');
+
+      notifier.updateTopTopic(
+        topicId: 2,
+        initialTitle: '新标题',
+        scrollToPostNumber: 42,
+        instanceId: 'instance-2',
+      );
+
+      expect(notifier.state.stack, hasLength(3));
+      expect(notifier.state.stack[0].topicId, 1);
+      expect(notifier.state.stack[1].username, 'alice');
+      expect(notifier.state.topEntry?.topicId, 2);
+      expect(notifier.state.topEntry?.initialTitle, '新标题');
+      expect(notifier.state.topEntry?.scrollToPostNumber, 42);
+      expect(notifier.state.topEntry?.instanceId, 'instance-2');
+    });
+
+    test('栈顶不是目标话题时不修改状态', () {
+      final notifier = SelectedTopicNotifier()
+        ..select(topicId: 1)
+        ..pushProfile('alice');
+      final before = notifier.state;
+
+      notifier.updateTopTopic(topicId: 1, scrollToPostNumber: 9);
+
+      expect(notifier.state, same(before));
+    });
+  });
+
+  test('切换左栏时仅保留当前栈顶详情', () {
+    final notifier = SelectedTopicNotifier()
+      ..select(topicId: 1)
+      ..pushProfile('alice')
+      ..push(topicId: 2);
+
+    notifier.collapseToTop();
+
+    expect(notifier.state.stack, hasLength(1));
+    expect(notifier.state.topicId, 2);
+    expect(notifier.state.isStacked, isFalse);
+  });
+
+  test('追觅平行视界与首页、搜索栈相互隔离', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(selectedSeekingProvider.notifier).select(topicId: 99);
+
+    expect(container.read(selectedSeekingProvider).topicId, 99);
+    expect(container.read(selectedTopicProvider).hasSelection, isFalse);
+    expect(container.read(selectedSearchProvider).hasSelection, isFalse);
+  });
+
+  testWidgets('EmbeddedStackScope 将资料页话题入口压入当前面板栈', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: EmbeddedStackScope(
+            stackProvider: selectedMessageProvider,
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => EmbeddedStackScope.maybePushTopic(
+                  context,
+                  topicId: 42,
+                  initialTitle: '资料页话题',
+                  scrollToPostNumber: 7,
+                ),
+                child: const Text('打开话题'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开话题'));
+
+    final state = container.read(selectedMessageProvider);
+    expect(state.stack, hasLength(1));
+    expect(state.topicId, 42);
+    expect(state.initialTitle, '资料页话题');
+    expect(state.scrollToPostNumber, 7);
+    expect(container.read(selectedTopicProvider).hasSelection, isFalse);
+  });
+}

--- a/test/utils/discourse_url_parser_test.dart
+++ b/test/utils/discourse_url_parser_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/utils/discourse_url_parser.dart';
+
+void main() {
+  group('平行视界左栏链接解析', () {
+    test('解析分类 ID', () {
+      expect(DiscourseUrlParser.parseCategory('/c/develop/42')?.categoryId, 42);
+      expect(DiscourseUrlParser.parseCategory('/c/42')?.categoryId, 42);
+    });
+
+    test('解析并解码标签', () {
+      expect(DiscourseUrlParser.parseTag('/tag/flutter'), 'flutter');
+      expect(DiscourseUrlParser.parseTag('/tag/%E4%B8%AD%E6%96%87'), '中文');
+    });
+
+    test('只把真正的站点根路径识别为首页', () {
+      expect(DiscourseUrlParser.isHomepage('/'), isTrue);
+      expect(DiscourseUrlParser.isHomepage('https://linux.do/'), isTrue);
+      expect(DiscourseUrlParser.isHomepage('/latest'), isFalse);
+    });
+  });
+}

--- a/test/utils/fluxdo_render_parallel_navigation_test.dart
+++ b/test/utils/fluxdo_render_parallel_navigation_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/providers/selected_topic_provider.dart';
+import 'package:fluxdo/utils/fluxdo_render_callbacks.dart';
+
+void main() {
+  testWidgets('正文站内链接压入当前平行视界栈', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedMessageProvider.notifier).select(topicId: 1);
+    final callbacks = FluxdoRenderCallbacks.generic(
+      heroTagNamespace: 'parallel_link_test',
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: EmbeddedStackScope(
+            stackProvider: selectedMessageProvider,
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => callbacks.linkHandler(
+                  context,
+                  'https://linux.do/t/topic/42/7',
+                ),
+                child: const Text('打开站内链接'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开站内链接'));
+    await tester.pump();
+
+    final state = container.read(selectedMessageProvider);
+    expect(state.stack, hasLength(2));
+    expect(state.topicId, 42);
+    expect(state.scrollToPostNumber, 7);
+    expect(container.read(selectedTopicProvider).hasSelection, isFalse);
+  });
+
+  testWidgets('master 预览里的正文链接替换右栏而不继续叠层', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedTopicProvider.notifier).select(topicId: 1);
+    container.read(selectedTopicProvider.notifier)
+      ..pushProfile('alice')
+      ..push(topicId: 2);
+    final callbacks = FluxdoRenderCallbacks.generic(
+      heroTagNamespace: 'parallel_truncate_test',
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: EmbeddedStackScope(
+            stackProvider: selectedTopicProvider,
+            truncateOnPush: true,
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => callbacks.linkHandler(
+                  context,
+                  'https://linux.do/t/topic/99',
+                ),
+                child: const Text('替换右栏'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('替换右栏'));
+    await tester.pump();
+
+    final state = container.read(selectedTopicProvider);
+    expect(state.stack, hasLength(3));
+    expect(state.stack[0].topicId, 1);
+    expect(state.stack[1].username, 'alice');
+    expect(state.stack[2].topicId, 99);
+  });
+
+  testWidgets('@提及在当前平行视界栈打开用户资料', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedSeekingProvider.notifier).select(topicId: 1);
+    final callbacks = FluxdoRenderCallbacks.generic(
+      heroTagNamespace: 'parallel_mention_test',
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: EmbeddedStackScope(
+            stackProvider: selectedSeekingProvider,
+            child: Builder(
+              builder: (context) => TextButton(
+                onPressed: () => callbacks.mentionTapHandler(
+                  context,
+                  'fallback',
+                  '/u/alice',
+                ),
+                child: const Text('打开提及用户'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('打开提及用户'));
+    await tester.pump();
+
+    final state = container.read(selectedSeekingProvider);
+    expect(state.stack, hasLength(2));
+    expect(state.kind, PaneKind.profile);
+    expect(state.username, 'alice');
+    expect(container.read(selectedTopicProvider).hasSelection, isFalse);
+  });
+}

--- a/test/widgets/layout/adaptive_scaffold_test.dart
+++ b/test/widgets/layout/adaptive_scaffold_test.dart
@@ -8,7 +8,7 @@ import 'package:fluxdo/widgets/layout/adaptive_scaffold.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  testWidgets('手机端 barVisibility 为 0 时隐藏底部导航栏', (tester) async {
+  testWidgets('手机端 barVisibility 为 0 时将底部导航栏平移出屏', (tester) async {
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.binding.setSurfaceSize(const Size(390, 844));
 
@@ -50,12 +50,27 @@ void main() {
       ),
     );
 
-    expect(find.byType(NavigationBar), findsNothing);
+    final bottomNavTranslation = find.byWidgetPredicate(
+      (widget) =>
+          widget is FractionalTranslation &&
+          widget.child is AdaptiveBottomNavigation,
+    );
+
+    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(bottomNavTranslation, findsOneWidget);
+    expect(
+      tester.widget<FractionalTranslation>(bottomNavTranslation).translation,
+      const Offset(0, 1),
+    );
 
     container.read(barVisibilityProvider.notifier).state = 1;
     await tester.pumpAndSettle();
 
     expect(find.byType(NavigationBar), findsOneWidget);
+    expect(
+      tester.widget<FractionalTranslation>(bottomNavTranslation).translation,
+      Offset.zero,
+    );
   });
 
   testWidgets('横屏二级平行视界隐藏全局侧栏', (tester) async {

--- a/test/widgets/layout/adaptive_scaffold_test.dart
+++ b/test/widgets/layout/adaptive_scaffold_test.dart
@@ -57,4 +57,51 @@ void main() {
 
     expect(find.byType(NavigationBar), findsOneWidget);
   });
+
+  testWidgets('横屏二级平行视界隐藏全局侧栏', (tester) async {
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.binding.setSurfaceSize(const Size(1400, 900));
+
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(1400, 900)),
+            child: AdaptiveScaffold(
+              selectedIndex: 0,
+              onDestinationSelected: (_) {},
+              hideNavigationRail: true,
+              destinations: const [
+                AdaptiveDestination(
+                  id: 'home',
+                  icon: Icon(Icons.home_outlined),
+                  selectedIcon: Icon(Icons.home),
+                  label: '首页',
+                ),
+                AdaptiveDestination(
+                  id: 'messages',
+                  icon: Icon(Icons.mail_outline),
+                  selectedIcon: Icon(Icons.mail),
+                  label: '私信',
+                ),
+              ],
+              body: const SizedBox.expand(child: Text('平行视界内容')),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(AdaptiveNavigationRail), findsNothing);
+    expect(find.byType(NavigationBar), findsNothing);
+    expect(find.text('平行视界内容'), findsOneWidget);
+  });
 }

--- a/test/widgets/layout/auto_restore_master_detail_route_test.dart
+++ b/test/widgets/layout/auto_restore_master_detail_route_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fluxdo/widgets/layout/auto_restore_master_detail_route.dart';
 
 void main() {
-  testWidgets('窗口恢复宽屏后移除临时全屏路由', (tester) async {
+  testWidgets('窗口恢复宽屏后移除话题与资料临时路由', (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(600, 800);
     addTearDown(tester.view.reset);
@@ -16,10 +16,21 @@ void main() {
       ),
     );
 
+    final topicRoute = MaterialPageRoute<void>(
+      builder: (_) => const Scaffold(body: Text('临时全屏话题页')),
+    );
+    navigatorKey.currentState!.push(topicRoute);
+    await tester.pumpAndSettle();
+
+    var restoreCount = 0;
     navigatorKey.currentState!.push(
       MaterialPageRoute<void>(
-        builder: (_) => const AutoRestoreMasterDetailRoute(
-          child: Scaffold(body: Text('临时全屏资料页')),
+        builder: (_) => AutoRestoreMasterDetailRoute(
+          onRestore: () {
+            restoreCount++;
+            navigatorKey.currentState!.removeRoute(topicRoute);
+          },
+          child: const Scaffold(body: Text('临时全屏资料页')),
         ),
       ),
     );
@@ -30,6 +41,52 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('临时全屏资料页'), findsNothing);
+    expect(find.text('临时全屏话题页'), findsNothing);
     expect(find.text('平行视界主页'), findsOneWidget);
+    expect(restoreCount, 1);
+  });
+
+  testWidgets('被上层页面覆盖时等待顶层页面返回后再恢复', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(600, 800);
+    addTearDown(tester.view.reset);
+
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('平行视界主页')),
+      ),
+    );
+
+    var restoreCount = 0;
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => AutoRestoreMasterDetailRoute(
+          onRestore: () => restoreCount++,
+          child: const Scaffold(body: Text('被覆盖的临时页')),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => const Scaffold(body: Text('顶层页面')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    tester.view.physicalSize = const Size(1200, 800);
+    await tester.pumpAndSettle();
+
+    expect(find.text('顶层页面'), findsOneWidget);
+    expect(restoreCount, 0);
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('被覆盖的临时页'), findsNothing);
+    expect(find.text('平行视界主页'), findsOneWidget);
+    expect(restoreCount, 1);
   });
 }

--- a/test/widgets/layout/auto_restore_master_detail_route_test.dart
+++ b/test/widgets/layout/auto_restore_master_detail_route_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/widgets/layout/auto_restore_master_detail_route.dart';
+
+void main() {
+  testWidgets('窗口恢复宽屏后移除临时全屏路由', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(600, 800);
+    addTearDown(tester.view.reset);
+
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: const Scaffold(body: Text('平行视界主页')),
+      ),
+    );
+
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => const AutoRestoreMasterDetailRoute(
+          child: Scaffold(body: Text('临时全屏资料页')),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('临时全屏资料页'), findsOneWidget);
+
+    tester.view.physicalSize = const Size(1200, 800);
+    await tester.pumpAndSettle();
+
+    expect(find.text('临时全屏资料页'), findsNothing);
+    expect(find.text('平行视界主页'), findsOneWidget);
+  });
+}

--- a/test/widgets/layout/full_screen_pane_stack_test.dart
+++ b/test/widgets/layout/full_screen_pane_stack_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/providers/selected_topic_provider.dart';
+import 'package:fluxdo/widgets/layout/auto_restore_master_detail_route.dart';
+import 'package:fluxdo/widgets/layout/full_screen_pane_stack.dart';
+
+void main() {
+  testWidgets('单栏返回逐层退出平行视界栈', (tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedSeekingProvider.notifier)
+      ..select(topicId: 1, instanceId: 'topic-1')
+      ..pushProfile('alice');
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('追觅主页')),
+        ),
+      ),
+    );
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(builder: (_) => _buildPaneStack()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('profile:alice'), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('topic:1'), findsOneWidget);
+    expect(container.read(selectedSeekingProvider).stack, hasLength(1));
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('追觅主页'), findsOneWidget);
+    expect(container.read(selectedSeekingProvider).stack, isEmpty);
+  });
+
+  testWidgets('达到追觅双栏阈值后自动恢复且保留平行视界栈', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(800, 800);
+    addTearDown(tester.view.reset);
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    container.read(selectedSeekingProvider.notifier)
+      ..select(topicId: 1, instanceId: 'topic-1')
+      ..pushProfile('alice');
+    final navigatorKey = GlobalKey<NavigatorState>();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: const Scaffold(body: Text('追觅主页')),
+        ),
+      ),
+    );
+    navigatorKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (_) => AutoRestoreMasterDetailRoute(
+          masterWidth: 440,
+          minDetailWidth: 480,
+          child: _buildPaneStack(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('profile:alice'), findsOneWidget);
+
+    tester.view.physicalSize = const Size(850, 800);
+    await tester.pumpAndSettle();
+
+    expect(find.text('profile:alice'), findsOneWidget);
+
+    tester.view.physicalSize = const Size(1000, 800);
+    await tester.pumpAndSettle();
+
+    expect(find.text('追觅主页'), findsOneWidget);
+    expect(container.read(selectedSeekingProvider).stack, hasLength(2));
+  });
+}
+
+Widget _buildPaneStack() {
+  return FullScreenPaneStack(
+    stackProvider: selectedSeekingProvider,
+    builder: (_, entry, onBack) => Scaffold(
+      appBar: AppBar(leading: BackButton(onPressed: onBack)),
+      body: Text('${entry.kind.name}:${entry.username ?? entry.topicId}'),
+    ),
+  );
+}

--- a/test/widgets/layout/master_detail_layout_test.dart
+++ b/test/widgets/layout/master_detail_layout_test.dart
@@ -28,7 +28,7 @@ void main() {
     );
   }
 
-  testWidgets('desktop layout widens the master pane on wide windows', (
+  testWidgets('desktop layout uses the default 20% master ratio', (
     tester,
   ) async {
     await pumpLayout(tester, width: 1600);
@@ -40,12 +40,12 @@ void main() {
       find.byKey(const ValueKey('detail-content')),
     );
 
-    expect(masterSize.width, closeTo(448, 0.1));
+    expect(masterSize.width, closeTo(320, 0.1));
     expect(detailSize.width, greaterThanOrEqualTo(400));
   });
 
   testWidgets(
-    'desktop layout keeps the existing compact width near tablet size',
+    'desktop layout keeps the absolute minimum width near tablet size',
     (tester) async {
       await pumpLayout(tester, width: 1000);
 
@@ -56,7 +56,7 @@ void main() {
         find.byKey(const ValueKey('detail-content')),
       );
 
-      expect(masterSize.width, closeTo(380, 0.1));
+      expect(masterSize.width, closeTo(240, 0.1));
       expect(detailSize.width, greaterThanOrEqualTo(400));
     },
   );
@@ -71,33 +71,29 @@ void main() {
     expect(find.byKey(const ValueKey('detail-content')), findsNothing);
   });
 
-  testWidgets('user resize sticks across window width changes', (
-    tester,
-  ) async {
+  testWidgets('user resize sticks across window width changes', (tester) async {
     await pumpLayout(tester, width: 1600);
 
-    // 初始：1600 * 0.28 = 448
-    var masterSize = tester.getSize(
-      find.byKey(const ValueKey('master-pane')),
-    );
-    expect(masterSize.width, closeTo(448, 0.1));
+    // 初始：1600 * 0.2 = 320
+    var masterSize = tester.getSize(find.byKey(const ValueKey('master-pane')));
+    expect(masterSize.width, closeTo(320, 0.1));
 
-    // 用户向右拖动 52 像素，master 调整到约 500
+    // 用户向右拖动 24 像素，master 调整到 344
     await tester.timedDrag(
       find.byType(DraggableDivider),
-      const Offset(52, 0),
+      const Offset(24, 0),
       const Duration(milliseconds: 300),
     );
     await tester.pump();
 
     masterSize = tester.getSize(find.byKey(const ValueKey('master-pane')));
-    expect(masterSize.width, closeTo(500, 1));
+    expect(masterSize.width, closeTo(344, 1));
 
-    // 缩小窗口到 1200，用户设定的 500 仍在合法范围内，应当保持
+    // 缩小窗口到 1200，用户设定的 344 仍在合法范围内，应当保持
     tester.view.physicalSize = const Size(1200, 800);
     await tester.pump();
 
     masterSize = tester.getSize(find.byKey(const ValueKey('master-pane')));
-    expect(masterSize.width, closeTo(500, 1));
+    expect(masterSize.width, closeTo(344, 1));
   });
 }


### PR DESCRIPTION
从 #336 拆出的平行视界与追觅提交。包含追觅监控、首页/搜索/设置/资料入口的平行视界、深层导航与返回、横竖屏恢复、正文链接和 @ 提及导航。
依赖 #338：本分支按原提交依赖堆叠在 Windows 分支之后；#338 合并后，本 PR 对 dev 的差异会自动收敛为 15 个平行视界提交。
验证：定向测试 20 项通过；51 个改动 Dart 文件定向分析无问题；git diff --check 通过。