### PR TITLE
fix: Windows 剪贴板历史(Win+V)粘贴图片无反应

### DIFF
--- a/lib/utils/clipboard_image_native.dart
+++ b/lib/utils/clipboard_image_native.dart
@@ -1,0 +1,19 @@
+/// 剪贴板位图的原生兜底读取(仅 Windows 有实现)。
+///
+/// **为什么需要它**:Windows 剪贴板历史(Win+V)粘贴图片时,系统放的 OLE
+/// data object 只在 OLE 层声明标记类格式(`ClipboardHistoryItemId` /
+/// `ExcludeClipboardContentFromMonitorProcessing` / `DropDescription`),
+/// 位图挂在**原始 Win32 剪贴板**上。super_clipboard 走 `IDataObject`
+/// 枚举,于是一张位图都看不到 —— 表现为「Win+V 粘贴图片没反应」,而
+/// Chrome 这类直接读原始剪贴板的应用正常。
+///
+/// 探针实测(Win+V 选历史图片):
+/// ```
+/// Win32 EnumClipboardFormats: CF_BITMAP / CF_DIB / CF_DIBV5  handle 均有效
+/// super_clipboard platformFormats: 只有两个标记格式
+/// ```
+/// 同一张图直接 Ctrl+C 复制则两边都正常 —— 只有走剪贴板历史这条路会这样。
+library;
+
+export 'clipboard_image_native_stub.dart'
+    if (dart.library.io) 'clipboard_image_native_io.dart';

