### PR TITLE
fix: WebView2 域 cookie 缺前导点被当 host-only 写入,导致子域名登录态丢失

### DIFF
--- a/lib/services/network/cookie/raw_cookie_writer_fallback.dart
+++ b/lib/services/network/cookie/raw_cookie_writer_fallback.dart
@@ -70,8 +70,14 @@ class RawCookieWriterFallback {
         value: canonical.value,
         path: canonical.path.isEmpty ? '/' : canonical.path,
         // host-only 时不传 domain (CookieManager native 会用 host 作 host-only)
-        // 非 host-only 时传原始 Domain= 字符串 (可能 ".linux.do" 或 "linux.do")
-        domain: canonical.hostOnly ? null : canonical.domain,
+        // 非 host-only 时传 Domain= 字符串——WebView2 的
+        // ICoreWebView2CookieManager 认"前导点"作为域 cookie(可匹配子域名)
+        // 的标记, 不带点会被当成 host-only 精确匹配写入(即使服务端 Set-Cookie
+        // 里 Domain= 没带点, 按 RFC 6265 仍应匹配所有子域名)。这里补上前导点,
+        // 否则 `Domain=linux.do`(无点)同步进 WebView 后, credit.linux.do /
+        // cdk.linux.do 等子域名读不到这条 cookie, 表现为子域名 WebView 里
+        // 显示未登录, 即使 Dio 侧 API 调用一切正常。
+        domain: canonical.hostOnly ? null : _domainCookieAttr(canonical.domain),
         expiresDate: canonical.expiresAt?.millisecondsSinceEpoch,
         maxAge: canonical.maxAge,
         isSecure: canonical.secure,
@@ -196,6 +202,10 @@ class RawCookieWriterFallback {
       return 0;
     }
   }
+
+  /// 补上前导点, 让 WebView2 把它当域 cookie (匹配子域名) 写入。
+  String? _domainCookieAttr(String? domain) =>
+      domain == null || domain.startsWith('.') ? domain : '.$domain';
 
   HTTPCookieSameSitePolicy? _mapSameSite(CookieSameSite sameSite) {
     switch (sameSite) {


### PR DESCRIPTION
## Summary
- credit.linux.do / cdk.linux.do 的登录 session cookie 实际是挂在父域名 `linux.do` 下的 `Domain=linux.do`(无前导点)cookie
- 同步到 WebView2 时,`ICoreWebView2CookieManager` 把没有前导点的 Domain 字符串当成 host-only 精确匹配写入,而不是能覆盖子域名的域 cookie(即便按 RFC 6265,`Domain=linux.do` 本就该匹配所有子域名)
- 结果:App 自身的 Dio API 调用(积分获取、OAuth 授权)一切正常,但点开内置 WebView 打开 `credit.linux.do/home` 时始终显示未登录
- 修复:`RawCookieWriterFallback.setRawCookie` 写入 WebView2 前,给非 host-only 的 domain 统一补上前导点

## Test plan
- [x] `dart analyze` 通过
- [x] Windows release 编译通过
- [x] 实机验证:LDC 重新授权后点开 credit.linux.do WebView 能正常显示登录态

🤖 Generated with [Claude Code](https://claude.com/claude-code)