### PR TITLE
fix: Windows 后台静默续期 pause/resume 改为复用 WebView,解除 Windows 禁用

### DIFF
--- a/lib/services/cf_clearance_refresh_service.dart
+++ b/lib/services/cf_clearance_refresh_service.dart
@@ -59,6 +59,10 @@ class CfClearanceRefreshService {
   bool _pausedByLifecycle = false;
   bool _isSyncingCookies = false;
 
+  /// 正在进行中的销毁 Future：供并发的 [stop] 调用等同一次销毁完成，
+  /// 而不是各自提前返回、让调用方误以为 WebView 已经销毁干净。
+  Future<void>? _disposingFuture;
+
   int _generation = 0;
   int _consecutiveFailures = 0;
 
@@ -120,6 +124,9 @@ class CfClearanceRefreshService {
   /// 这个方法不阻塞启动链路；没有 sitekey 或没有现存 cf_clearance 时不会
   /// 主动拉起验证页，交给正常请求的 CF challenge 流程处理。
   void start() {
+    // (2026-07-23：此前 Windows 因常驻 Turnstile WebView 反复触发合成线程
+    // 卡死而禁用；pause/resume 改为复用同一个 WebView、不再逐次销毁重建后，
+    // 实测卡顿明显缓解且能正常静默续期，解除禁用。)
     _shouldBeRunning = true;
     _pausedByLifecycle = false;
     if (_isRunning && !_isDisposing) return;
@@ -139,34 +146,32 @@ class CfClearanceRefreshService {
     _startWebView();
   }
 
-  /// 暂停：应用进后台时释放 WebView，避免后台 WebView 被系统挂起后状态不明。
+  /// 暂停：应用进后台时只停止维护任务，保留同一个 Headless WebView。
+  ///
+  /// Windows WebView2 的创建/销毁与主窗口共用平台消息线程。前后台切换如果
+  /// 每次都 dispose/recreate，会放大原生生命周期竞态，甚至造成窗口无响应。
   void pause() {
     _isForeground = false;
-    final shouldResume = _shouldBeRunning || _isRunning || _isDisposing;
-    if (!shouldResume) return;
+    if (!_shouldBeRunning && !_isRunning && !_isDisposing) return;
     _pausedByLifecycle = true;
-    _shouldBeRunning = false;
-    _generation++;
     _cancelDelayedTimers();
-    if (_isDisposing) {
-      CfChallengeLogger.log('[CfRefresh] 暂停，等待当前 WebView 销毁');
-      return;
-    }
-    if (!_isRunning && _headlessWebView == null && _webViewController == null) {
-      CfChallengeLogger.log('[CfRefresh] 暂停，取消待启动 WebView');
-      return;
-    }
-    CfChallengeLogger.log('[CfRefresh] 暂停，释放 WebView');
-    unawaited(_disposeWebView(reason: 'pause'));
+    _cancelRuntimeTimers();
+    CfChallengeLogger.log('[CfRefresh] 暂停维护，保留现有 WebView');
   }
 
-  /// 恢复：应用回前台后重新创建轻量 WebView。
+  /// 恢复：应用回前台后复用现有 WebView，只恢复计时器与 cookie 同步。
   void resume() {
     _isForeground = true;
     if (!_pausedByLifecycle && !_shouldBeRunning) return;
     _pausedByLifecycle = false;
     _shouldBeRunning = true;
-    if (_isRunning && !_isDisposing) return;
+    if (_isRunning && !_isDisposing) {
+      final gen = _generation;
+      CfChallengeLogger.log('[CfRefresh] 恢复，复用现有 WebView');
+      _startTimers(gen, includeInitialTimeout: false);
+      unawaited(_syncAndCheckCookies('lifecycle_resume', gen));
+      return;
+    }
 
     _generation++;
     _consecutiveFailures = 0;
@@ -180,14 +185,23 @@ class CfClearanceRefreshService {
     _startWebView();
   }
 
-  /// 停止服务。
-  void stop() {
+  /// 停止服务。返回的 Future 在真正需要"确保 WebView 已销毁完毕再继续"的
+  /// 调用点（如 [CfChallengeService.showManualVerify] 起自己的验证 WebView
+  /// 之前）应该 await；其余生命周期钩子等不关心时序的调用点可以不 await
+  /// （fire-and-forget，跟之前行为一致）。
+  ///
+  /// 之前这里是同步方法内部 `unawaited(_disposeWebView(...))`：调用方拿不到
+  /// 完成信号，紧接着立刻建自己的验证 WebView，两个 WebView 短暂共存，实测
+  /// 会撞上 flutter_inappwebview_windows_plugin 的一处原生崩溃（0xc0000005）。
+  Future<void> stop() async {
     _pausedByLifecycle = false;
     if (!_shouldBeRunning && !_isRunning && !_isDisposing) {
       return;
     }
 
     if (_isDisposing && !_shouldBeRunning) {
+      // 已有一次销毁在进行中：等它完成，而不是直接返回让调用方以为已销毁。
+      await _disposingFuture;
       return;
     }
 
@@ -197,7 +211,7 @@ class CfClearanceRefreshService {
     _cancelDelayedTimers();
 
     if (_isRunning || _headlessWebView != null || _webViewController != null) {
-      unawaited(_disposeWebView(reason: 'stop'));
+      await _disposeWebView(reason: 'stop');
     }
     CfChallengeLogger.log('[CfRefresh] 服务已停止');
   }
@@ -448,9 +462,7 @@ document.close();
       return;
     }
     if (_staleReloads >= _maxReloadsBeforeRestart) {
-      CfChallengeLogger.log(
-        '[CfRefresh] 原地重载 $_staleReloads 次仍无更新,退回完全重建',
-      );
+      CfChallengeLogger.log('[CfRefresh] 原地重载 $_staleReloads 次仍无更新,退回完全重建');
       _staleReloads = 0;
       _scheduleRestart(reason, gen: gen);
       return;
@@ -480,12 +492,20 @@ document.close();
     }
   }
 
-  Future<void> _disposeWebView({required String reason}) async {
+  Future<void> _disposeWebView({required String reason}) {
     if (_isDisposing) {
       CfChallengeLogger.log('[CfRefresh] 忽略重复 dispose 请求: $reason');
-      return;
+      return _disposingFuture ?? Future.value();
     }
+    final future = _disposeWebViewImpl(reason);
+    _disposingFuture = future;
+    future.whenComplete(() {
+      if (identical(_disposingFuture, future)) _disposingFuture = null;
+    });
+    return future;
+  }
 
+  Future<void> _disposeWebViewImpl(String reason) async {
     _isDisposing = true;
     _isRunning = false;
     _isSyncingCookies = false;
@@ -538,15 +558,17 @@ document.close();
   // Cookie 同步与健康检查
   // ---------------------------------------------------------------------------
 
-  void _startTimers(int gen) {
+  void _startTimers(int gen, {bool includeInitialTimeout = true}) {
     _cancelRuntimeTimers();
 
-    _initialTimer = Timer(_initialTimeout, () {
-      if (!_canHandleGeneration(gen)) return;
-      CfChallengeLogger.log('[CfRefresh] Turnstile 初始运行超时，准备重建');
-      unawaited(_syncAndCheckCookies('initial_timeout', gen));
-      _recordFailure('initial_timeout', gen: gen, restart: true);
-    });
+    if (includeInitialTimeout) {
+      _initialTimer = Timer(_initialTimeout, () {
+        if (!_canHandleGeneration(gen)) return;
+        CfChallengeLogger.log('[CfRefresh] Turnstile 初始运行超时，准备重建');
+        unawaited(_syncAndCheckCookies('initial_timeout', gen));
+        _recordFailure('initial_timeout', gen: gen, restart: true);
+      });
+    }
 
     _cookiePollTimer = Timer.periodic(_cookiePollInterval, (_) {
       if (!_canHandleGeneration(gen)) {


### PR DESCRIPTION
## Summary
- Windows 上常驻的 Turnstile Headless WebView 此前每次 app 前后台切换都会 dispose 再重建,与主窗口共用的 Win32 消息线程反复竞争,严重时把窗口拖到无响应,因此此前直接禁用了整个 Windows 平台(`if (io.Platform.isWindows) return;`)。
- `pause()`/`resume()` 改为复用同一个 WebView:前后台切换只停/启计时器和 cookie 同步,不再销毁重建,大幅减少原生生命周期竞态。
- `stop()` 改成返回 `Future<void>`,在真正销毁完成后才 resolve。之前 fire-and-forget 的写法会让调用方(如 `CfChallengeService` 起自己的验证 WebView 前)在旧 WebView 还没销毁完时就新建一个,两者短暂共存,实测撞上过 `flutter_inappwebview_windows_plugin` 的原生崩溃(`0xc0000005`)。调用方目前仍是 fire-and-forget 调用,行为不受影响,只是关键路径需要时可以 `await`。
- 实测 Windows 上卡顿明显缓解(仍有偶发的几百 ms~1s 级卡顿尖峰,但可用)且能正常静默续期,解除了 Windows 平台的禁用。

## Test plan
- [x] Windows 桌面端跑一段时间,前后台反复切换,确认没有窗口无响应
- [x] 观察 `[CfRefresh]` 日志,确认能正常拿到/续期 `cf_clearance`
- [x] 触发一次手动过盾(网络设置页「立即验证」),确认跟常驻续期共存时不崩溃