--- a/lib/utils/clipboard_image_native_io.dart
+++ b/lib/utils/clipboard_image_native_io.dart
@@ -1,0 +1,148 @@
+import 'dart:ffi';
+import 'dart:io' show Platform;
+import 'dart:typed_data';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:image/image.dart' as img;
+
+/// 从**原始 Win32 剪贴板**取位图 → PNG 字节;取不到返回 null。
+///
+/// 只在 Windows 上有实际动作,其它 dart:io 平台直接返回 null。
+/// 背景与实测证据见 `clipboard_image_native.dart` 的文档注释。
+///
+/// 直接用 `dart:ffi` 绑定 user32/kernel32 的 5 个函数,**不引入 win32 包**
+/// —— 只为这一处兜底加一个直接依赖不划算,样板也就几十行。
+Uint8List? readClipboardImageNative() {
+  if (!Platform.isWindows) return null;
+  final api = _Win32Clipboard.instance;
+  if (api == null) return null;
+  if (api.openClipboard(nullptr) == 0) return null;
+  try {
+    // 先 CF_DIB:经典头,alpha 语义明确不含歧义。CF_DIBV5 的 32bpp 常见
+    // alpha 全 0(写入方不填),按 BGRA 解出来是整张透明图。
+    for (final fmt in const [_cfDib, _cfDibV5]) {
+      final handle = api.getClipboardData(fmt);
+      if (handle == nullptr) continue;
+      final ptr = api.globalLock(handle);
+      if (ptr == nullptr) continue;
+      try {
+        final size = api.globalSize(handle);
+        if (size < 40) continue; // 连 BITMAPINFOHEADER 都不够
+        final dib = ptr.cast<Uint8>().asTypedList(size);
+        final decoded = img.decodeBmp(_dibToBmpFile(dib));
+        if (decoded == null) continue;
+        return Uint8List.fromList(img.encodePng(_fixOpaque(decoded)));
+      } catch (e) {
+        debugPrint('[ClipboardNative] DIB 解码失败: $e');
+      } finally {
+        api.globalUnlock(handle);
+      }
+    }
+    return null;
+  } catch (e) {
+    debugPrint('[ClipboardNative] 读取失败: $e');
+    return null;
+  } finally {
+    api.closeClipboard();
+  }
+}
+
+const int _cfDib = 8;
+const int _cfDibV5 = 17;
+
+/// 剪贴板位图的 alpha 常常是**没意义的填充 0**(写入方只管 RGB)。整张
+/// 全 0 会被当成完全透明 —— 实测症状:预览一片空白、PNG 只有几百字节。
+/// 只在「全图 alpha 都是 0」时判定为无效并整体置不透明;真正带透明度的
+/// 图至少有一个像素 alpha 非 0,不受影响。
+img.Image _fixOpaque(img.Image src) {
+  if (src.numChannels < 4) return src;
+  for (final p in src) {
+    if (p.a != 0) return src; // 有有效 alpha,原样保留
+  }
+  for (final p in src) {
+    p.a = 255;
+  }
+  return src;
+}
+
+/// CF_DIB / CF_DIBV5 的内容是 `BITMAPINFOHEADER + (掩码/调色板) + 像素`,
+/// **没有文件头**。补 14 字节 `BITMAPFILEHEADER` 即成合法 .bmp。
+///
+/// `offBits`(像素起始偏移)必须把掩码和调色板都算进去,算错整张图会错位:
+/// - 调色板:`biBitCount <= 8` 且 `biClrUsed == 0` 时按 `2^bpp` 项,每项 4 字节;
+/// - `BI_BITFIELDS`(compression == 3):经典头后面还有 3 个 DWORD 掩码;
+///   V5 头(`biSize >= 108`)自带掩码字段,不能重复计。
+Uint8List _dibToBmpFile(Uint8List dib) {
+  final info = ByteData.sublistView(dib);
+  final biSize = info.getUint32(0, Endian.little);
+  final biBitCount = info.getUint16(14, Endian.little);
+  final biCompression = info.getUint32(16, Endian.little);
+  var biClrUsed = info.getUint32(32, Endian.little);
+
+  if (biClrUsed == 0 && biBitCount <= 8) biClrUsed = 1 << biBitCount;
+  var extra = biClrUsed * 4;
+  if (biCompression == 3 && biSize < 108) extra += 12;
+
+  final out = Uint8List(14 + dib.length);
+  final head = ByteData.sublistView(out);
+  head.setUint8(0, 0x42); // 'B'
+  head.setUint8(1, 0x4D); // 'M'
+  head.setUint32(2, out.length, Endian.little);
+  head.setUint32(6, 0, Endian.little); // 保留位
+  head.setUint32(10, 14 + biSize + extra, Endian.little); // offBits
+  out.setRange(14, out.length, dib);
+  return out;
+}
+
+typedef _OpenClipboardC = Int32 Function(Pointer<Void>);
+typedef _OpenClipboardD = int Function(Pointer<Void>);
+typedef _CloseClipboardC = Int32 Function();
+typedef _CloseClipboardD = int Function();
+typedef _GetClipboardDataC = Pointer<Void> Function(Uint32);
+typedef _GetClipboardDataD = Pointer<Void> Function(int);
+typedef _GlobalLockC = Pointer<Void> Function(Pointer<Void>);
+typedef _GlobalLockD = Pointer<Void> Function(Pointer<Void>);
+typedef _GlobalUnlockC = Int32 Function(Pointer<Void>);
+typedef _GlobalUnlockD = int Function(Pointer<Void>);
+typedef _GlobalSizeC = IntPtr Function(Pointer<Void>);
+typedef _GlobalSizeD = int Function(Pointer<Void>);
+
+/// user32/kernel32 的最小绑定(只要这一处兜底用到的 5 个函数)。
+class _Win32Clipboard {
+  _Win32Clipboard._(this.openClipboard, this.closeClipboard,
+      this.getClipboardData, this.globalLock, this.globalUnlock, this.globalSize);
+
+  final _OpenClipboardD openClipboard;
+  final _CloseClipboardD closeClipboard;
+  final _GetClipboardDataD getClipboardData;
+  final _GlobalLockD globalLock;
+  final _GlobalUnlockD globalUnlock;
+  final _GlobalSizeD globalSize;
+
+  static bool _tried = false;
+  static _Win32Clipboard? _instance;
+
+  /// 加载失败(理论上不会,除非 dll 缺失)时返回 null,调用方静默跳过。
+  static _Win32Clipboard? get instance {
+    if (_tried) return _instance;
+    _tried = true;
+    try {
+      final user32 = DynamicLibrary.open('user32.dll');
+      final kernel32 = DynamicLibrary.open('kernel32.dll');
+      _instance = _Win32Clipboard._(
+        user32.lookupFunction<_OpenClipboardC, _OpenClipboardD>('OpenClipboard'),
+        user32
+            .lookupFunction<_CloseClipboardC, _CloseClipboardD>('CloseClipboard'),
+        user32.lookupFunction<_GetClipboardDataC, _GetClipboardDataD>(
+            'GetClipboardData'),
+        kernel32.lookupFunction<_GlobalLockC, _GlobalLockD>('GlobalLock'),
+        kernel32.lookupFunction<_GlobalUnlockC, _GlobalUnlockD>('GlobalUnlock'),
+        kernel32.lookupFunction<_GlobalSizeC, _GlobalSizeD>('GlobalSize'),
+      );
+    } catch (e) {
+      debugPrint('[ClipboardNative] 绑定 Win32 失败: $e');
+      _instance = null;
+    }
+    return _instance;
+  }
+}

