### PR TITLE
🐛 修复 macOS 启动时未恢复窗口状态

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -274,7 +274,11 @@ Future<void> main() async {
     // MainPage 尚未挂载的阶段也能正常响应窗口关闭
     WindowStateService.instance.startListening();
     if (isVisible) {
-      await WindowStateService.instance.attach(prefs);
+      if (Platform.isMacOS) {
+        await WindowStateService.instance.restore(prefs);
+      } else {
+        await WindowStateService.instance.attach(prefs);
+      }
       if (Platform.isLinux) {
         await windowManager.focus();
       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -259,7 +259,9 @@ Future<void> main() async {
   // Android 由 WV onLoadStop 等 hook 主动调 notifyExternalChange()。
   CookieStoreObserver.instance.attach();
 
-  // 桌面平台：恢复窗口状态后再显示，避免默认位置闪烁
+  // 桌面平台：三端 runner 均隐藏启动（macOS 在 MainFlutterWindow 首次
+  // order 时隐藏，Windows/Linux 由 runner 创建隐藏窗口），正常冷启动都
+  // 走下方 else 分支：首帧光栅化后恢复窗口状态再显示，避免默认位置闪烁。
   if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
     await acrylic.Window.setEffect(
       effect: Platform.isMacOS
@@ -274,6 +276,10 @@ Future<void> main() async {
     // MainPage 尚未挂载的阶段也能正常响应窗口关闭
     WindowStateService.instance.startListening();
     if (isVisible) {
+      // 窗口已可见（热重启，或原生隐藏启动未生效的兜底路径）：
+      // macOS 走 restore() 读取并应用保存的窗口状态——attach() 只刷新
+      // 最大化缓存不读状态文件，曾导致 macOS 冷启动永远回到 XIB 默认
+      // 位置；Windows/Linux 可见说明状态已恢复过，attach 即可。
       if (Platform.isMacOS) {
         await WindowStateService.instance.restore(prefs);
       } else {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,8 +1,20 @@
 import Cocoa
 import FlutterMacOS
 import WebKit
+import window_manager
 
 class MainFlutterWindow: NSWindow {
+  // 隐藏启动:XIB 窗口默认 visibleAtLaunch,直接显示会先落在 XIB 默认
+  // 位置(800×600),等 Dart 端读完 window_state.json 才跳到恢复位置,
+  // 产生肉眼可见的闪跳。这里在首次 order 时立刻隐藏窗口(与 Windows/
+  // Linux runner 的隐藏启动对齐),由 Dart 端 main() 冷启动分支在首帧
+  // 光栅化后恢复位置再显示。hiddenWindowAtLaunch 内部带 configured
+  // 标记,只在首次生效,不影响后续 show/hide/Dock 唤起。
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
+  }
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame


### PR DESCRIPTION
## 问题说明

FluxDO 在 macOS 上会正常保存窗口位置、大小和最大化状态，但应用完全退出并重新启动后，窗口仍然回到 XIB 中的默认位置和 `800 × 600` 大小。

本地检查确认 `window_state.json` 已经正常写入，因此问题不在保存阶段，而在启动恢复阶段。

## 根因

窗口状态功能最初由提交 [`50726b58`](https://github.com/Lingyan000/fluxdo/commit/50726b582ccce4429f3eca8c1fad3467c9677537) 引入。在 `v0.1.55` 中，桌面端启动时会直接调用：

```dart
await WindowStateService.instance.restore(prefs);
```

随后提交 [`d0e52c56`](https://github.com/Lingyan000/fluxdo/commit/d0e52c56a60abec0200460321486d9bdac84618d) 为了修复 Windows 最大化异常，增加了窗口可见性判断：

```dart
if (isVisible) {
  await WindowStateService.instance.attach(prefs);
} else {
  await WindowStateService.instance.restore(prefs);
}
```

macOS 的主窗口由 XIB 创建，冷启动时已经处于可见状态，因此总是进入 `attach()` 分支，没有执行 `restore()`。状态文件仍会正常保存，但下次启动不会读取并应用其中的窗口位置和大小。

## 修复方式

当窗口已经可见时：

- macOS 调用现有的 `WindowStateService.restore()`；
- Windows 和 Linux 继续使用原来的 `attach()`；
- 不修改隐藏窗口的冷启动流程。

```dart
if (isVisible) {
  if (Platform.isMacOS) {
    await WindowStateService.instance.restore(prefs);
  } else {
    await WindowStateService.instance.attach(prefs);
  }
}
```

## 影响范围

- 仅修改 `lib/main.dart`
- 新增 5 行、替换 1 行
- 不增加依赖
- 不修改 XIB 和原生窗口创建流程
- 不修改窗口状态的保存格式
- 不影响 Windows、Linux、Android 和 iOS
- 保留 Windows 最大化异常修复引入的原有分支逻辑

## 验证结果

### macOS 实机验证

测试环境：macOS、Apple Silicon arm64、FluxDO Release 构建。

验证步骤：

1. 启动应用，确认窗口立即显示；
2. 移动窗口并调整大小；
3. 等待窗口状态完成防抖保存；
4. 使用 `Cmd + Q` 完全退出应用；
5. 重新启动应用。

验证结果：

- [x] 启动后窗口能够立即显示
- [x] 能够恢复上次关闭前的位置
- [x] 能够恢复上次关闭前的大小
- [x] 未出现启动后只显示 Dock 图标的问题

### 云端构建

[GitHub Actions macOS arm64 Release 构建](https://github.com/Yuv96/fluxdo/actions/runs/29678868826)通过：

- [x] Flutter macOS Release 构建成功
- [x] 主程序为 arm64
- [x] `libdoh_proxy.dylib` 为 arm64
- [x] 应用 bundle 完整
- [x] ZIP 产物生成成功

## 说明

本 PR 不包含用于测试的临时 GitHub Actions workflow、构建产物或签名配置。
