### PR TITLE
fix: 图片复制引用改用 upload:// 短链

### DIFF
--- a/lib/utils/fluxdo_render_callbacks.dart
+++ b/lib/utils/fluxdo_render_callbacks.dart
@@ -30,6 +30,7 @@ import '../services/highlighter_service.dart';
 import '../services/media_compat_service.dart';
 import '../services/toast_service.dart';
 import '../utils/discourse_url_parser.dart';
+import '../utils/html_to_markdown.dart';
 import '../utils/link_launcher.dart';
 import '../utils/svg_utils.dart';
 import '../utils/url_helper.dart';
@@ -1340,7 +1341,30 @@ class FluxdoRenderCallbacks {
       topicId: topicId,
       onQuoteImage: liveQuoteHandler,
       position: position,
+      quoteMarkdown: post != null ? _uploadMarkdownForImage(post, image) : null,
     );
+  }
+
+  /// 引用/复制引用图片时,对齐 Web 端行为:用 `upload://sha1.ext` 短链而非
+  /// CDN 解析后的完整 URL(那样粘回聊天框/编辑器无法被识别为图片附件)。
+  ///
+  /// fluxdo_render 的 ImageRun 不携带 `data-base62-sha1`(解析器未提取),
+  /// 这里退回原始 post.cooked 按 src 精确匹配对应 `<img>`,复用
+  /// [HtmlToMarkdown] 里已有的 upload:// 短链构造逻辑。匹配失败(如
+  /// cooked 结构变化)返回 null,调用方降级用 `![image](CDN url)`。
+  static String? _uploadMarkdownForImage(Post post, ImageRun image) {
+    try {
+      final fragment = html_parser.parseFragment(post.cooked);
+      for (final img in fragment.querySelectorAll('img')) {
+        if (img.attributes['src'] == image.src) {
+          final markdown = HtmlToMarkdown.convert(img.outerHtml).trim();
+          return markdown.isEmpty ? null : markdown;
+        }
+      }
+    } catch (_) {
+      // 忽略,调用方降级处理。
+    }
+    return null;
   }
 
   /// 用 jovial_svg 把内容 svg 源串渲染成等比铺满列宽的 widget。

--- a/lib/utils/html_to_markdown.dart
+++ b/lib/utils/html_to_markdown.dart
@@ -325,6 +325,13 @@ class _LinkTag extends _Tag {
               _extensionFromUrl(attr['href']) ??
               _extensionFromUrl(attr['data-download-href']);
           if (ext != null) href += '.$ext';
+        } else {
+          // 客户端 cook 预览形态(见 _ImageTag 同名注释):没有
+          // data-base62-sha1 时,真实短链在 img 的 data-orig-src。
+          final origSrc = img.attributes['data-orig-src'];
+          if (origSrc != null && origSrc.startsWith('upload://')) {
+            href = origSrc;
+          }
         }
 
         final width = img.attributes['width'];
@@ -372,6 +379,14 @@ class _ImageTag extends _Tag {
       final ext = _extensionFromUrl(attr['src'] ?? pAttr['src']) ??
           _extensionFromUrl(attr['data-orig-src']);
       if (ext != null) src = '$src.$ext';
+    } else {
+      // 刚发帖/编辑后本地乐观渲染的「客户端 cook 预览形态」:src 是占位图
+      // /images/transparent.png,没有 data-base62-sha1,真实短链在
+      // data-orig-src(等服务端返回真 cooked 前一直是这个形态)。
+      final origSrc = attr['data-orig-src'] ?? pAttr['data-orig-src'];
+      if (origSrc != null && origSrc.startsWith('upload://')) {
+        src = origSrc;
+      }
     }
 
     // emoji

--- a/lib/widgets/common/image_context_menu.dart
+++ b/lib/widgets/common/image_context_menu.dart
@@ -40,6 +40,10 @@ class ImageContextMenu {
     void Function(String quote, Post post)? onQuoteImage,
     Offset? position,
     VoidCallback? onClose,
+    // 引用/复制引用用的 markdown(理想情况是 `![alt](upload://sha1.ext)`,
+    // 对齐 Web 端「复制引用」原样保留图片格式的行为)。为 null 时(如
+    // cooked 里找不到匹配 img)降级用 `![image](CDN 完整 URL)`。
+    String? quoteMarkdown,
   }) {
     final originalUrl = DiscourseImageUtils.getOriginalUrl(imageUrl);
 
@@ -54,6 +58,7 @@ class ImageContextMenu {
         onQuoteImage: onQuoteImage,
         position: position,
         onClose: onClose,
+        quoteMarkdown: quoteMarkdown,
       );
     } else {
       _showMobileMenu(
@@ -65,6 +70,7 @@ class ImageContextMenu {
         topicId: topicId,
         onQuoteImage: onQuoteImage,
         onClose: onClose,
+        quoteMarkdown: quoteMarkdown,
       );
     }
   }