--- a/lib/utils/clipboard_image_native_stub.dart
+++ b/lib/utils/clipboard_image_native_stub.dart
@@ -1,0 +1,4 @@
+import 'dart:typed_data';
+
+/// 非 dart:io 平台(web)无原生剪贴板访问,恒返回 null。
+Uint8List? readClipboardImageNative() => null;

--- a/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
+++ b/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
@@ -45,6 +45,7 @@ import '../../../services/app_error_handler.dart';
 import '../../../services/discourse/discourse_service.dart';
 import '../../../services/discourse_cook_service.dart';
 import '../../../services/emoji_handler.dart';
+import '../../../utils/clipboard_image_native.dart';
 import '../../../utils/dialog_utils.dart';
 import '../../../utils/fluxdo_render_callbacks.dart';
 import '../../../utils/link_launcher.dart';
@@ -1289,6 +1290,15 @@ class RichComposerEditorState extends State<RichComposerEditor> {
       final img = await MarkdownToolbarState.readImageFromReader(reader);
       if (img != null) {
         unawaited(_uploadPastedImage(img.$1, img.$2));
+        return null;
+      }
+      // 原生兜底(Windows):剪贴板历史(Win+V)放的 OLE data object 只在
+      // OLE 层声明标记类格式,位图挂在原始 Win32 剪贴板上,super_clipboard
+      // 枚举不到 —— 表现为「Win+V 粘贴图片没反应」。探针实测原生能拿到
+      // CF_DIB 并成功转出 PNG,见 clipboard_image_native.dart。
+      final native = readClipboardImageNative();
+      if (native != null) {
+        unawaited(_uploadPastedImage(native, 'png'));
       }
     }
     return null;


### PR DESCRIPTION
## 现象

Windows 上用 **Win+V(剪贴板历史)** 粘贴图片,编辑器毫无反应。同一张图直接 `Ctrl+C` 粘贴则正常;Chrome 等应用粘贴 Win+V 的图也正常。

## 根因

写了独立探针实测(同一张图,对比两条来源):

| | Win32 `EnumClipboardFormats` | super_clipboard `platformFormats` |
|---|---|---|
| **Win+V 历史图片** | `CF_BITMAP` / `CF_DIB` / `CF_DIBV5`,handle **均有效** | 只有 `ClipboardHistoryItemId`、`ExcludeClipboardContentFromMonitorProcessing`、`DropDescription` |
| **直接 Ctrl+C** | 正常 | 正常 |

剪贴板历史放的 OLE data object **只在 OLE 层声明标记类格式**,位图挂在**原始 Win32 剪贴板**上。super_clipboard 走 `IDataObject` 枚举,因此一张位图都看不到;Chrome 这类直接读原始剪贴板的应用不受影响。

在「粘贴当下 / 300ms / 1s / 3s」四个时机复测结果一致,**排除**时序与延迟渲染的可能。

## 改动

新增 `lib/utils/clipboard_image_native.dart`(条件导入):Windows 上读 `CF_DIB` → 补 `BITMAPFILEHEADER` 拼成合法 BMP → 解码 → 编码 PNG。非 Windows 走 stub 恒返回 `null`。

接入点在 `_importRichPaste`,**只在 super_clipboard 拿不到图时兜底**;既有粘贴路径(截图 `Ctrl+C`、复制图片文件、html、纯文本)一律不变。

两个实现要点:
- `offBits` 必须算上调色板(`<=8bpp` 且 `clrUsed=0` 时按 `2^bpp`)与 `BI_BITFIELDS` 的 12 字节掩码(V5 头自带则不重复计),算错整张图会错位;
- 剪贴板位图的 alpha 常常是写入方没填的 `0`,按 BGRA 解出来是整张透明图(实测症状:预览空白、PNG 仅 387 字节)。**只在全图 alpha 都为 0 时**判定无效并整体置不透明,真正带透明度的图不受影响。因此优先 `CF_DIB`(经典头 alpha 语义无歧义),`CF_DIBV5` 退后。

## 依赖

**零新增依赖** —— 用 `dart:ffi` 直接绑定 user32/kernel32 的 5 个函数,没有引入 `win32` 包。`image` 包上游已有。

## 影响面

- 仅 app 侧,**不涉及 `fluxdo_render` 子模块**(pin 未动)
- 仅 Windows 生效,其它平台走 stub

## 验证

- 在上游 main 基线(submodule 为上游 pin)`flutter analyze lib` **零 error**
- Windows 实机:Win+V 粘贴图片正常插入;截图 `Ctrl+C`、复制图片文件、网页/纯文本粘贴均无回归