@@ -80,6 +86,7 @@ class ImageContextMenu {
     void Function(String quote, Post post)? onQuoteImage,
     required Offset position,
     VoidCallback? onClose,
+    String? quoteMarkdown,
   }) {
     final overlayRenderObject = Overlay.of(context).context.findRenderObject();
     if (overlayRenderObject is! RenderBox || !overlayRenderObject.hasSize) {
@@ -165,6 +172,7 @@ class ImageContextMenu {
         topicId: topicId,
         onQuoteImage: onQuoteImage,
         onClose: onClose,
+        quoteMarkdown: quoteMarkdown,
       );
     });
   }
@@ -179,6 +187,7 @@ class ImageContextMenu {
     int? topicId,
     void Function(String quote, Post post)? onQuoteImage,
     VoidCallback? onClose,
+    String? quoteMarkdown,
   }) {
     AppBottomSheet.show(
       context: context,
@@ -232,7 +241,7 @@ class ImageContextMenu {
                 onTap: () {
                   Navigator.pop(ctx);
                   final quote = QuoteBuilder.build(
-                    markdown: '![image]($originalUrl)',
+                    markdown: quoteMarkdown ?? '![image]($originalUrl)',
                     username: post.username,
                     postNumber: post.postNumber,
                     topicId: topicId,
@@ -247,7 +256,7 @@ class ImageContextMenu {
                 onTap: () {
                   Navigator.pop(ctx);
                   final quote = QuoteBuilder.build(
-                    markdown: '![image]($originalUrl)',
+                    markdown: quoteMarkdown ?? '![image]($originalUrl)',
                     username: post.username,
                     postNumber: post.postNumber,
                     topicId: topicId,
@@ -281,6 +290,7 @@ class ImageContextMenu {
     int? topicId,
     void Function(String quote, Post post)? onQuoteImage,
     VoidCallback? onClose,
+    String? quoteMarkdown,
   }) {
     switch (action) {
       case 'viewFull':
@@ -295,7 +305,7 @@ class ImageContextMenu {
       case 'quote':
         if (post != null && topicId != null && onQuoteImage != null) {
           final quote = QuoteBuilder.build(
-            markdown: '![image]($originalUrl)',
+            markdown: quoteMarkdown ?? '![image]($originalUrl)',
             username: post.username,
             postNumber: post.postNumber,
             topicId: topicId,
@@ -305,7 +315,7 @@ class ImageContextMenu {
       case 'copyQuote':
         if (post != null && topicId != null) {
           final quote = QuoteBuilder.build(
-            markdown: '![image]($originalUrl)',
+            markdown: quoteMarkdown ?? '![image]($originalUrl)',
             username: post.username,
             postNumber: post.postNumber,
             topicId: topicId,


### PR DESCRIPTION
## Summary
- 图片「引用/复制引用」此前一律硬编码 `![image](CDN URL)`,粘贴到聊天框/编辑器既不是有效附件引用,alt/尺寸信息也丢了。
- 改为按 `<img src>` 精确匹配回 `post.cooked` 里的对应节点,复用 `HtmlToMarkdown` 已有的 `upload://sha1.ext` 短链构造逻辑,对齐 Web 端「复制引用」原样保留图片格式的行为。
- 匹配失败(如 cooked 结构变化)时降级回原来的 `![image](CDN URL)`,不会比现状更差。
- 顺带给 `data-orig-src`(客户端 cook 预览形态,刚发帖/编辑后本地乐观渲染阶段)加了短链兜底。

## Test plan
- [ ] 长按/右键图片 → 复制引用,粘贴到纯文本编辑器确认是 `![alt](upload://sha1.ext)` 格式
- [ ] 匹配不到对应 img 时(理论上少见)确认能正常降级,不崩溃