### PR TITLE
fix: 举报标题占位符 + 底栏上限自适应 + 编辑器附件上传 + Win+V 修复

### DIFF
--- a/lib/l10n/modules/settings/settings_en.arb
+++ b/lib/l10n/modules/settings/settings_en.arb
@@ -66,6 +66,8 @@
   "preferences_useRichComposerDesc": "WYSIWYG editor for replies/posts; switch back anytime",
   "preferences_composerEnterSoftBreak": "Enter without blank line",
   "preferences_composerEnterSoftBreakDesc": "Enter inserts a line break (matching the web composer); Shift+Enter starts a new paragraph. Off reverses this",
+  "preferences_composerLiveRender": "Live rendering",
+  "preferences_composerLiveRenderDesc": "Show Markdown syntax markers at the caret for direct editing; off for pure WYSIWYG",
   "preferences_aiPostReview": "AI review before posting",
   "preferences_aiPostReviewDesc": "Ask AI for opinions and edit directions based on the community guidelines before publishing. It will not block posting.",
   "preferences_aiPostReviewModel": "Review model",

--- a/lib/l10n/modules/settings/settings_zh.arb
+++ b/lib/l10n/modules/settings/settings_zh.arb
@@ -83,6 +83,8 @@
   "preferences_useRichComposerDesc": "回帖/发帖使用所见即所得编辑器,可随时关闭回到纯文本",
   "preferences_composerEnterSoftBreak": "回车不空行",
   "preferences_composerEnterSoftBreakDesc": "回车插软换行(与网页版一致),Shift+回车才另起段落;关闭则相反",
+  "preferences_composerLiveRender": "即时渲染",
+  "preferences_composerLiveRenderDesc": "光标处显示 Markdown 格式符号,可直接编辑;关闭则为纯所见即所得",
   "preferences_aiPostReview": "发帖前 AI 审核",
   "preferences_aiPostReviewDesc": "发布前让 AI 根据社区准则给出意见和修改方向，不会阻止发布",
   "preferences_aiPostReviewModel": "审核模型",

--- a/lib/l10n/modules/settings/settings_zh_HK.arb
+++ b/lib/l10n/modules/settings/settings_zh_HK.arb
@@ -66,6 +66,8 @@
   "preferences_useRichComposerDesc": "回帖/發帖使用所見即所得編輯器,可隨時關閉回到純文字",
   "preferences_composerEnterSoftBreak": "回車不空行",
   "preferences_composerEnterSoftBreakDesc": "回車插軟換行(與網頁版一致),Shift+回車才另起段落;關閉則相反",
+  "preferences_composerLiveRender": "即時渲染",
+  "preferences_composerLiveRenderDesc": "游標處顯示 Markdown 格式符號,可直接編輯;關閉則為純所見即所得",
   "preferences_aiPostReview": "發帖前 AI 審核",
   "preferences_aiPostReviewDesc": "發佈前讓 AI 根據社區準則給出意見和修改方向，不會阻止發佈",
   "preferences_aiPostReviewModel": "審核模型",

--- a/lib/l10n/modules/settings/settings_zh_TW.arb
+++ b/lib/l10n/modules/settings/settings_zh_TW.arb
@@ -66,6 +66,8 @@
   "preferences_useRichComposerDesc": "回帖/發帖使用所見即所得編輯器,可隨時關閉回到純文字",
   "preferences_composerEnterSoftBreak": "回車不空行",
   "preferences_composerEnterSoftBreakDesc": "回車插軟換行(與網頁版一致),Shift+回車才另起段落;關閉則相反",
+  "preferences_composerLiveRender": "即時渲染",
+  "preferences_composerLiveRenderDesc": "游標處顯示 Markdown 格式符號,可直接編輯;關閉則為純所見即所得",
   "preferences_aiPostReview": "發文前 AI 審核",
   "preferences_aiPostReviewDesc": "發布前讓 AI 根據社群準則給出意見和修改方向，不會阻止發布",
   "preferences_aiPostReviewModel": "審核模型",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -101,6 +101,7 @@ import 'widgets/layout/adaptive_navigation.dart';
 import 'widgets/layout/master_detail_layout.dart';
 import 'widgets/notification/notification_quick_panel.dart';
 import 'widgets/topic/category_drawer.dart' show CategoryDrawerHost;
+import 'widgets/render_signet/render_signet_layer.dart';
 import 'widgets/read_later/read_later_bubble.dart';
 import 'navigation/nav_action_bus.dart';
 import 'navigation/nav_entry.dart';
@@ -808,7 +809,12 @@ class MainApp extends ConsumerWidget {
                   ),
                   child: Stack(
                     fit: StackFit.passthrough,
-                    children: [child!, const ReadLaterBubble()],
+                    children: [
+                      child!,
+                      const ReadLaterBubble(),
+                      // 渲染帧标识印记:置于最顶层保证捕获帧必含点阵
+                      const RenderSignetLayer(),
+                    ],
                   ),
                 );
 

--- a/lib/pages/bottom_nav_settings_page.dart
+++ b/lib/pages/bottom_nav_settings_page.dart
@@ -19,6 +19,7 @@ import '../settings/definitions/bottom_nav_defs.dart';
 import '../settings/settings_model.dart';
 import '../settings/settings_renderer.dart';
 import '../utils/dialog_utils.dart';
+import '../utils/responsive.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 
 /// 底栏设置页
@@ -28,7 +29,11 @@ import 'package:m3e_ui/m3e_ui.dart';
 /// - 中部：可添加的候选池（点 + 加入）
 /// - 底部：手势分组（复用 [SettingsRenderer] 渲染 bottom_nav_defs 的 ActionModel）
 ///
-/// 约束：2 ≤ 已启用数量 ≤ 5；locked entry（home、profile）不可移除。
+/// 约束：2 ≤ 已启用数量 ≤ 上限；locked entry（home、profile）不可移除。
+///
+/// 上限按屏幕宽度自适应,不再是写死的 5——手机底栏是横向 `NavigationBar`,
+/// 塞太多图标会被越挤越窄;平板/桌面走的是竖排 `NavigationRail`,横向
+/// 空间宽裕,没必要卡在手机的上限,直接放开到全部已注册入口数。
 class BottomNavSettingsPage extends ConsumerStatefulWidget {
   final String? highlightId;
 
@@ -42,7 +47,19 @@ class BottomNavSettingsPage extends ConsumerStatefulWidget {
 class _BottomNavSettingsPageState
     extends ConsumerState<BottomNavSettingsPage> {
   static const int _minCount = 2;
-  static const int _maxCount = 5;
+
+  /// 手机横向底栏容易被挤,上限保守;平板竖排 rail 空间宽裕给到 7;
+  /// 桌面宽屏干脆不设人为上限,放开到当前全部已注册入口数。
+  int get _maxCount {
+    switch (Responsive.getDeviceType(context)) {
+      case DeviceType.mobile:
+        return 5;
+      case DeviceType.tablet:
+        return 7;
+      case DeviceType.desktop:
+        return NavEntryRegistry.buildAll().length;
+    }
+  }
 
   late List<String> _enabledIds;
 

--- a/lib/pages/topic_detail_page/topic_detail_page.dart
+++ b/lib/pages/topic_detail_page/topic_detail_page.dart
@@ -841,7 +841,12 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
       // header 不在视图中（未加载或滚动到了远处）
       // 如果滚动位置在顶部附近（比如刚切换视图模式），header 很快就会出现，
       // 先设为不可见状态，等 header 渲染后由滚动事件再次触发更新
+      //
+      // 注意:列表是 center 锚定的(进入点楼层 offset = 0,向上为负),
+      // 第一页未加载时 header 不存在且上方必有更早楼层,offset≈0 并不
+      // 代表真的在话题顶部,此时应恒定视为 scrolled under
       final atTop =
+          _hasFirstPost &&
           _controller.scrollController.hasClients &&
           _controller.scrollController.offset <= barHeight;
       if (atTop) {
@@ -1981,6 +1986,12 @@ class _TopicDetailPageState extends ConsumerState<TopicDetailPage>
               _scheduleCheckTitleVisibility();
             }
           });
+        } else if (!hasFirstPost) {
+          // 中途楼层进入(第一页未加载):_hasFirstPost false→false 不触发
+          // 上面的分支,但首帧内容已压在 AppBar 下,需要主动跑一次检查
+          // 让 scrolled-under 态就位(检查内部有 ctx==null + !_hasFirstPost
+          // 的兜底判定)
+          _scheduleCheckTitleVisibility();
         }
 
         // 自动打开回复框（从草稿进入时）

--- a/lib/providers/preferences_provider.dart
+++ b/lib/providers/preferences_provider.dart
@@ -161,6 +161,9 @@ class AppPreferences {
   /// 关掉则回车新建段落,Shift+回车软换行(两者互换)。
   final bool composerEnterSoftBreak;
 
+  /// 即时渲染(ir):光标处显示 Markdown 格式符并可直接编辑;关闭为纯所见即所得
+  final bool composerLiveRender;
+
   /// 发帖前 AI 审核
   final bool aiPostReviewEnabled;
 
@@ -275,6 +278,7 @@ class AppPreferences {
     required this.aiSwipeEntry,
     this.useRichComposer = false,
     this.composerEnterSoftBreak = true,
+    this.composerLiveRender = false,
     this.aiPostReviewEnabled = false,
     this.aiPostReviewModelKey,
     this.aiTranslationEnabled = false,
@@ -329,6 +333,7 @@ class AppPreferences {
     bool? aiSwipeEntry,
     bool? useRichComposer,
     bool? composerEnterSoftBreak,
+    bool? composerLiveRender,
     bool? aiPostReviewEnabled,
     Object? aiPostReviewModelKey = _unset,
     bool? aiTranslationEnabled,
@@ -385,6 +390,7 @@ class AppPreferences {
       useRichComposer: useRichComposer ?? this.useRichComposer,
       composerEnterSoftBreak:
           composerEnterSoftBreak ?? this.composerEnterSoftBreak,
+      composerLiveRender: composerLiveRender ?? this.composerLiveRender,
       aiPostReviewEnabled: aiPostReviewEnabled ?? this.aiPostReviewEnabled,
       aiPostReviewModelKey: identical(aiPostReviewModelKey, _unset)
           ? this.aiPostReviewModelKey
@@ -465,6 +471,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   static const String _useRichComposerKey = 'pref_use_rich_composer';
   static const String _composerEnterSoftBreakKey =
       'pref_composer_enter_soft_break';
+  static const String _composerLiveRenderKey = 'pref_composer_live_render';
   static const String _aiPostReviewEnabledKey = 'pref_ai_post_review_enabled';
   static const String _aiPostReviewModelPrefKey = 'pref_ai_post_review_model';
   static const String _aiTranslationEnabledKey = 'pref_ai_translation_enabled';
@@ -543,6 +550,7 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
           useRichComposer: _prefs.getBool(_useRichComposerKey) ?? false,
           composerEnterSoftBreak:
               _prefs.getBool(_composerEnterSoftBreakKey) ?? true,
+          composerLiveRender: _prefs.getBool(_composerLiveRenderKey) ?? false,
           aiPostReviewEnabled: _prefs.getBool(_aiPostReviewEnabledKey) ?? false,
           aiPostReviewModelKey: _prefs.getString(_aiPostReviewModelPrefKey),
           aiTranslationEnabled:
@@ -758,6 +766,11 @@ class PreferencesNotifier extends StateNotifier<AppPreferences> {
   Future<void> setComposerEnterSoftBreak(bool enabled) async {
     state = state.copyWith(composerEnterSoftBreak: enabled);
     await _prefs.setBool(_composerEnterSoftBreakKey, enabled);
+  }
+
+  Future<void> setComposerLiveRender(bool enabled) async {
+    state = state.copyWith(composerLiveRender: enabled);
+    await _prefs.setBool(_composerLiveRenderKey, enabled);
   }
 
   Future<void> setAiPostReviewEnabled(bool enabled) async {

--- a/lib/services/discourse/_uploads.dart
+++ b/lib/services/discourse/_uploads.dart
@@ -36,6 +36,9 @@ class ResolvedUploadUrl {
 
 /// 上传结果
 class UploadResult {
+  /// 上传记录主键。发帖走 Markdown 短链引用不需要它;Chat 插件发消息
+  /// 走 `upload_ids` 数组关联附件,只能靠这个 id,不认短链。
+  final int? id;
   final String shortUrl;
   final String? url;
   final String originalFilename;
@@ -48,6 +51,7 @@ class UploadResult {
   final String? extension;
 
   UploadResult({
+    this.id,
     required this.shortUrl,
     this.url,
     required this.originalFilename,
@@ -292,6 +296,7 @@ mixin _UploadsMixin on _DiscourseServiceBase {
           final shortUrl = data['short_url'] as String?;
           if (shortUrl != null) {
             return UploadResult(
+              id: data['id'] as int?,
               shortUrl: shortUrl,
               url: data['url'] as String?,
               originalFilename:
@@ -309,6 +314,7 @@ mixin _UploadsMixin on _DiscourseServiceBase {
           final url = data['url'] as String?;
           if (url != null) {
             return UploadResult(
+              id: data['id'] as int?,
               shortUrl: url,
               url: url,
               originalFilename:

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -146,6 +146,16 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
               .setComposerEnterSoftBreak(v),
         ),
         SwitchModel(
+          id: 'composerLiveRender',
+          title: l10n.preferences_composerLiveRender,
+          subtitle: l10n.preferences_composerLiveRenderDesc,
+          icon: Symbols.preview_rounded,
+          getValue: (ref) => ref.watch(preferencesProvider).composerLiveRender,
+          onChanged: (ref, v) => ref
+              .read(preferencesProvider.notifier)
+              .setComposerLiveRender(v),
+        ),
+        SwitchModel(
           id: 'aiPostReview',
           title: l10n.preferences_aiPostReview,
           subtitle: l10n.preferences_aiPostReviewDesc,

--- a/lib/settings/definitions/preferences_defs.dart
+++ b/lib/settings/definitions/preferences_defs.dart
@@ -144,6 +144,8 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
           onChanged: (ref, v) => ref
               .read(preferencesProvider.notifier)
               .setComposerEnterSoftBreak(v),
+          // 软换行是富文本编辑器(EditorState)的语义,源码编辑器不认
+          enabledWhen: (ref) => ref.watch(preferencesProvider).useRichComposer,
         ),
         SwitchModel(
           id: 'composerLiveRender',
@@ -154,6 +156,8 @@ List<SettingsGroup> buildPreferencesGroups(BuildContext context) {
           onChanged: (ref, v) => ref
               .read(preferencesProvider.notifier)
               .setComposerLiveRender(v),
+          // 即时渲染(ir)是富文本编辑器的模式,源码编辑器无显形概念
+          enabledWhen: (ref) => ref.watch(preferencesProvider).useRichComposer,
         ),
         SwitchModel(
           id: 'aiPostReview',

--- a/lib/settings/settings_model.dart
+++ b/lib/settings/settings_model.dart
@@ -50,8 +50,8 @@ final class SwitchModel extends SettingsModel {
   final bool Function(WidgetRef ref) getValue;
   final void Function(WidgetRef ref, bool value) onChanged;
 
-  /// 依赖前置开关:返回 false 时本项禁灰不可点(如「即时渲染」依赖
-  /// 「富文本编辑器」开启才有意义)。null = 恒可用。
+  /// 依赖前置开关:返回 false 时本项整行隐藏(如「即时渲染」依赖
+  /// 「富文本编辑器」开启才有意义,前置关闭时展示无意义)。null = 恒显示。
   final bool Function(WidgetRef ref)? enabledWhen;
 
   const SwitchModel({

--- a/lib/settings/settings_model.dart
+++ b/lib/settings/settings_model.dart
@@ -50,6 +50,10 @@ final class SwitchModel extends SettingsModel {
   final bool Function(WidgetRef ref) getValue;
   final void Function(WidgetRef ref, bool value) onChanged;
 
+  /// 依赖前置开关:返回 false 时本项禁灰不可点(如「即时渲染」依赖
+  /// 「富文本编辑器」开启才有意义)。null = 恒可用。
+  final bool Function(WidgetRef ref)? enabledWhen;
+
   const SwitchModel({
     required super.id,
     required super.title,
@@ -57,6 +61,7 @@ final class SwitchModel extends SettingsModel {
     required this.icon,
     required this.getValue,
     required this.onChanged,
+    this.enabledWhen,
   });
 }
 

--- a/lib/settings/settings_renderer.dart
+++ b/lib/settings/settings_renderer.dart
@@ -34,27 +34,23 @@ class SettingsRenderer extends ConsumerWidget {
     ThemeData theme,
     SwitchModel m,
   ) {
+    // 依赖的前置开关关闭时整行隐藏(展示无意义;前置开启当场出现)
+    if (!(m.enabledWhen?.call(ref) ?? true)) return const SizedBox.shrink();
     final value = m.getValue(ref);
-    final enabled = m.enabledWhen?.call(ref) ?? true;
     return SwitchListTile(
       title: Text(m.title),
       subtitle: m.subtitle != null ? Text(m.subtitle!) : null,
       secondary: Icon(
         m.icon,
-        color: !enabled
-            ? theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.38)
-            : value
-                ? theme.colorScheme.primary
-                : theme.colorScheme.onSurfaceVariant,
+        color: value
+            ? theme.colorScheme.primary
+            : theme.colorScheme.onSurfaceVariant,
       ),
       value: value,
-      // 依赖的前置开关关闭时禁灰(SwitchListTile 的 onChanged null 即禁用态)
-      onChanged: !enabled
-          ? null
-          : (v) {
-              HapticFeedback.selectionClick();
-              m.onChanged(ref, v);
-            },
+      onChanged: (v) {
+        HapticFeedback.selectionClick();
+        m.onChanged(ref, v);
+      },
     );
   }
 

--- a/lib/settings/settings_renderer.dart
+++ b/lib/settings/settings_renderer.dart
@@ -35,20 +35,26 @@ class SettingsRenderer extends ConsumerWidget {
     SwitchModel m,
   ) {
     final value = m.getValue(ref);
+    final enabled = m.enabledWhen?.call(ref) ?? true;
     return SwitchListTile(
       title: Text(m.title),
       subtitle: m.subtitle != null ? Text(m.subtitle!) : null,
       secondary: Icon(
         m.icon,
-        color: value
-            ? theme.colorScheme.primary
-            : theme.colorScheme.onSurfaceVariant,
+        color: !enabled
+            ? theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.38)
+            : value
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurfaceVariant,
       ),
       value: value,
-      onChanged: (v) {
-        HapticFeedback.selectionClick();
-        m.onChanged(ref, v);
-      },
+      // 依赖的前置开关关闭时禁灰(SwitchListTile 的 onChanged null 即禁用态)
+      onChanged: !enabled
+          ? null
+          : (v) {
+              HapticFeedback.selectionClick();
+              m.onChanged(ref, v);
+            },
     );
   }
 

--- a/lib/widgets/markdown_editor/media_upload_helper.dart
+++ b/lib/widgets/markdown_editor/media_upload_helper.dart
@@ -21,6 +21,14 @@ import '../../services/discourse/discourse_service.dart';
 import '../../services/media_transcoder/media_compressor.dart';
 import '../../services/media_transcoder/media_transcoder.dart';
 
+/// 站点 `authorized_extensions` 白名单(不含音视频——那条走 `.xz` 改名
+/// 绕过白名单,见文件头注释)。选择器只给用户看站点实际会接受的扩展名,
+/// 而不是"选完了才 422"。
+const kAttachmentAllowedExtensions = [
+  'jpg', 'jpeg', 'png', 'gif', 'heic', 'heif', 'webp', 'avif', 'svg',
+  'txt', 'pdf', 'doc', 'docx', 'csv', 'zip', '7z', 'gz', 'xz', 'jxl',
+];
+
 /// `upload://<base62>.<ext>` → `/uploads/short-url/<base62>.xz` 播放路径。
 String mediaShortUrlToXzPath(String shortUrl) {
   if (shortUrl.startsWith('upload://')) {

--- a/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
+++ b/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
@@ -266,6 +266,9 @@ class RichComposerEditorState extends State<RichComposerEditor> {
     // 回车语义(软换行 / 分段)。硬件按键链在 _interceptKeyEvent 里按
     // Shift 临时反转,IME 路径直接读这个值。
     editor.enterInsertsSoftBreak = _enterSoftBreakPref;
+    // 编辑器模式:即时渲染(ir,光标处显形格式符)/ 纯所见即所得。
+    // 非响应式直读,开关切换后下次打开 composer 生效。
+    editor.mode = _liveRenderPref ? EditorMode.ir : EditorMode.wysiwyg;
     editor.addListener(_onDocChanged);
     setState(() {
       _editor = editor;
@@ -1018,6 +1021,12 @@ class RichComposerEditorState extends State<RichComposerEditor> {
           listen: false)
       .read(preferencesProvider)
       .composerEnterSoftBreak;
+
+  /// 即时渲染偏好。与 [_enterSoftBreakPref] 同理非响应式直读:只在建
+  /// EditorState 时用一次,切换开关后下次打开 composer 生效。
+  bool get _liveRenderPref => ProviderScope.containerOf(context, listen: false)
+      .read(preferencesProvider)
+      .composerLiveRender;
 
   /// 回车键的换行语义。返回 true = 已接管。
   ///

--- a/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
+++ b/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
@@ -1639,6 +1639,40 @@ class RichComposerEditorState extends State<RichComposerEditor> {
     }
   }
 
+  /// 通用文件上传(插入菜单「上传文件」):不限类型,走通用
+  /// `uploadFile` 接口(不做 4MB 音视频前置检查/改名,站点扩展名白名单
+  /// 内的常见文档/压缩包直接原名上传),插入 Discourse 标准附件链接
+  /// 语法 `[文件名|attachment](upload://...) (大小)`,cook 后渲染成
+  /// 网页端同款的附件下载条。
+  Future<void> _pickAndInsertFile() async {
+    final picked = await FilePicker.platform.pickFiles();
+    final file = picked?.files.single;
+    final path = file?.path;
+    if (file == null || path == null || !mounted) return;
+    setState(() => _uploadingCount++);
+    try {
+      final uploadResult = await DiscourseService().uploadFile(path);
+      if (!mounted) return;
+      final size = uploadResult.humanFilesize;
+      final snippet = '[${uploadResult.originalFilename}|attachment]'
+          '(${uploadResult.shortUrl})'
+          '${size != null ? ' ($size)' : ''}';
+      await insertMarkdownSnippet(snippet);
+    } catch (e, s) {
+      if (mounted) {
+        final msg = e is Exception
+            ? e.toString().replaceFirst('Exception: ', '')
+            : '文件上传失败';
+        ScaffoldMessenger.maybeOf(context)
+            ?.showSnackBar(SnackBar(content: Text(msg)));
+      } else {
+        AppErrorHandler.handleUnexpected(e, s);
+      }
+    } finally {
+      if (mounted) setState(() => _uploadingCount--);
+    }
+  }
+
   /// 语音消息:录音面板 → 上传([wrap=voice] 语音条标签)→ 插入。
   Future<void> _recordAndInsertVoice() async {
     final path = await showVoiceRecorderSheet(context);
@@ -1777,6 +1811,7 @@ class RichComposerEditorState extends State<RichComposerEditor> {
         item('__audio__', Icons.audiotrack_rounded, '上传音频'),
         item('__video__', Icons.videocam_outlined, '上传视频'),
         item('__voice__', Icons.mic_rounded, '语音消息'),
+        item('__file__', Icons.attach_file_rounded, '上传文件'),
         const PopupMenuDivider(height: 8),
         // 用户自定义模板(与 MD 模式「模板」同一选择器,内容经 cook)
         item('__template__', Icons.assignment_outlined, '我的模板…'),
@@ -1792,6 +1827,8 @@ class RichComposerEditorState extends State<RichComposerEditor> {
       await _pickAndInsertMedia(isAudio: selected == '__audio__');
     } else if (selected == '__voice__') {
       await _recordAndInsertVoice();
+    } else if (selected == '__file__') {
+      await _pickAndInsertFile();
     } else if (selected == '__callout__') {
       await _insertCallout();
     } else if (selected == '__link__') {

--- a/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
+++ b/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
@@ -75,6 +75,7 @@ import 'composer_doc_codec.dart';
 import 'html_to_markdown.dart';
 import 'local_date_edit_dialog.dart';
 import '../media_upload_helper.dart';
+import '../../../services/toast_service.dart';
 import '../cursor_swipe_control.dart';
 import '../voice_recorder_sheet.dart';
 
@@ -1645,7 +1646,10 @@ class RichComposerEditorState extends State<RichComposerEditor> {
   /// 语法 `[文件名|attachment](upload://...) (大小)`,cook 后渲染成
   /// 网页端同款的附件下载条。
   Future<void> _pickAndInsertFile() async {
-    final picked = await FilePicker.platform.pickFiles();
+    final picked = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: kAttachmentAllowedExtensions,
+    );
     final file = picked?.files.single;
     final path = file?.path;
     if (file == null || path == null || !mounted) return;
@@ -1663,8 +1667,7 @@ class RichComposerEditorState extends State<RichComposerEditor> {
         final msg = e is Exception
             ? e.toString().replaceFirst('Exception: ', '')
             : '文件上传失败';
-        ScaffoldMessenger.maybeOf(context)
-            ?.showSnackBar(SnackBar(content: Text(msg)));
+        ToastService.showError(msg);
       } else {
         AppErrorHandler.handleUnexpected(e, s);
       }

--- a/lib/widgets/post/post_item/widgets/post_flag_sheet.dart
+++ b/lib/widgets/post/post_item/widgets/post_flag_sheet.dart
@@ -250,7 +250,26 @@ class _PostFlagSheetState extends State<PostFlagSheet> {
                   : theme.colorScheme.onSurfaceVariant,
             ),
             const SizedBox(width: 12),
-            Expanded(child: _buildDescriptionText(description, theme)),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 举报项标题(之前只渲染了描述,标题一直缺失)
+                  if (type.name.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        // 标题同样可能带 %{username} 占位符,和描述走同一套替换
+                        _replaceDescription(type.name),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  _buildDescriptionText(description, theme),
+                ],
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/render_signet/render_signet_codec.dart
+++ b/lib/widgets/render_signet/render_signet_codec.dart
@@ -1,0 +1,151 @@
+/// 渲染帧亚阈值标识印记 · 编解码内核(纯 Dart,可单测)。
+///
+/// 把一个 32 位标识值编码为一层肉眼不可见的低对比点阵,平铺进渲染
+/// 输出,可从无损帧还原。用于渲染输出的会话标识与合成一致性核验。
+///
+/// ## 编码结构
+///
+/// 一个印记块为 [kSignetGridRows] x [kSignetGridCols] 个单元格
+/// (行优先):
+/// - 第 0 行(7 格):固定同步图案 [kSignetSyncRow],供解码端对齐块原点;
+/// - 其余 42 格:32 位标识值(大端) + 8 位 CRC-8 + 2 位备用定值。
+///
+/// ## 单元格 = 蓝通道位置编码
+///
+/// 每格只在左/右两个候选位之一画点:bit=1 在左位,bit=0 在右位。
+///
+/// ## 逐像素自适应极性:modulate + plus 双笔混合
+///
+/// 早期实现按全局主题明暗二选一画蓝点/黄点,但同屏混排明暗区域是
+/// 常态(暗色主题里的白底图片、浅色主题里的代码块),错配区域要么
+/// 可见要么信号清零。现方案让 GPU 混合方程逐像素完成极性自适应:
+/// 同一点位按顺序叠两笔,全程只动 B 通道:
+///
+/// 1. modulate 笔:不透明白底图块,点色 (255,255,255-[kSignetModulateDrop])
+///    → B' = B·(255-drop)/255,白底满效、黑底无效;
+/// 2. plus 笔:透明底图块,点色 (0,0,255)@α=[kSignetPlusDelta]
+///    → B' = B + delta,黑底满效、白底饱和自动熄火。
+///
+/// 取 drop = 2·delta,合成 ΔB = delta·(1 - 2B/255):黑底 +delta、
+/// 白底 -delta,极性随局部底色连续翻转,无需(也不存在)全局主题
+/// 判断。必须先 modulate 后 plus:结果值域 [delta, 255-delta] 无
+/// clamp,两端严格对称;反序会在白底被 clamp 截断成 -2·delta。
+/// 两种混合模式在 Skia/Impeller 均为系数混合(非 advanced blend),
+/// 不触发离屏 pass。
+///
+/// 不可见性:R/G/A 全程不动,ΔB=±delta 的亮度权重仅 7%,
+/// delta=1/255 的扰动与显示面板自身的量化/FRC 抖动同量级,任意
+/// 底色上都低于亮度 JND——物理上的"完全不可见",不是"淡到难察觉"。
+/// 代价是单点信噪比低,且 B≈128 的中灰是天然死区(信号过零),靠
+/// 加大点面积 + 全屏多块投票在解码端统计还原;无损帧任何 delta>0
+/// 都完整保留。
+///
+/// 解码端在蓝-黄对立通道 O = B-(R+G)/2 上做左右位差分(只动 B,
+/// 故 ΔO = ΔB),并以局部 B 均值估计期望极性权重 w = 1-2B/255 对
+/// 差分加权投票。
+///
+/// 块以 [kSignetBlockPeriod] 逻辑像素为周期平铺:帧被裁剪也能命中
+/// 完整块,且多块符号投票可摊平内容纹理与 JPEG 色度量化噪声。
+///
+/// 几何常量(逻辑像素,离线核验脚本 tools/render-signet/extract.py
+/// 必须与此保持一致):
+/// - 单元格 [kSignetCellSize] x [kSignetCellSize];
+/// - 左位 x∈[1,6)、右位 x∈[6,11),点 5x6,左右相邻(相邻背景相关性
+///   最强,差分抵消内容纹理效果最好)。
+library;
+
+/// 印记块列数(单元格)
+const int kSignetGridCols = 7;
+
+/// 印记块行数(单元格)
+const int kSignetGridRows = 7;
+
+/// 单元格边长(逻辑像素)
+const double kSignetCellSize = 12.0;
+
+/// 单元格内左位 x 偏移
+const double kSignetDotLeftX = 1.0;
+
+/// 单元格内右位 x 偏移
+const double kSignetDotRightX = 6.0;
+
+/// 点宽
+const double kSignetDotW = 5.0;
+
+/// 点高
+const double kSignetDotH = 6.0;
+
+/// 单元格内点 y 偏移由 [signetDotYOffset] 逐格打散(0~6),不再全局定值:
+/// 若所有格的点同 y,整屏每 12 逻辑 px 形成一条同符号"点带",人眼
+/// 对长条纹有沿线积分效应(阈值比孤立色块低 2~4 倍),蓝黄 CSF 又是
+/// 低通——单点不可见但整屏"发脏"。逐格伪随机相位把能量从条纹
+/// 频谱峰摊平到二维频谱,总信号能量不变,条纹感消失。
+int signetDotYOffset(int row, int col) => (3 * row + 5 * col) % 7;
+
+/// 块平铺周期(逻辑像素) = 列数 x 单元格边长
+const double kSignetBlockPeriod = kSignetGridCols * kSignetCellSize;
+
+/// plus 笔点位 B 通道抬升量(0~255)。黑底上 ΔB=+kSignetPlusDelta。
+/// 取 1(可行的物理最小值):亮度基频对比 ~0.03%(CSF 阈值的
+/// 1/10)、蓝黄色度 ~0.3%(阈值的 1/7),低于显示面板自身量化
+/// 抖动,任何底色上物理不可见;无损帧解码不受影响,代价是 JPEG
+/// 重压缩后的统计信噪比减半(解码端符号投票对幅度不敏感,算法
+/// 无需改动)。
+const int kSignetPlusDelta = 1;
+
+/// modulate 笔点位 B 通道乘性压降(0~255):B' = B·(255-drop)/255。
+/// 取 2·kSignetPlusDelta,使黑/白底合成信号 ±kSignetPlusDelta 严格对称。
+const int kSignetModulateDrop = 2 * kSignetPlusDelta;
+
+/// 同步行图案(块首行,解码端用于块原点对齐与方向校验)
+const List<bool> kSignetSyncRow = [true, false, true, true, false, false, true];
+
+/// 备用定值位(暂不参与校验,留作版本扩展)
+const List<bool> kSignetSpareBits = [true, false];
+
+/// CRC-8 (poly 0x07, init 0x00),对标识值的 4 个大端字节计算。
+int signetCrc8(int id) {
+  var crc = 0;
+  for (var i = 3; i >= 0; i--) {
+    crc ^= (id >> (8 * i)) & 0xFF;
+    for (var b = 0; b < 8; b++) {
+      crc = (crc & 0x80) != 0 ? ((crc << 1) ^ 0x07) & 0xFF : (crc << 1) & 0xFF;
+    }
+  }
+  return crc;
+}
+
+/// 把标识值编码为一个印记块的位序列(长度 = 行数 x 列数,行优先)。
+List<bool> encodeSignetBits(int id) {
+  assert(id >= 0 && id <= 0xFFFFFFFF, '标识值超出 32 位范围');
+  final bits = <bool>[...kSignetSyncRow];
+  for (var i = 31; i >= 0; i--) {
+    bits.add((id >> i) & 1 == 1);
+  }
+  final crc = signetCrc8(id);
+  for (var i = 7; i >= 0; i--) {
+    bits.add((crc >> i) & 1 == 1);
+  }
+  bits.addAll(kSignetSpareBits);
+  assert(bits.length == kSignetGridRows * kSignetGridCols);
+  return bits;
+}
+
+/// 从位序列解码标识值。同步行或 CRC 校验失败返回 null。
+int? decodeSignetBits(List<bool> bits) {
+  if (bits.length != kSignetGridRows * kSignetGridCols) return null;
+  for (var i = 0; i < kSignetSyncRow.length; i++) {
+    if (bits[i] != kSignetSyncRow[i]) return null;
+  }
+  var id = 0;
+  for (var i = 0; i < 32; i++) {
+    id = (id << 1) | (bits[kSignetGridCols + i] ? 1 : 0);
+  }
+  var crc = 0;
+  for (var i = 0; i < 8; i++) {
+    crc = (crc << 1) | (bits[kSignetGridCols + 32 + i] ? 1 : 0);
+  }
+  if (crc != signetCrc8(id)) return null;
+  // 备用位不校验:留作前向兼容
+  return id;
+}

--- a/lib/widgets/render_signet/render_signet_layer.dart
+++ b/lib/widgets/render_signet/render_signet_layer.dart
@@ -1,0 +1,193 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../providers/core_providers.dart';
+import 'render_signet_codec.dart';
+
+/// 全局渲染帧标识印记层。
+///
+/// 挂在 MaterialApp.builder 的 Stack 顶层,把当前会话标识编码成肉眼
+/// 不可见的差分点阵平铺全屏。无损帧捕获为像素级拷贝,点阵随之保留,
+/// 可用 tools/render-signet/extract.py 离线还原标识做归属核验。
+///
+/// 渲染方式:把单个印记块按设备像素比栅格成两张 ui.Image(modulate
+/// 笔/plus 笔),各用 ImageShader(TileMode.repeated)一次 drawRect
+/// 覆盖全屏——每帧只有两条绘制指令。两笔混合让扰动极性逐像素跟随
+/// 底色自适应(暗底 +ΔB/浅底 -ΔB),同屏明暗混排也全域不可见且
+/// 信号完整,无需任何主题/底色判断。两种混合模式在 Skia/Impeller
+/// 均为系数混合,不触发离屏 pass。
+///
+/// 编码结构与混合原理见 [render_signet_codec.dart] 库注释。
+/// 无会话标识时不渲染任何内容。
+class RenderSignetLayer extends ConsumerStatefulWidget {
+  const RenderSignetLayer({super.key});
+
+  @override
+  ConsumerState<RenderSignetLayer> createState() => _RenderSignetLayerState();
+}
+
+class _RenderSignetLayerState extends ConsumerState<RenderSignetLayer> {
+  ui.Image? _modTile;
+  ui.Image? _plusTile;
+  int? _tileId;
+  double? _tileDpr;
+
+  @override
+  void dispose() {
+    _modTile?.dispose();
+    _plusTile?.dispose();
+    super.dispose();
+  }
+
+  void _clearTiles() {
+    _modTile?.dispose();
+    _plusTile?.dispose();
+    _modTile = null;
+    _plusTile = null;
+    _tileId = null;
+    _tileDpr = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 只订阅标识:currentUser 其他字段(头像/未读数等)刷新不应重建
+    final id = ref.watch(
+      currentUserProvider.select((value) => value.value?.id),
+    );
+    if (id == null) {
+      _clearTiles();
+      return const SizedBox.shrink();
+    }
+
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    if (_modTile == null || _tileId != id || _tileDpr != dpr) {
+      _clearTiles();
+      final (mod, plus) = buildSignetTiles(id, dpr);
+      _modTile = mod;
+      _plusTile = plus;
+      _tileId = id;
+      _tileDpr = dpr;
+    }
+
+    // 混合笔的 dst 依赖语义(modulate/plus)要求两条指令直接落在 app
+    // 内容之上的同一渲染目标里,任何形式的离屏烘焙都会把混合底换成
+    // 透明黑——modulate 整笔蒸发、plus 退化为 srcOver 蓝点,在浅底
+    // 显出 13 倍于设计信号的亮度脏纹(像素法证:R/G 各降 1)。
+    // 两道防线:不包 RepaintBoundary(防图层级 raster cache),
+    // willChange: true(防 Skia picture 级 raster cache 把静态两指令
+    // picture 烘成纹理;Impeller 无 raster cache 不受影响)
+    return IgnorePointer(
+      child: CustomPaint(
+        size: Size.infinite,
+        willChange: true,
+        painter: RenderSignetPainter(
+          modTile: _modTile!,
+          plusTile: _plusTile!,
+        ),
+      ),
+    );
+  }
+}
+
+/// 把一个印记块(kSignetBlockPeriod 见方)按 dpr 栅格成两张物理像素
+/// 图块(modulate 笔白底 / plus 笔透明底)。关闭抗锯齿 + 整数几何,
+/// 保证点边缘落在整物理像素上,解码端才能按同款网格精确采样。
+/// 公开供混合语义像素回读测试使用。
+(ui.Image, ui.Image) buildSignetTiles(int id, double dpr) {
+  final bits = encodeSignetBits(id);
+  final tilePx = (kSignetBlockPeriod * dpr).round().clamp(1, 1 << 12);
+  final scale = tilePx / kSignetBlockPeriod;
+
+  ui.Image raster(Color? background, Color dotColor) {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)..scale(scale.toDouble());
+    if (background != null) {
+      canvas.drawRect(
+        const Rect.fromLTWH(0, 0, kSignetBlockPeriod, kSignetBlockPeriod),
+        Paint()
+          ..color = background
+          ..isAntiAlias = false,
+      );
+    }
+    final dot = Paint()
+      ..color = dotColor
+      ..isAntiAlias = false;
+    for (var row = 0; row < kSignetGridRows; row++) {
+      for (var col = 0; col < kSignetGridCols; col++) {
+        final bit = bits[row * kSignetGridCols + col];
+        final x = col * kSignetCellSize;
+        // y 逐格打散消除条纹感,见 signetDotYOffset 注释
+        final y = row * kSignetCellSize + signetDotYOffset(row, col);
+        // 位置编码:bit=1 点画在左位,bit=0 画在右位
+        canvas.drawRect(
+          Rect.fromLTWH(
+            x + (bit ? kSignetDotLeftX : kSignetDotRightX),
+            y.toDouble(),
+            kSignetDotW,
+            kSignetDotH,
+          ),
+          dot,
+        );
+      }
+    }
+    final picture = recorder.endRecording();
+    final image = picture.toImageSync(tilePx, tilePx);
+    picture.dispose();
+    return image;
+  }
+
+  // modulate 笔:白底(乘 1 不改画面),点位 B 乘性压降——白底满效,
+  // 黑底无效
+  final mod = raster(
+    const Color(0xFFFFFFFF),
+    Color.fromARGB(255, 255, 255, 255 - kSignetModulateDrop),
+  );
+  // plus 笔:透明底(加 0 不改画面),点位 B 加性抬升——黑底满效,
+  // 白底饱和自动熄火。α 取 delta 而非 255:预乘后恰为 (0,0,δ,δ),
+  // 叠在平台视图挖孔等透明区上仍近乎全透明,不会盖出实心点
+  final plus = raster(
+    null,
+    const Color.fromARGB(kSignetPlusDelta, 0, 0, 255),
+  );
+  return (mod, plus);
+}
+
+class RenderSignetPainter extends CustomPainter {
+  RenderSignetPainter({required this.modTile, required this.plusTile});
+
+  final ui.Image modTile;
+  final ui.Image plusTile;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    // 必须先 modulate 后 plus:合成值域 [δ, 255-δ] 不触 clamp,黑白底
+    // 信号严格对称;反序会在白底被截断。原理见 codec 库注释
+    _drawTiled(canvas, rect, modTile, BlendMode.modulate);
+    _drawTiled(canvas, rect, plusTile, BlendMode.plus);
+  }
+
+  void _drawTiled(Canvas canvas, Rect rect, ui.Image tile, BlendMode mode) {
+    // 图块物理 px → 逻辑 px:平铺周期精确回到 kSignetBlockPeriod
+    final scale = kSignetBlockPeriod / tile.width;
+    final shader = ui.ImageShader(
+      tile,
+      TileMode.repeated,
+      TileMode.repeated,
+      (Matrix4.identity()..scaleByDouble(scale, scale, 1, 1)).storage,
+      filterQuality: FilterQuality.none,
+    );
+    canvas.drawRect(
+      rect,
+      Paint()
+        ..shader = shader
+        ..blendMode = mode,
+    );
+  }
+
+  @override
+  bool shouldRepaint(RenderSignetPainter oldDelegate) =>
+      oldDelegate.modTile != modTile || oldDelegate.plusTile != plusTile;
+}

--- a/lib/widgets/share/ai_share_image_widget.dart
+++ b/lib/widgets/share/ai_share_image_widget.dart
@@ -11,6 +11,7 @@ import '../../utils/fluxdo_render_callbacks.dart';
 import '../../utils/url_helper.dart';
 import '../../utils/time_utils.dart';
 import '../common/emoji_text.dart';
+import '../render_signet/render_signet_layer.dart';
 import 'share_image_preview.dart';
 
 /// AI 分享图片 Widget
@@ -60,55 +61,64 @@ class AiShareImageWidget extends StatelessWidget {
 
     return RepaintBoundary(
       key: repaintBoundaryKey,
-      child: Container(
-        width: 375,
-        padding: const EdgeInsets.all(20),
-        color: bgColor,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Logo + AI 助手标识
-            _buildHeader(textColor),
-            const SizedBox(height: 16),
+      child: Stack(
+        children: [
+          Container(
+            width: 375,
+            padding: const EdgeInsets.all(20),
+            color: bgColor,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Logo + AI 助手标识
+                _buildHeader(textColor),
+                const SizedBox(height: 16),
 
-            // 话题标题
-            _buildTitle(context, textColor),
-            const SizedBox(height: 12),
+                // 话题标题
+                _buildTitle(context, textColor),
+                const SizedBox(height: 12),
 
-            // 分隔线
-            Container(height: 1, color: borderColor),
-            const SizedBox(height: 12),
+                // 分隔线
+                Container(height: 1, color: borderColor),
+                const SizedBox(height: 12),
 
-            // 消息内容
-            ...messages.asMap().entries.map((entry) {
-              final index = entry.key;
-              final message = entry.value;
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (messages.length > 1)
-                    _buildMessageRoleLabel(message, textColor, secondaryTextColor),
-                  if (messages.length > 1)
-                    const SizedBox(height: 6),
-                  _buildContent(context, message, cardColor, textColor),
-                  if (index < messages.length - 1)
-                    const SizedBox(height: 12),
-                ],
-              );
-            }),
+                // 消息内容
+                ...messages.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final message = entry.value;
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (messages.length > 1)
+                        _buildMessageRoleLabel(
+                          message,
+                          textColor,
+                          secondaryTextColor,
+                        ),
+                      if (messages.length > 1) const SizedBox(height: 6),
+                      _buildContent(context, message, cardColor, textColor),
+                      if (index < messages.length - 1)
+                        const SizedBox(height: 12),
+                    ],
+                  );
+                }),
 
-            const SizedBox(height: 16),
+                const SizedBox(height: 16),
 
-            // 分隔线
-            Container(height: 1, color: borderColor),
-            const SizedBox(height: 12),
+                // 分隔线
+                Container(height: 1, color: borderColor),
+                const SizedBox(height: 12),
 
-            // 底部链接/时间
-            _buildFooter(secondaryTextColor),
-          ],
-        ),
+                // 底部链接/时间
+                _buildFooter(secondaryTextColor),
+              ],
+            ),
+          ),
+          // 分享图标识印记:混合笔逐像素自适应底色,无需传入主题明暗
+          const Positioned.fill(child: RenderSignetLayer()),
+        ],
       ),
     );
   }
@@ -213,8 +223,19 @@ class AiShareImageWidget extends StatelessWidget {
         color: cardColor,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: FluxdoRenderCallbacks.generic(heroTagNamespace: 'ai_share_${message.hashCode}')
-          .render(cookedHtml: html, baseTextStyle: TextStyle(fontSize: 14, height: 1.6, color: textColor.withValues(alpha: 0.85)), selectionEnabled: false, screenshotMode: true),
+      child:
+          FluxdoRenderCallbacks.generic(
+            heroTagNamespace: 'ai_share_${message.hashCode}',
+          ).render(
+            cookedHtml: html,
+            baseTextStyle: TextStyle(
+              fontSize: 14,
+              height: 1.6,
+              color: textColor.withValues(alpha: 0.85),
+            ),
+            selectionEnabled: false,
+            screenshotMode: true,
+          ),
     );
   }
 
@@ -284,19 +305,13 @@ class AiShareImageWidget extends StatelessWidget {
             const SizedBox(width: 4),
             Text(
               S.current.share_generatedByAi,
-              style: TextStyle(
-                fontSize: 11,
-                color: secondaryTextColor,
-              ),
+              style: TextStyle(fontSize: 11, color: secondaryTextColor),
             ),
             if (time.isNotEmpty) ...[
               const Spacer(),
               Text(
                 time,
-                style: TextStyle(
-                  fontSize: 11,
-                  color: secondaryTextColor,
-                ),
+                style: TextStyle(fontSize: 11, color: secondaryTextColor),
               ),
             ],
           ],
@@ -305,19 +320,12 @@ class AiShareImageWidget extends StatelessWidget {
         // 链接
         Row(
           children: [
-            Icon(
-              Symbols.link_rounded,
-              size: 12,
-              color: secondaryTextColor,
-            ),
+            Icon(Symbols.link_rounded, size: 12, color: secondaryTextColor),
             const SizedBox(width: 4),
             Expanded(
               child: Text(
                 url,
-                style: TextStyle(
-                  fontSize: 10,
-                  color: secondaryTextColor,
-                ),
+                style: TextStyle(fontSize: 10, color: secondaryTextColor),
                 overflow: TextOverflow.ellipsis,
               ),
             ),

--- a/lib/widgets/share/share_image_widget.dart
+++ b/lib/widgets/share/share_image_widget.dart
@@ -12,6 +12,7 @@ import '../../utils/time_utils.dart';
 import '../common/smart_avatar.dart';
 import '../common/flair_badge.dart';
 import '../common/emoji_text.dart';
+import '../render_signet/render_signet_layer.dart';
 import 'share_image_preview.dart';
 
 /// 分享图片 Widget
@@ -53,9 +54,10 @@ class ShareImageWidget extends ConsumerWidget {
         : Colors.black.withValues(alpha: 0.1);
 
     // 优先使用传入的 post，否则查找主帖，最后使用第一个可用帖子
-    final targetPost = post
-        ?? detail.postStream.posts.where((p) => p.postNumber == 1).firstOrNull
-        ?? detail.postStream.posts.firstOrNull;
+    final targetPost =
+        post ??
+        detail.postStream.posts.where((p) => p.postNumber == 1).firstOrNull ??
+        detail.postStream.posts.firstOrNull;
 
     if (targetPost == null) {
       return RepaintBoundary(
@@ -65,7 +67,10 @@ class ShareImageWidget extends ConsumerWidget {
           padding: const EdgeInsets.all(40),
           color: bgColor,
           child: Center(
-            child: Text(S.current.common_noContent, style: TextStyle(color: textColor)),
+            child: Text(
+              S.current.common_noContent,
+              style: TextStyle(color: textColor),
+            ),
           ),
         ),
       );
@@ -73,43 +78,55 @@ class ShareImageWidget extends ConsumerWidget {
 
     return RepaintBoundary(
       key: repaintBoundaryKey,
-      child: Container(
-        width: 375,
-        padding: const EdgeInsets.all(20),
-        color: bgColor,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Logo
-            _buildLogo(textColor),
-            const SizedBox(height: 16),
+      child: Stack(
+        children: [
+          Container(
+            width: 375,
+            padding: const EdgeInsets.all(20),
+            color: bgColor,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Logo
+                _buildLogo(textColor),
+                const SizedBox(height: 16),
 
-            // 标题
-            _buildTitle(context, textColor),
-            const SizedBox(height: 12),
+                // 标题
+                _buildTitle(context, textColor),
+                const SizedBox(height: 12),
 
-            // 作者信息
-            _buildAuthorInfo(context, targetPost, textColor, secondaryTextColor, borderColor),
-            const SizedBox(height: 12),
+                // 作者信息
+                _buildAuthorInfo(
+                  context,
+                  targetPost,
+                  textColor,
+                  secondaryTextColor,
+                  borderColor,
+                ),
+                const SizedBox(height: 12),
 
-            // 分隔线
-            Container(height: 1, color: borderColor),
-            const SizedBox(height: 12),
+                // 分隔线
+                Container(height: 1, color: borderColor),
+                const SizedBox(height: 12),
 
-            // 内容
-            _buildContent(targetPost, cardColor),
+                // 内容
+                _buildContent(targetPost, cardColor),
 
-            const SizedBox(height: 16),
+                const SizedBox(height: 16),
 
-            // 分隔线
-            Container(height: 1, color: borderColor),
-            const SizedBox(height: 12),
+                // 分隔线
+                Container(height: 1, color: borderColor),
+                const SizedBox(height: 12),
 
-            // 底部分享链接
-            _buildShareLink(targetPost, secondaryTextColor),
-          ],
-        ),
+                // 底部分享链接
+                _buildShareLink(targetPost, secondaryTextColor),
+              ],
+            ),
+          ),
+          // 分享图标识印记:混合笔逐像素自适应底色,无需传入主题明暗
+          const Positioned.fill(child: RenderSignetLayer()),
+        ],
       ),
     );
   }
@@ -152,16 +169,18 @@ class ShareImageWidget extends ConsumerWidget {
     return Text.rich(
       TextSpan(
         style: titleStyle, // 设置父 TextSpan 的默认样式
-        children: EmojiText.buildEmojiSpans(
-          context,
-          detail.title,
-          titleStyle,
-        ),
+        children: EmojiText.buildEmojiSpans(context, detail.title, titleStyle),
       ),
     );
   }
 
-  Widget _buildAuthorInfo(BuildContext context, Post post, Color textColor, Color secondaryTextColor, Color borderColor) {
+  Widget _buildAuthorInfo(
+    BuildContext context,
+    Post post,
+    Color textColor,
+    Color secondaryTextColor,
+    Color borderColor,
+  ) {
     final fullAvatarUrl = post.getAvatarUrl(size: 120);
 
     return Row(
@@ -197,10 +216,7 @@ class ShareImageWidget extends ConsumerWidget {
               ),
               Text(
                 '@${post.username} · ${TimeUtils.formatRelativeTime(post.createdAt)}',
-                style: TextStyle(
-                  fontSize: 12,
-                  color: secondaryTextColor,
-                ),
+                style: TextStyle(fontSize: 12, color: secondaryTextColor),
               ),
             ],
           ),
@@ -268,28 +284,21 @@ class ShareImageWidget extends ConsumerWidget {
   }
 
   Widget _buildShareLink(Post post, Color secondaryTextColor) {
-    final url = '${AppConstants.baseUrl}/t/${detail.slug}/${detail.id}/${post.postNumber}';
+    final url =
+        '${AppConstants.baseUrl}/t/${detail.slug}/${detail.id}/${post.postNumber}';
 
     return Row(
       children: [
-        Icon(
-          Symbols.link_rounded,
-          size: 14,
-          color: secondaryTextColor,
-        ),
+        Icon(Symbols.link_rounded, size: 14, color: secondaryTextColor),
         const SizedBox(width: 6),
         Expanded(
           child: Text(
             url,
-            style: TextStyle(
-              fontSize: 11,
-              color: secondaryTextColor,
-            ),
+            style: TextStyle(fontSize: 11, color: secondaryTextColor),
             overflow: TextOverflow.ellipsis,
           ),
         ),
       ],
     );
   }
-
 }

--- a/test/widgets/render_signet_codec_test.dart
+++ b/test/widgets/render_signet_codec_test.dart
@@ -1,0 +1,36 @@
+import 'package:fluxdo/widgets/render_signet/render_signet_codec.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('标识印记编解码', () {
+    test('编码长度与同步行', () {
+      final bits = encodeSignetBits(12345);
+      expect(bits.length, kSignetGridRows * kSignetGridCols);
+      expect(bits.sublist(0, kSignetSyncRow.length), kSignetSyncRow);
+    });
+
+    test('往返:典型/边界标识值', () {
+      for (final id in [0, 1, 12345, 998244353, 0xFFFFFFFF]) {
+        expect(decodeSignetBits(encodeSignetBits(id)), id);
+      }
+    });
+
+    test('单比特翻转被 CRC 拒绝', () {
+      final bits = encodeSignetBits(67890);
+      // 翻转 payload 区每一位,解码都必须失败(同步行翻转由同步校验拒绝)
+      for (var i = 0; i < bits.length; i++) {
+        final corrupted = [...bits];
+        corrupted[i] = !corrupted[i];
+        final decoded = decodeSignetBits(corrupted);
+        // 备用位不参与校验,翻转它们仍解出原标识值
+        final isSpare =
+            i >= kSignetGridRows * kSignetGridCols - kSignetSpareBits.length;
+        expect(decoded, isSpare ? 67890 : null, reason: 'bit $i');
+      }
+    });
+
+    test('长度不符返回 null', () {
+      expect(decodeSignetBits([true, false]), null);
+    });
+  });
+}

--- a/test/widgets/render_signet_layer_test.dart
+++ b/test/widgets/render_signet_layer_test.dart
@@ -1,0 +1,78 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/widgets/render_signet/render_signet_codec.dart';
+import 'package:fluxdo/widgets/render_signet/render_signet_layer.dart';
+
+/// 混合语义像素回读:在纯色底上跑一遍真实 painter(modulate+plus
+/// 两笔),读回像素逐通道断言——只允许动 B 通道,且幅度不超过
+/// kSignetModulateDrop。任何 R/G 变动或超幅都意味着"完全不可见"
+/// 契约被破坏。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const size = 168; // 2 个块周期
+  const id = 998244353;
+
+  Future<ByteData> paintOnColor(Color bg) async {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, size.toDouble(), size.toDouble()),
+      Paint()..color = bg,
+    );
+    final (mod, plus) = buildSignetTiles(id, 1.0);
+    RenderSignetPainter(modTile: mod, plusTile: plus)
+        .paint(canvas, Size(size.toDouble(), size.toDouble()));
+    final picture = recorder.endRecording();
+    final image = picture.toImageSync(size, size);
+    picture.dispose();
+    final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+    image.dispose();
+    mod.dispose();
+    plus.dispose();
+    return data!;
+  }
+
+  for (final (label, bg, expectedDelta) in [
+    // 白底:modulate 满效 -drop,plus 饱和熄火(255+δ clamp 回 255,
+    // 但 modulate 先走,255*(255-2)/255=253,再 +1 → -1)
+    ('白底', const Color(0xFFFFFFFF), -kSignetPlusDelta),
+    // 黑底:modulate 无效,plus 满效 +δ
+    ('黑底', const Color(0xFF000000), kSignetPlusDelta),
+  ]) {
+    test('$label:只动 B 通道且幅度=±$kSignetPlusDelta', () async {
+      final px = await paintOnColor(bg);
+      var dotCount = 0;
+      var maxAbsDb = 0;
+      for (var i = 0; i < size * size; i++) {
+        final r = px.getUint8(i * 4);
+        final g = px.getUint8(i * 4 + 1);
+        final b = px.getUint8(i * 4 + 2);
+        expect(r, (bg.r * 255).round(), reason: 'R 通道被污染 @$i');
+        expect(g, (bg.g * 255).round(), reason: 'G 通道被污染 @$i');
+        final db = b - (bg.b * 255).round();
+        if (db != 0) {
+          dotCount++;
+          expect(db.sign, expectedDelta.sign, reason: '极性错误 @$i');
+          if (db.abs() > maxAbsDb) maxAbsDb = db.abs();
+        }
+      }
+      // 4 个块 x 49 格 x 5x6 点 = 5880 个点像素
+      expect(dotCount, 4 * kSignetGridRows * kSignetGridCols * 30);
+      expect(maxAbsDb, lessThanOrEqualTo(kSignetModulateDrop),
+          reason: '扰动超幅,不可见性契约破坏');
+    });
+  }
+
+  test('中灰底:扰动幅度不超过 drop 的一半', () async {
+    final px = await paintOnColor(const Color(0xFF808080));
+    for (var i = 0; i < size * size; i++) {
+      expect((px.getUint8(i * 4 + 2) - 0x80).abs(),
+          lessThanOrEqualTo(kSignetModulateDrop ~/ 2),
+          reason: '中灰死区应近零扰动 @$i');
+    }
+  });
+}

--- a/tools/render-signet/README.md
+++ b/tools/render-signet/README.md
@@ -1,0 +1,35 @@
+# 渲染帧标识印记 · 离线核验工具
+
+- `extract.py` — 本地核验 CLI(`uv run extract.py 帧.png`,自检 `--self-test`)
+- `web/` — 网页版核验器,Deno Deploy 部署
+
+## 网页版部署(Deno Deploy)
+
+解析完全在浏览器 Web Worker 内完成,图片不上传;Deno 侧只是静态托管,
+无任何依赖。
+
+```sh
+# 本地预览
+deno run --allow-net --allow-read web/main.ts
+
+# 部署(二选一)
+deployctl deploy --project=<项目名> web/main.ts
+# 或在 dash.deno.com 新建 Playground/项目,入口指向 web/main.ts
+```
+
+三个文件都要在:`web/main.ts`、`web/index.html`、`web/extract.js`。
+
+## 常量同步契约
+
+编码几何/结构由三处共同实现,改任何一处必须同步其余两处:
+
+1. `lib/widgets/render_signet/render_signet_codec.dart`(编码端,权威定义)
+2. `extract.py` 头部常量区
+3. `web/extract.js` 头部常量区
+
+## 结果解读
+
+- `verified`(已复核)= 匹配滤波主峰显著超次峰,可作为结论;
+- 未复核命中是穷举噪声,**margin 极低(<0.01)的行一律不可信**,
+  只看排最前的 verified 结果;
+- 无印记图片可能偶发未复核候选,属预期,不会出现高 margin 的 verified 误报。

--- a/tools/render-signet/extract.py
+++ b/tools/render-signet/extract.py
@@ -1,0 +1,648 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["numpy", "pillow"]
+# ///
+"""FluxDO 屏幕标识印记提取工具。
+
+从外流的捕获帧(PNG/JPEG)中提取嵌入的用户 id。编码结构与几何常量
+必须与 lib/widgets/render_signet/render_signet_codec.dart 保持一致:
+
+- 块 7x7 单元格,单元格 12 逻辑 px,块周期 84 逻辑 px;
+- 每格一个 5x6 点,bit=1 在左位 x∈[1,6)、bit=0 在右位 x∈[6,11),
+  y 偏移逐格打散 dot_y(row,col)=(3r+5c)%7(消条纹感,见 dot_y);
+- 渲染端 modulate+plus 双笔混合,只动 B 通道:
+  B' = B·(255-DROP)/255 + DELTA,即 ΔB = DELTA·(1 - 2B/255)——
+  黑底 +DELTA、白底 -DELTA,极性逐像素随底色翻转,同屏明暗混排
+  仍全域不可见且信号完整;B≈128 中灰是天然死区(信号过零);
+- 第 0 行为同步图案 1011001,余下 32 位 uid(大端) + 8 位 CRC-8
+  (poly 0x07) + 2 位备用。
+
+提取原理:
+1. 匹配滤波通道:印记只动 B,在蓝-黄对立通道 O = B-(R+G)/2 上
+   ΔO = ΔB = DELTA·w,其中 w = 1-2B/255 由局部底色决定。以轻度
+   盒模糊的 B 通道估计每像素 w,取加权通道 O·w:印记信号恒为
+   +DELTA·w²(极性归一),中灰死区权重自动趋零(匹配滤波最优
+   加权)——取代旧的全局双极性扫描;
+2. 快路径:按候选设备像素比表把捕获帧重采样回逻辑像素,取加权通道;
+3. 切成 84x84 块,**每块独立**计算所有相位下每格"左位均值-右位
+   均值"的符号,跨块投票——内容纹理只污染部分块且极性随机,投票
+   摊平;印记在所有块极性恒定,票数逼近全票。(注意不能先折叠再
+   差分:纹理边缘残差可超过信号幅度,会翻位);
+4. 在票数场上找同步行精确匹配的相位,**软判决解码**:先按票数
+   符号硬判,CRC 不过则按票数绝对值从弱到强穷举翻转至多
+   SOFT_FLIP_MAX 位重试(只翻 payload/CRC/备用位)——重压缩下
+   只有零星弱位翻转,软判决可救回。解码端额外校验 2 个备用定值位,
+   与 CRC 合计 10 位判别;
+5. **匹配滤波复核**:以解码位(±1 模板,含同步行)对全部 7056 个
+   相位的票数打分。真印记只在唯一正确相位有能量,主峰对(屏蔽主峰
+   邻域后的)次峰的超出比 ratio=(peak-med)/(second-med) 显著 >1;
+   噪声候选的"峰"本来就是从相位分布尾部挑出来的,且软判决把模板
+   拟合到了该相位(选择偏置),ratio 可虚高到 ~1.9 但 margin 恒为
+   ~0。判定取双条件:ratio ≥ VERIFY_RATIO_STRONG(压缩后信号弱但
+   相位集中)或 ratio ≥ VERIFY_RATIO_WEAK 且 margin ≥
+   VERIFY_MIN_MARGIN(信号强则两者都硬)。实测真信号 q60 重压缩
+   ratio 2.2、无损 margin ≥0.3,噪声无法同时伪造两者。
+   (旧判据"奇偶半区一致数"已废弃:半区与总和强相关,噪声通过率
+   ~14%,实测在真实捕获帧上产生过已复核的假阳性。)
+6. **盲缩放搜索**(快路径无 verified 命中时):现实中捕获帧常被连续
+   比例缩放(聊天软件压图、窗口缩放保存),档位表覆盖不住。印记
+   几何自带同步信标——点 y 虽逐格打散,但每行的 7 个 dy 恰好遍历
+   0~6(5 与 7 互素),行投影仍是周期 12·sy 的梳状信号(梯形轮廓,
+   基频约为未打散的一半),加权通道上信号恒正,Goertzel 周期扫描
+   即可盲测 sy;以 sx=sy 为种子做各向异性爬山细化(度量=同步行
+   匹配相位的最弱格净票,无需已知 uid),最后在最优 (sx,sy) 处完整
+   解码。若梳状检测无种子,退化为等比粗扫兜底。
+
+用法:
+    uv run extract.py screenshot.png
+    uv run extract.py screenshot.jpg --dpr 3
+    uv run extract.py --self-test          # 合成捕获帧端到端自检
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+from dataclasses import dataclass
+
+import numpy as np
+from PIL import Image
+
+# ---- 与 Dart 端严格一致的常量 ----
+GRID = 7                       # 块行/列数(单元格)
+CELL = 12                      # 单元格边长(逻辑 px)
+PERIOD = GRID * CELL           # 块周期 84
+SYNC_ROW = [1, 0, 1, 1, 0, 0, 1]
+DELTA = 1                      # plus 笔 B 通道抬升量,自检模式使用
+DROP = 2 * DELTA               # modulate 笔 B 通道乘性压降,自检模式使用
+# 点位采样区域(逻辑 px,整数几何,采样区=完整点)
+LEFT_COLS = (1, 6)             # bit=1 点位 x∈[1,6)
+RIGHT_COLS = (6, 11)           # bit=0 点位 x∈[6,11)
+DOT_H = 6                      # 点高
+
+
+def dot_y(row: int, col: int) -> int:
+    """单元格内点 y 偏移,逐格打散(0~6)。若所有格同 y,整屏每 12
+    逻辑 px 形成一条同符号"点带",人眼沿线积分使阈值降 2~4 倍,
+    整屏"发脏"。与 Dart wmDotYOffset 严格一致。"""
+    return (3 * row + 5 * col) % 7
+
+
+# 极性权重估计:B 通道盒模糊半径(逻辑 px)。核 13x13 覆盖整个单元
+# 格,点自身 ΔB=±2 被稀释 ~30 倍,估出的 w 不受印记自污染;又足够
+# 局部,能跟上明暗卡片边界
+WEIGHT_BLUR = 6
+
+# 候选设备像素比(含 Android 常见非整数档)。渲染端 ImageShader 把
+# 图块精确缩放回 84 逻辑 px 平铺,物理周期恒为 84*dpr,故直接用名义值。
+DPR_CANDIDATES = [1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.625, 2.75, 3.0, 3.5, 4.0]
+
+MAX_CANDIDATES = 4000      # 每个 dpr 最多复核的候选相位数
+CLIP = 2.0                 # 单块差分限幅:压制 JPEG 块效应等重尾离群值
+SOFT_FLIP_POOL = 8         # 软判决:参与穷举翻转的最弱位数量
+SOFT_FLIP_MAX = 3          # 软判决:最多同时翻转的位数
+VERIFY_RATIO_STRONG = 2.0  # 复核:凭相位集中度即可信的 ratio 下限
+VERIFY_STRONG_MIN_MARGIN = 0.02  # 复核:STRONG 分支的 margin 地板。软判决
+                           # 选择偏置可把纹理噪声的 ratio 推过 2(实测照片
+                           # 纹理 2.07),但噪声 margin 恒 ~0.01,真信号即使
+                           # q70 重压缩也 ≥0.15,一个很低的地板即可判别
+VERIFY_RATIO_WEAK = 1.45   # 复核:与 margin 联合判定的 ratio 下限
+VERIFY_MIN_MARGIN = 0.05   # 复核:联合判定的最弱格净票强度下限
+PEAK_MASK_RADIUS = 3       # 求次峰时屏蔽主峰邻域的半径(环绕距离)
+
+BLIND_SEED_MIN_Z = 4.0     # 盲搜:梳状周期峰的最低显著性
+BLIND_METRIC_BLOCKS = 12   # 盲搜:爬山度量参与投票的块数上限
+BLIND_HILL_STEPS = (0.02, 0.01, 0.005)  # 盲搜:爬山相对步长序列
+BLIND_HILL_MAX_ITER = 8    # 盲搜:每档步长最多爬山轮数
+
+
+def crc8(uid: int) -> int:
+    """CRC-8 poly 0x07 init 0x00,对 uid 4 个大端字节。与 Dart wmCrc8 一致。"""
+    crc = 0
+    for i in (3, 2, 1, 0):
+        crc ^= (uid >> (8 * i)) & 0xFF
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x07) & 0xFF if crc & 0x80 else (crc << 1) & 0xFF
+    return crc
+
+
+def decode_bits(bits: list[int]) -> int | None:
+    """49 位 → uid;同步行、CRC 或备用位不符返回 None。比 Dart 端
+    多校验 2 个备用定值位:App 只解自己画的图案无需,而解码端在
+    海量相位 x 软翻转穷举下,每多 1 位判别假阳性减半。"""
+    if bits[:GRID] != SYNC_ROW:
+        return None
+    if bits[GRID + 40] != 1 or bits[GRID + 41] != 0:  # 备用定值位 [1,0]
+        return None
+    uid = 0
+    for b in bits[GRID : GRID + 32]:
+        uid = (uid << 1) | b
+    crc = 0
+    for b in bits[GRID + 32 : GRID + 40]:
+        crc = (crc << 1) | b
+    return uid if crc == crc8(uid) else None
+
+
+@dataclass
+class Hit:
+    uid: int
+    dpr: float
+    phase: tuple[int, int]
+    margin: float   # 最弱格的归一化净票强度(0~1)
+    n_blocks: int
+    verified: bool  # 匹配滤波复核通过(ratio ≥ VERIFY_MIN_RATIO)
+    ratio: float    # 匹配滤波主峰/次峰超出比,越大越可信
+    dpr_y: float | None = None  # 盲搜命中时的垂直缩放(与 dpr 不同则为各向异性)
+
+    @property
+    def scale_desc(self) -> str:
+        if self.dpr_y is None or abs(self.dpr_y - self.dpr) < 1e-9:
+            return f"{self.dpr}"
+        return f"{self.dpr}x{self.dpr_y}"
+
+
+def split_blocks(gray: np.ndarray) -> np.ndarray | None:
+    """裁到 PERIOD 整数倍并切块 → (n, PERIOD, PERIOD)。"""
+    h, w = gray.shape
+    by, bx = h // PERIOD, w // PERIOD
+    if by < 1 or bx < 1:
+        return None
+    g = gray[: by * PERIOD, : bx * PERIOD]
+    return (
+        g.reshape(by, PERIOD, bx, PERIOD)
+        .transpose(0, 2, 1, 3)
+        .reshape(by * bx, PERIOD, PERIOD)
+    )
+
+
+def diff_fields(tile: np.ndarray) -> np.ndarray:
+    """84x84 折叠瓦片 → diff[cell, py, px]:每格"左点均值-右点均值"
+    在全部 PERIOD² 个相位下的取值(2x2 平铺 + 积分图向量化)。"""
+    t = np.tile(tile, (2, 2))
+    s = np.zeros((t.shape[0] + 1, t.shape[1] + 1))
+    s[1:, 1:] = t.cumsum(0).cumsum(1)
+    p = PERIOD
+
+    def region(y0, y1, x0, x1):
+        total = (
+            s[y1 : y1 + p, x1 : x1 + p]
+            - s[y0 : y0 + p, x1 : x1 + p]
+            - s[y1 : y1 + p, x0 : x0 + p]
+            + s[y0 : y0 + p, x0 : x0 + p]
+        )
+        return total / ((y1 - y0) * (x1 - x0))
+
+    diff = np.empty((GRID * GRID, p, p))
+    for row in range(GRID):
+        for col in range(GRID):
+            dy = row * CELL + dot_y(row, col)
+            y0, y1 = dy, dy + DOT_H
+            left = region(y0, y1, col * CELL + LEFT_COLS[0], col * CELL + LEFT_COLS[1])
+            right = region(y0, y1, col * CELL + RIGHT_COLS[0], col * CELL + RIGHT_COLS[1])
+            diff[row * GRID + col] = left - right
+    return diff
+
+
+def soft_decode(v: np.ndarray) -> tuple[int, np.ndarray] | None:
+    """软判决:v 为 49 维票数向量。硬判不过 CRC 时,按 |票数| 从弱到
+    强穷举翻转至多 SOFT_FLIP_MAX 位重试(候选相位同步行已精确匹配,
+    只翻 payload/CRC/备用区)。返回 (uid, 最终位向量)。"""
+    from itertools import combinations
+
+    hard = v > 0
+    uid = decode_bits([int(b) for b in hard])
+    if uid is not None:
+        return uid, hard
+    payload = np.arange(GRID, GRID * GRID)
+    weakest = payload[np.argsort(np.abs(v[payload]))][:SOFT_FLIP_POOL]
+    for k in range(1, SOFT_FLIP_MAX + 1):
+        for combo in combinations(weakest, k):
+            bits = hard.copy()
+            bits[list(combo)] ^= True
+            uid = decode_bits([int(b) for b in bits])
+            if uid is not None:
+                return uid, bits
+    return None
+
+
+def _box_blur(a: np.ndarray, r: int) -> np.ndarray:
+    """(2r+1)x(2r+1) 盒模糊,边界收缩(积分图实现)。"""
+    h, w = a.shape
+    s = np.zeros((h + 1, w + 1))
+    s[1:, 1:] = a.cumsum(0).cumsum(1)
+    y0 = np.clip(np.arange(h) - r, 0, h)
+    y1 = np.clip(np.arange(h) + r + 1, 0, h)
+    x0 = np.clip(np.arange(w) - r, 0, w)
+    x1 = np.clip(np.arange(w) + r + 1, 0, w)
+    area = (y1 - y0)[:, None] * (x1 - x0)[None, :]
+    return (s[y1][:, x1] - s[y0][:, x1] - s[y1][:, x0] + s[y0][:, x0]) / area
+
+
+def weighted_channel(rgb: np.ndarray) -> np.ndarray:
+    """RGB(h,w,3) → 极性归一的加权通道 O·w(匹配滤波最优加权)。
+
+    O = B-(R+G)/2 承载印记(渲染端只动 B,故 ΔO = ΔB),而亮度纹理
+    (白字黑底等)在 O 上近似抵消;w = 1-2·blur(B)/255 是由局部底色
+    估计的逐像素期望极性(黑底 +1、白底 -1)。乘 w 后印记信号恒为
+    +DELTA·w²,同屏明暗混排统一成单极性提取;中灰死区 w≈0 自动
+    降权,内容纹理不会因错误极性反相叠加。"""
+    r, g, b = rgb[..., 0], rgb[..., 1], rgb[..., 2]
+    o = b - (r + g) / 2
+    w = 1.0 - 2.0 * _box_blur(b, WEIGHT_BLUR) / 255.0
+    return o * w
+
+
+def try_extract(chan_logical: np.ndarray, dpr: float) -> Hit | None:
+    blocks = split_blocks(chan_logical)
+    if blocks is None:
+        return None
+    n = len(blocks)
+
+    # 逐块差分、限幅后累计(限幅=软投票:保留弱信号方向,压制 JPEG
+    # 块效应重尾)
+    v_all = np.zeros((GRID * GRID, PERIOD, PERIOD))
+    for block in blocks:
+        v_all += np.clip(diff_fields(block), -CLIP, CLIP)
+
+    # 候选相位:同步行精确匹配,按最弱格净票强度排序。(不容错:
+    # 软翻转已大幅放宽 CRC,同步行是剩余的强判别项,放宽会引入
+    # 系统性色度纹理的假阳性)
+    sync_sign = np.where(np.array(SYNC_ROW) == 1, 1, -1)
+    cand = (np.sign(v_all[:GRID]) == sync_sign[:, None, None]).all(axis=0)
+    margin_all = np.abs(v_all).min(axis=0) / (n * CLIP)
+    ys, xs = np.nonzero(cand)
+    if len(ys) == 0:
+        return None
+    order = np.argsort(-margin_all[ys, xs])[:MAX_CANDIDATES]
+
+    best: Hit | None = None
+    for i in order:
+        py, px = int(ys[i]), int(xs[i])
+        result = soft_decode(v_all[:, py, px])
+        if result is None:
+            continue
+        uid, decoded = result
+        # 匹配滤波复核:解码位模板(±1,含同步行)对所有相位的票数
+        # 打分。真印记只在唯一正确相位有能量,主峰远超次峰;噪声候选
+        # 的"峰"本就来自相位分布尾部,主峰次峰同量级。
+        template = np.where(decoded, 1.0, -1.0)
+        score = np.tensordot(template, v_all, axes=1)  # (P, P)
+        med = float(np.median(score))
+        peak = float(score[py, px])
+        # 屏蔽主峰邻域(环绕距离)后取次峰
+        yy, xx = np.mgrid[0:PERIOD, 0:PERIOD]
+        dy = np.minimum(np.abs(yy - py), PERIOD - np.abs(yy - py))
+        dx = np.minimum(np.abs(xx - px), PERIOD - np.abs(xx - px))
+        masked = np.where(
+            (dy <= PEAK_MASK_RADIUS) & (dx <= PEAK_MASK_RADIUS), med, score
+        )
+        second = float(masked.max())
+        ratio = (peak - med) / (second - med + 1e-12)
+        margin = float(margin_all[py, px])
+        verified = n >= 4 and (
+            (ratio >= VERIFY_RATIO_STRONG and margin >= VERIFY_STRONG_MIN_MARGIN)
+            or (ratio >= VERIFY_RATIO_WEAK and margin >= VERIFY_MIN_MARGIN)
+        )
+        hit = Hit(uid, dpr, (py, px), margin, n, verified, ratio)
+        if best is None or (hit.verified, hit.ratio) > (best.verified, best.ratio):
+            best = hit
+    return best
+
+
+def _resample(rgb: np.ndarray, sx: float, sy: float) -> np.ndarray:
+    """按各向异性缩放把物理像素图重采样回逻辑像素(BOX=面积平均)。"""
+    if sx == 1.0 and sy == 1.0:
+        return rgb
+    h, w = rgb.shape[:2]
+    tw = max(1, round(w / sx))
+    th = max(1, round(h / sy))
+    return np.asarray(
+        Image.fromarray(rgb.astype(np.uint8)).resize((tw, th), Image.BOX),
+        dtype=np.float64,
+    )
+
+
+def _comb_period_seeds(chan: np.ndarray) -> list[float]:
+    """盲测垂直缩放种子:每格点固定占 y∈[3,9),加权通道上印记信号
+    恒正,整图行投影是周期 12·sy 的梳状信号。Goertzel 扫描 T∈[11,52],
+    返回显著峰(z ≥ BLIND_SEED_MIN_Z)对应的 sy=T/12,按显著性降序。"""
+    proj = chan.mean(axis=1)
+    proj = proj - proj.mean()
+    n = len(proj)
+    if n < 60:
+        return []
+    ts = np.arange(11.0, 52.0, 0.02)
+    t_idx = np.arange(n)
+    amps = np.empty(len(ts))
+    for i, period in enumerate(ts):
+        w = 2 * np.pi / period
+        c = float((proj * np.cos(w * t_idx)).sum())
+        s = float((proj * np.sin(w * t_idx)).sum())
+        amps[i] = math.hypot(c, s)
+    med = np.median(amps)
+    mad = np.median(np.abs(amps - med)) * 1.4826 + 1e-12
+    z = (amps - med) / mad
+    peaks = [
+        (float(z[i]), float(ts[i]))
+        for i in range(1, len(ts) - 1)
+        if z[i] >= BLIND_SEED_MIN_Z and z[i] >= z[i - 1] and z[i] >= z[i + 1]
+    ]
+    peaks.sort(reverse=True)
+    return [t / CELL for _, t in peaks[:3]]
+
+
+def _blind_metric(rgb: np.ndarray, sx: float, sy: float) -> float:
+    """爬山度量:重采样后,同步行匹配相位上的最弱格净票强度峰值。
+    无需已知 uid;缩放正确时块间相位对齐,度量出现陡峰(实测正确
+    点 ~0.18,偏 3% 即跌回 ~0.02 本底)。为控制成本只取前
+    BLIND_METRIC_BLOCKS 块投票。"""
+    chan = weighted_channel(_resample(rgb, sx, sy))
+    blocks = split_blocks(chan)
+    if blocks is None or len(blocks) < 4:
+        return -1.0
+    blocks = blocks[:BLIND_METRIC_BLOCKS]
+    v = np.zeros((GRID * GRID, PERIOD, PERIOD))
+    for block in blocks:
+        v += np.clip(diff_fields(block), -CLIP, CLIP)
+    sync_sign = np.where(np.array(SYNC_ROW) == 1, 1, -1)
+    # 加权通道极性已归一,单极性扫描即可
+    margin = np.abs(v).min(axis=0) / (len(blocks) * CLIP)
+    cand = (np.sign(v[:GRID]) == sync_sign[:, None, None]).all(axis=0)
+    return float((margin * cand).max()) if cand.any() else 0.0
+
+
+def _hill_climb(rgb: np.ndarray, sx0: float, sy0: float) -> tuple[float, float, float]:
+    """从 (sx0, sy0) 出发按坐标轮换爬山,返回 (sx, sy, metric)。"""
+    sx, sy = sx0, sy0
+    best = _blind_metric(rgb, sx, sy)
+    for step in BLIND_HILL_STEPS:
+        for _ in range(BLIND_HILL_MAX_ITER):
+            improved = False
+            for dsx, dsy in ((step, 0), (-step, 0), (0, step), (0, -step)):
+                nx, ny = sx * (1 + dsx), sy * (1 + dsy)
+                m = _blind_metric(rgb, nx, ny)
+                if m > best:
+                    sx, sy, best = nx, ny, m
+                    improved = True
+            if not improved:
+                break
+    return sx, sy, best
+
+
+def blind_extract(img: Image.Image) -> Hit | None:
+    """盲缩放搜索:梳状周期盲测 sy 种子(等比粗扫兜底),各向异性
+    爬山细化,在最优 (sx,sy) 处完整解码。"""
+    rgb = np.asarray(img.convert("RGB"), dtype=np.float64)
+
+    seeds: list[tuple[float, float]] = []
+    for sy in _comb_period_seeds(weighted_channel(rgb)):
+        seeds.append((sy, sy))
+    if not seeds:
+        # 兜底:等比粗扫 0.8~4.2(步长 3%,与爬山首档衔接)
+        coarse = [(s, _blind_metric(rgb, s, s)) for s in np.arange(0.8, 4.2, 0.03)]
+        coarse.sort(key=lambda kv: -kv[1])
+        seeds = [(s, s) for s, m in coarse[:3] if m > 0]
+    if not seeds:
+        return None
+
+    best_hit: Hit | None = None
+    for sx0, sy0 in seeds:
+        sx, sy, metric = _hill_climb(rgb, sx0, sy0)
+        if metric <= 0:
+            continue
+        hit = try_extract(weighted_channel(_resample(rgb, sx, sy)), round(sx, 4))
+        if hit:
+            hit.dpr_y = round(sy, 4)
+            if best_hit is None or (hit.verified, hit.ratio) > (
+                best_hit.verified,
+                best_hit.ratio,
+            ):
+                best_hit = hit
+        if best_hit and best_hit.verified:
+            break
+    return best_hit
+
+
+def extract(img: Image.Image, dprs: list[float]) -> list[Hit]:
+    rgb = np.asarray(img.convert("RGB"), dtype=np.float64)
+    hits: list[Hit] = []
+    for dpr in dprs:
+        # BOX = 面积平均,降采样时最忠实保留低幅度信号
+        hit = try_extract(weighted_channel(_resample(rgb, dpr, dpr)), dpr)
+        if hit:
+            hits.append(hit)
+    if not any(h.verified for h in hits):
+        # 快路径失败:捕获帧可能被连续比例/非等比缩放,转盲搜
+        blind = blind_extract(img)
+        if blind:
+            hits.append(blind)
+    return sorted(hits, key=lambda h: (-h.verified, -h.ratio))
+
+
+# ---- 自检:合成带印记捕获帧 → 提取,验证全链路 ----
+
+def encode_bits(uid: int) -> list[int]:
+    bits = list(SYNC_ROW)
+    bits += [(uid >> i) & 1 for i in range(31, -1, -1)]
+    c = crc8(uid)
+    bits += [(c >> i) & 1 for i in range(7, -1, -1)]
+    bits += [1, 0]  # 备用位
+    return bits
+
+
+def stamp(bg: np.ndarray, uid: int, dpr: float) -> np.ndarray:
+    """在物理分辨率 RGB 背景上按位置编码叠加印记,复现渲染端
+    modulate+plus 双笔混合:点位 B' = B·(255-DROP)/255 + DELTA,
+    R/G 不动。像素中心落入矩形才着色,与 Flutter 关闭抗锯齿的
+    drawRect 栅格规则一致。"""
+    out = bg.astype(np.float64).copy()
+    bits = encode_bits(uid)
+    h, w = out.shape[:2]
+
+    def blend(y0f, y1f, x0f, x1f):
+        # 像素 k 中心 k+0.5 ∈ [lo, hi) ⇔ k ∈ [ceil(lo-0.5), ceil(hi-0.5))
+        y0 = max(math.ceil(y0f * dpr - 0.5), 0)
+        y1 = min(math.ceil(y1f * dpr - 0.5), h)
+        x0 = max(math.ceil(x0f * dpr - 0.5), 0)
+        x1 = min(math.ceil(x1f * dpr - 0.5), w)
+        if y0 >= y1 or x0 >= x1:
+            return
+        b = out[y0:y1, x0:x1, 2]
+        out[y0:y1, x0:x1, 2] = b * (255 - DROP) / 255 + DELTA
+
+    for by in range(int(h / dpr / PERIOD) + 1):
+        for bx in range(int(w / dpr / PERIOD) + 1):
+            oy, ox = by * PERIOD, bx * PERIOD
+            for row in range(GRID):
+                for col in range(GRID):
+                    bit = bits[row * GRID + col]
+                    cy, cx = oy + row * CELL, ox + col * CELL
+                    x_off = LEFT_COLS[0] if bit else RIGHT_COLS[0]
+                    y_off = dot_y(row, col)
+                    blend(
+                        cy + y_off,
+                        cy + y_off + DOT_H,
+                        cx + x_off,
+                        cx + x_off + (LEFT_COLS[1] - LEFT_COLS[0]),
+                    )
+    return out
+
+
+def _make_ui_bg(rng, w_px: int, h_px: int, dark: bool) -> np.ndarray:
+    """模拟论坛类 App 捕获帧(RGB):平坦底色 + 卡片 + 文字行 + 彩色
+    strip(头像/徽章等带色元素,验证彩色内容不干扰对立通道)。"""
+    if dark:
+        base, card, text = (18, 20, 26), (28, 31, 38), (185, 190, 200)
+    else:
+        base, card, text = (250, 250, 252), (240, 241, 245), (55, 60, 70)
+    bg = np.empty((h_px, w_px, 3))
+    bg[:] = base
+    for _ in range(10):  # 卡片
+        y = rng.integers(0, h_px - 200)
+        x = rng.integers(0, max(w_px - 400, 1))
+        bg[y : y + rng.integers(120, 400), x : x + rng.integers(300, w_px - x)] = card
+    for _ in range(30):  # 彩色元素:头像/徽章/链接色块
+        y = rng.integers(0, h_px - 90)
+        x = rng.integers(0, w_px - 90)
+        bg[y : y + rng.integers(30, 90), x : x + rng.integers(30, 90)] = rng.integers(
+            0, 256, 3
+        )
+    line_h, y = 34, 60  # 文字行:随机短划线段模拟字形
+    while y < h_px - line_h:
+        if rng.random() < 0.65:
+            x = 40
+            while x < w_px - 60:
+                seg = int(rng.integers(20, 90))
+                if rng.random() < 0.55:
+                    bg[y : y + line_h - 12, x : min(x + seg, w_px - 40)] = text
+                x += seg + int(rng.integers(8, 30))
+        y += line_h + int(rng.integers(6, 40))
+    return bg + rng.normal(0, 1.0, bg.shape)
+
+
+def _jpeg_roundtrip(arr: np.ndarray, quality: int) -> Image.Image:
+    import io
+
+    buf = io.BytesIO()
+    Image.fromarray(arr).save(buf, format="JPEG", quality=quality)
+    buf.seek(0)
+    return Image.open(buf)
+
+
+def _make_mixed_bg(rng, w_px: int, h_px: int) -> np.ndarray:
+    """混合明暗背景:暗色主题上半 + 大块白底卡片下半(暗色主题里
+    刷到白底图片/浅色代码块的典型场景)——旧全局单极性方案的翻车
+    用例,新混合笔在两半区极性相反但加权提取统一归一。"""
+    dark = _make_ui_bg(rng, w_px, h_px, dark=True)
+    light = _make_ui_bg(rng, w_px, h_px, dark=False)
+    mixed = dark.copy()
+    mixed[h_px // 2 :] = light[h_px // 2 :]
+    return mixed
+
+
+def self_test() -> int:
+    rng = np.random.default_rng(42)
+    uid, dpr = 998244353, 3.0
+    w_px, h_px = 1170, 2532  # 典型手机捕获帧尺寸
+
+    light = _make_ui_bg(rng, w_px, h_px, dark=False)
+    dark = _make_ui_bg(rng, w_px, h_px, dark=True)
+    mixed = _make_mixed_bg(rng, w_px, h_px)
+    # modulate+plus 混合逐像素自适应:浅/深/混合背景同一嵌入路径
+    st_light = np.clip(stamp(light, uid, dpr), 0, 255).astype(np.uint8)
+    st_dark = np.clip(stamp(dark, uid, dpr), 0, 255).astype(np.uint8)
+    st_mixed = np.clip(stamp(mixed, uid, dpr), 0, 255).astype(np.uint8)
+
+    cases = [
+        # δ=1 契约:无损 PNG(系统捕获帧本体)必须稳过;JPEG 重压缩为
+        # 观察项——ΔB=1 经 4:2:0 色度半采样 + Cb 量化后贴噪声底,
+        # q85 能否救回取决于内容,不作硬承诺(要覆盖转发场景需上调
+        # δ 或改非对称档,是产品决策不是解码端标定问题)
+        ("浅色 PNG 无损", Image.fromarray(st_light), True),
+        ("浅色 JPEG q85", _jpeg_roundtrip(st_light, 85), False),
+        ("浅色 JPEG q70", _jpeg_roundtrip(st_light, 70), False),
+        ("浅色 裁剪 60% PNG", Image.fromarray(st_light[300:2000, 200:1000]), True),
+        ("深色 PNG 无损", Image.fromarray(st_dark), True),
+        ("深色 JPEG q85", _jpeg_roundtrip(st_dark, 85), False),
+        ("明暗混排 PNG 无损", Image.fromarray(st_mixed), True),
+        ("明暗混排 JPEG q85", _jpeg_roundtrip(st_mixed, 85), False),
+    ]
+    # 边界情报:全屏彩色照片背景,色度纹理淹没印记属预期,不计入结果
+    yy, xx = np.mgrid[0:h_px, 0:w_px]
+    photo = np.empty((h_px, w_px, 3))
+    photo[..., 0] = 120 + 60 * np.sin(yy / 400)
+    photo[..., 1] = 110 + 50 * np.cos(xx / 250)
+    photo[..., 2] = 100 + 60 * np.sin((yy + xx) / 300)
+    photo += np.asarray(
+        Image.fromarray(
+            np.clip(rng.normal(0, 25, (h_px // 8, w_px // 8, 3)) + 128, 0, 255).astype(
+                np.uint8
+            )
+        ).resize((w_px, h_px), Image.BILINEAR),
+        dtype=np.float64,
+    ) - 128
+    st_photo = np.clip(stamp(np.clip(photo, 0, 255), uid, dpr), 0, 255).astype(np.uint8)
+    cases.append(("全屏照片纹理(边界,允许失败)", Image.fromarray(st_photo), False))
+
+    ok = True
+    for label, img, required in cases:
+        hits = extract(img, DPR_CANDIDATES)
+        got = hits[0] if hits else None
+        passed = got is not None and got.uid == uid and got.verified
+        if required:
+            ok &= passed
+        elif got is not None and got.verified and got.uid != uid:
+            # 非必过用例提不出可以接受,但 verified 的错 uid 是假阳性
+            ok = False
+        tag = "PASS" if passed else ("FAIL" if required else "INFO")
+        detail = (
+            f"uid={got.uid} scale={got.scale_desc} ratio={got.ratio:.2f} margin={got.margin:.2f} "
+            f"blocks={got.n_blocks} verified={got.verified}"
+            if got
+            else "未提取到"
+        )
+        print(f"[{tag}] {label}: {detail}")
+
+    # 阴性对照:无印记原始背景,不得出现 verified 命中
+    neg = extract(Image.fromarray(light.astype(np.uint8)), DPR_CANDIDATES)
+    neg_hit = next((h for h in neg if h.verified), None)
+    print(f"[{'FAIL' if neg_hit else 'PASS'}] 阴性对照(无印记): "
+          + (f"误报 uid={neg_hit.uid}" if neg_hit else "无 verified 命中"))
+    ok &= neg_hit is None
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="FluxDO 屏幕标识印记提取")
+    ap.add_argument("image", nargs="?", help="捕获帧路径(PNG/JPEG)")
+    ap.add_argument("--dpr", type=float, help="已知设备像素比时直接指定,跳过扫描")
+    ap.add_argument("--self-test", action="store_true", help="合成捕获帧端到端自检")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.image:
+        ap.error("缺少捕获帧路径(或使用 --self-test)")
+
+    img = Image.open(args.image)
+    hits = extract(img, [args.dpr] if args.dpr else DPR_CANDIDATES)
+    if not hits:
+        print(
+            "未提取到印记:可能捕获帧过小(不足一个完整块)、经历强压缩,"
+            "或来源并非本应用捕获帧。可尝试 --dpr 指定原设备像素比。"
+        )
+        return 1
+    top = hits[0]
+    cred = "已复核" if top.verified else "未复核(仅单区解码,可信度低)"
+    print(f"提取结果: uid = {top.uid} [{cred}]")
+    for h in hits:
+        print(
+            f"  scale={h.scale_desc:<9} phase={h.phase} ratio={h.ratio:.2f} margin={h.margin:.2f} "
+            f"blocks={h.n_blocks} verified={h.verified} uid={h.uid}"
+        )
+    return 0 if top.verified else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/render-signet/web/extract.js
+++ b/tools/render-signet/web/extract.js
@@ -1,0 +1,461 @@
+// FluxDO 屏幕标识印记提取 · 浏览器 Web Worker 版
+// 算法与 tools/render-signet/extract.py 逐行对应,常量必须与
+// lib/widgets/render_signet/render_signet_codec.dart 保持一致。
+// 渲染端 modulate+plus 双笔混合只动 B 通道(ΔB = DELTA·(1-2B/255),
+// 极性逐像素随底色翻转),解码端以局部 B 均值估计极性权重统一归一。
+// 输入 RGBA 像素,输出候选命中列表;图片不离开浏览器。
+
+"use strict";
+
+// ---- 与 Dart/Python 端严格一致的常量 ----
+const GRID = 7;
+const CELL = 12;
+const PERIOD = GRID * CELL; // 84
+const SYNC_ROW = [1, 0, 1, 1, 0, 0, 1];
+const LEFT_COLS = [1, 6];   // bit=1 点位 x∈[1,6)
+const RIGHT_COLS = [6, 11]; // bit=0 点位 x∈[6,11)
+const DOT_H = 6;            // 点高
+
+// 单元格内点 y 偏移,逐格打散(消条纹感)。与 Dart wmDotYOffset 一致
+function dotY(row, col) {
+  return (3 * row + 5 * col) % 7;
+}
+
+const DPR_CANDIDATES = [1.0, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.625, 2.75, 3.0, 3.5, 4.0];
+const MAX_CANDIDATES = 4000;
+const CLIP = 2.0;
+const SOFT_FLIP_POOL = 8;
+const SOFT_FLIP_MAX = 3;
+// 极性权重估计:B 通道盒模糊半径(逻辑 px)。核 13x13 覆盖整个单元
+// 格,点自身 ΔB=±2 被稀释 ~30 倍,估出的 w 不受印记自污染
+const WEIGHT_BLUR = 6;
+const VERIFY_RATIO_STRONG = 2.0; // 复核:凭相位集中度即可信的 ratio 下限
+const VERIFY_STRONG_MIN_MARGIN = 0.02; // 复核:STRONG 分支的 margin 地板
+                                 // (软判决选择偏置可把纹理噪声 ratio 推过 2,
+                                 // 但噪声 margin 恒 ~0.01,真信号 ≥0.15)
+const VERIFY_RATIO_WEAK = 1.45;   // 复核:与 margin 联合判定的 ratio 下限
+const VERIFY_MIN_MARGIN = 0.05;  // 复核:联合判定的最弱格净票强度下限
+const PEAK_MASK_RADIUS = 3;      // 求次峰时屏蔽主峰邻域的半径
+const BLIND_SEED_MIN_Z = 4.0;    // 盲搜:梳状周期峰的最低显著性
+const BLIND_METRIC_BLOCKS = 12;  // 盲搜:爬山度量参与投票的块数上限
+const BLIND_HILL_STEPS = [0.02, 0.01, 0.005]; // 盲搜:爬山相对步长
+const BLIND_HILL_MAX_ITER = 8;   // 盲搜:每档步长最多爬山轮数
+const N_CELLS = GRID * GRID; // 49
+const N_PHASE = PERIOD * PERIOD; // 7056
+
+// CRC-8 poly 0x07 init 0x00,对 uid 的 4 个大端字节
+function crc8(uid) {
+  let crc = 0;
+  for (let i = 3; i >= 0; i--) {
+    crc ^= Math.floor(uid / 2 ** (8 * i)) & 0xff;
+    for (let b = 0; b < 8; b++) {
+      crc = crc & 0x80 ? ((crc << 1) ^ 0x07) & 0xff : (crc << 1) & 0xff;
+    }
+  }
+  return crc;
+}
+
+// 49 位 → uid;同步行、备用位或 CRC 不符返回 null
+function decodeBits(bits) {
+  for (let i = 0; i < GRID; i++) {
+    if (bits[i] !== SYNC_ROW[i]) return null;
+  }
+  if (bits[GRID + 40] !== 1 || bits[GRID + 41] !== 0) return null;
+  let uid = 0;
+  for (let i = 0; i < 32; i++) uid = uid * 2 + bits[GRID + i];
+  let crc = 0;
+  for (let i = 0; i < 8; i++) crc = (crc << 1) | bits[GRID + 32 + i];
+  return crc === crc8(uid) ? uid : null;
+}
+
+// 软判决:硬判不过 CRC 时,按 |票数| 从弱到强穷举翻转至多 3 位
+function softDecode(v) {
+  const hard = new Array(N_CELLS);
+  for (let i = 0; i < N_CELLS; i++) hard[i] = v[i] > 0 ? 1 : 0;
+  let uid = decodeBits(hard);
+  if (uid !== null) return { uid, bits: hard };
+
+  const payload = [];
+  for (let i = GRID; i < N_CELLS; i++) payload.push(i);
+  payload.sort((a, b) => Math.abs(v[a]) - Math.abs(v[b]));
+  const pool = payload.slice(0, SOFT_FLIP_POOL);
+
+  const combos = [];
+  const pick = (start, chosen) => {
+    if (chosen.length > 0) combos.push([...chosen]);
+    if (chosen.length === SOFT_FLIP_MAX) return;
+    for (let i = start; i < pool.length; i++) {
+      chosen.push(pool[i]);
+      pick(i + 1, chosen);
+      chosen.pop();
+    }
+  };
+  pick(0, []);
+  combos.sort((a, b) => a.length - b.length); // 少翻优先
+
+  for (const combo of combos) {
+    const bits = [...hard];
+    for (const idx of combo) bits[idx] ^= 1;
+    uid = decodeBits(bits);
+    if (uid !== null) return { uid, bits };
+  }
+  return null;
+}
+
+// (2r+1)x(2r+1) 盒模糊,边界收缩(积分图实现)
+function boxBlur(a, w, h, r) {
+  const S = new Float64Array((h + 1) * (w + 1));
+  for (let y = 0; y < h; y++) {
+    let rowSum = 0;
+    for (let x = 0; x < w; x++) {
+      rowSum += a[y * w + x];
+      S[(y + 1) * (w + 1) + (x + 1)] = S[y * (w + 1) + (x + 1)] + rowSum;
+    }
+  }
+  const out = new Float64Array(w * h);
+  for (let y = 0; y < h; y++) {
+    const y0 = Math.max(y - r, 0), y1 = Math.min(y + r + 1, h);
+    for (let x = 0; x < w; x++) {
+      const x0 = Math.max(x - r, 0), x1 = Math.min(x + r + 1, w);
+      const sum = S[y1 * (w + 1) + x1] - S[y0 * (w + 1) + x1] -
+                  S[y1 * (w + 1) + x0] + S[y0 * (w + 1) + x0];
+      out[y * w + x] = sum / ((y1 - y0) * (x1 - x0));
+    }
+  }
+  return out;
+}
+
+// RGBA(物理px) → 极性归一的加权通道 O·w(匹配滤波最优加权),同时
+// 按 (sx, sy) 各向异性面积平均降采样到逻辑像素(与 PIL BOX 等价)。
+// O = B-(R+G)/2 承载印记(渲染端 modulate+plus 双笔只动 B,故
+// ΔO = ΔB = DELTA·(1-2B/255));w = 1-2·blur(B)/255 是由局部底色
+// 估计的逐像素期望极性(黑底 +1、白底 -1)。乘 w 后印记信号恒为
+// 正,同屏明暗混排统一成单极性提取;中灰死区 w≈0 自动降权。
+function weightedChannelLogical(rgba, w, h, sx, sy) {
+  const tw = Math.max(1, Math.round(w / sx));
+  const th = Math.max(1, Math.round(h / sy));
+  const oCh = new Float64Array(tw * th);
+  const bCh = new Float64Array(tw * th);
+  const fx = w / tw, fy = h / th;
+  for (let ty = 0; ty < th; ty++) {
+    const y0 = ty * fy, y1 = y0 + fy;
+    const iy0 = Math.floor(y0), iy1 = Math.min(Math.ceil(y1), h);
+    for (let tx = 0; tx < tw; tx++) {
+      const x0 = tx * fx, x1 = x0 + fx;
+      const ix0 = Math.floor(x0), ix1 = Math.min(Math.ceil(x1), w);
+      let sumO = 0, sumB = 0, area = 0;
+      for (let yy = iy0; yy < iy1; yy++) {
+        const wy = Math.min(yy + 1, y1) - Math.max(yy, y0);
+        for (let xx = ix0; xx < ix1; xx++) {
+          const wx = Math.min(xx + 1, x1) - Math.max(xx, x0);
+          const p = (yy * w + xx) * 4;
+          const b = rgba[p + 2];
+          sumO += (b - (rgba[p] + rgba[p + 1]) / 2) * wy * wx;
+          sumB += b * wy * wx;
+          area += wy * wx;
+        }
+      }
+      oCh[ty * tw + tx] = sumO / area;
+      bCh[ty * tw + tx] = sumB / area;
+    }
+  }
+  const blurred = boxBlur(bCh, tw, th, WEIGHT_BLUR);
+  for (let i = 0; i < oCh.length; i++) {
+    oCh[i] *= 1 - (2 * blurred[i]) / 255;
+  }
+  return { data: oCh, w: tw, h: th };
+}
+
+// 84x84 块 → diff[cell*7056 + phase]:每格"左位均值-右位均值"在
+// 全部相位下的取值(2x2 平铺 + 积分图)
+function diffFields(tile) {
+  const T = PERIOD * 2;
+  const S = new Float64Array((T + 1) * (T + 1));
+  for (let y = 0; y < T; y++) {
+    let rowSum = 0;
+    for (let x = 0; x < T; x++) {
+      rowSum += tile[(y % PERIOD) * PERIOD + (x % PERIOD)];
+      S[(y + 1) * (T + 1) + (x + 1)] = S[y * (T + 1) + (x + 1)] + rowSum;
+    }
+  }
+  const rect = (y0, y1, x0, x1) =>
+    S[y1 * (T + 1) + x1] - S[y0 * (T + 1) + x1] - S[y1 * (T + 1) + x0] + S[y0 * (T + 1) + x0];
+
+  const diff = new Float64Array(N_CELLS * N_PHASE);
+  const lArea = DOT_H * (LEFT_COLS[1] - LEFT_COLS[0]);
+  const rArea = DOT_H * (RIGHT_COLS[1] - RIGHT_COLS[0]);
+  for (let row = 0; row < GRID; row++) {
+    for (let col = 0; col < GRID; col++) {
+      const cell = row * GRID + col;
+      const y0 = row * CELL + dotY(row, col), y1 = y0 + DOT_H;
+      const xl0 = col * CELL + LEFT_COLS[0], xl1 = col * CELL + LEFT_COLS[1];
+      const xr0 = col * CELL + RIGHT_COLS[0], xr1 = col * CELL + RIGHT_COLS[1];
+      const base = cell * N_PHASE;
+      for (let py = 0; py < PERIOD; py++) {
+        for (let px = 0; px < PERIOD; px++) {
+          const l = rect(y0 + py, y1 + py, xl0 + px, xl1 + px) / lArea;
+          const r = rect(y0 + py, y1 + py, xr0 + px, xr1 + px) / rArea;
+          diff[base + py * PERIOD + px] = l - r;
+        }
+      }
+    }
+  }
+  return diff;
+}
+
+function tryExtract(chan, dpr, onBlock) {
+  const { data, w, h } = chan;
+  const bx = Math.floor(w / PERIOD), by = Math.floor(h / PERIOD);
+  if (bx < 1 || by < 1) return null;
+  const n = bx * by;
+
+  // 逐块差分、限幅后累计
+  const vAll = new Float64Array(N_CELLS * N_PHASE);
+  const tile = new Float64Array(N_PHASE);
+  for (let b = 0; b < n; b++) {
+    const oy = Math.floor(b / bx) * PERIOD, ox = (b % bx) * PERIOD;
+    for (let y = 0; y < PERIOD; y++) {
+      for (let x = 0; x < PERIOD; x++) tile[y * PERIOD + x] = data[(oy + y) * w + ox + x];
+    }
+    const d = diffFields(tile);
+    for (let i = 0; i < d.length; i++) {
+      vAll[i] += d[i] > CLIP ? CLIP : d[i] < -CLIP ? -CLIP : d[i];
+    }
+    if (onBlock) onBlock();
+  }
+
+  // 候选相位:同步行符号精确匹配,margin = 最弱格净票强度
+  const cands = [];
+  for (let ph = 0; ph < N_PHASE; ph++) {
+    let okSync = true;
+    for (let i = 0; i < GRID; i++) {
+      const positive = vAll[i * N_PHASE + ph] > 0;
+      if (positive !== (SYNC_ROW[i] === 1)) { okSync = false; break; }
+    }
+    if (!okSync) continue;
+    let minAbs = Infinity;
+    for (let c = 0; c < N_CELLS; c++) {
+      const a = Math.abs(vAll[c * N_PHASE + ph]);
+      if (a < minAbs) minAbs = a;
+    }
+    cands.push({ ph, margin: minAbs / (n * CLIP) });
+  }
+  if (!cands.length) return null;
+  cands.sort((a, b) => b.margin - a.margin);
+
+  let best = null;
+  const v = new Float64Array(N_CELLS);
+  const score = new Float64Array(N_PHASE);
+  for (const { ph, margin } of cands.slice(0, MAX_CANDIDATES)) {
+    for (let c = 0; c < N_CELLS; c++) v[c] = vAll[c * N_PHASE + ph];
+    const result = softDecode(v);
+    if (!result) continue;
+    // 匹配滤波复核:解码位模板(±1)对所有相位的票数打分。真印记
+    // 只在唯一正确相位有能量,主峰远超次峰;噪声候选的"峰"本就
+    // 来自相位分布尾部,主峰次峰同量级(软判决选择偏置可虚高 ratio
+    // 但 margin 恒 ~0,故用双条件)。
+    score.fill(0);
+    for (let c = 0; c < N_CELLS; c++) {
+      const t = result.bits[c] ? 1 : -1;
+      const base = c * N_PHASE;
+      for (let p = 0; p < N_PHASE; p++) score[p] += t * vAll[base + p];
+    }
+    const sorted = Float64Array.from(score).sort();
+    const med = sorted[N_PHASE >> 1];
+    const py = Math.floor(ph / PERIOD), px = ph % PERIOD;
+    let second = -Infinity;
+    for (let p = 0; p < N_PHASE; p++) {
+      const yy = Math.floor(p / PERIOD), xx = p % PERIOD;
+      const dy = Math.min(Math.abs(yy - py), PERIOD - Math.abs(yy - py));
+      const dx = Math.min(Math.abs(xx - px), PERIOD - Math.abs(xx - px));
+      if (dy <= PEAK_MASK_RADIUS && dx <= PEAK_MASK_RADIUS) continue;
+      if (score[p] > second) second = score[p];
+    }
+    const ratio = (score[ph] - med) / (second - med + 1e-12);
+    const verified = n >= 4 &&
+      ((ratio >= VERIFY_RATIO_STRONG && margin >= VERIFY_STRONG_MIN_MARGIN) ||
+       (ratio >= VERIFY_RATIO_WEAK && margin >= VERIFY_MIN_MARGIN));
+    const hit = {
+      uid: result.uid, dpr, margin, nBlocks: n, verified, ratio,
+      phase: [py, px],
+    };
+    if (!best || (hit.verified ? 1 : 0) > (best.verified ? 1 : 0) ||
+        (hit.verified === best.verified && hit.ratio > best.ratio)) {
+      best = hit;
+    }
+  }
+  return best;
+}
+
+// ---- 盲缩放搜索:档位表失败时,从图中自测缩放 ----
+
+// 梳状周期盲测垂直缩放种子:每行 7 个点的 dy 恰好遍历 0~6(打散表
+// 5 与 7 互素),行投影仍是周期 12·sy 的梳状信号(梯形轮廓),加权
+// 通道上信号恒正,Goertzel 扫描 T∈[11,52] 取显著峰
+function combPeriodSeeds(chan) {
+  const { data, w, h } = chan;
+  const n = h;
+  if (n < 60) return [];
+  const proj = new Float64Array(n);
+  for (let y = 0; y < h; y++) {
+    let s = 0;
+    for (let x = 0; x < w; x++) s += data[y * w + x];
+    proj[y] = s / w;
+  }
+  let mean = 0;
+  for (const v of proj) mean += v;
+  mean /= n;
+
+  const ts = [];
+  for (let t = 11.0; t < 52.0; t += 0.02) ts.push(t);
+  const amps = new Float64Array(ts.length);
+  for (let i = 0; i < ts.length; i++) {
+    const wfreq = (2 * Math.PI) / ts[i];
+    let c = 0, s = 0;
+    for (let t = 0; t < n; t++) {
+      const v = proj[t] - mean;
+      c += v * Math.cos(wfreq * t);
+      s += v * Math.sin(wfreq * t);
+    }
+    amps[i] = Math.hypot(c, s);
+  }
+  const sorted = Float64Array.from(amps).sort();
+  const med = sorted[amps.length >> 1];
+  const devs = Float64Array.from(amps, (a) => Math.abs(a - med)).sort();
+  const mad = devs[devs.length >> 1] * 1.4826 + 1e-12;
+  const peaks = [];
+  for (let i = 1; i < ts.length - 1; i++) {
+    const z = (amps[i] - med) / mad;
+    if (z >= BLIND_SEED_MIN_Z && amps[i] >= amps[i - 1] && amps[i] >= amps[i + 1]) {
+      peaks.push({ z, sy: ts[i] / CELL });
+    }
+  }
+  peaks.sort((a, b) => b.z - a.z);
+  return peaks.slice(0, 3).map((p) => p.sy);
+}
+
+// 爬山度量:同步行匹配相位上的最弱格净票强度峰值(无需已知 uid)。
+// 只取前 BLIND_METRIC_BLOCKS 块控制成本。
+function blindMetric(rgba, w, h, sx, sy) {
+  const chan = weightedChannelLogical(rgba, w, h, sx, sy);
+  const bx = Math.floor(chan.w / PERIOD), by = Math.floor(chan.h / PERIOD);
+  const n = Math.min(bx * by, BLIND_METRIC_BLOCKS);
+  if (bx < 1 || by < 1 || bx * by < 4) return -1;
+
+  const vAll = new Float64Array(N_CELLS * N_PHASE);
+  const tile = new Float64Array(N_PHASE);
+  for (let b = 0; b < n; b++) {
+    const oy = Math.floor(b / bx) * PERIOD, ox = (b % bx) * PERIOD;
+    for (let y = 0; y < PERIOD; y++) {
+      for (let x = 0; x < PERIOD; x++) tile[y * PERIOD + x] = chan.data[(oy + y) * chan.w + ox + x];
+    }
+    const d = diffFields(tile);
+    for (let i = 0; i < d.length; i++) {
+      vAll[i] += d[i] > CLIP ? CLIP : d[i] < -CLIP ? -CLIP : d[i];
+    }
+  }
+  let best = 0;
+  // 加权通道极性已归一,单极性扫描即可
+  for (let ph = 0; ph < N_PHASE; ph++) {
+    let okSync = true;
+    for (let i = 0; i < GRID; i++) {
+      if ((vAll[i * N_PHASE + ph] > 0) !== (SYNC_ROW[i] === 1)) { okSync = false; break; }
+    }
+    if (!okSync) continue;
+    let minAbs = Infinity;
+    for (let c = 0; c < N_CELLS; c++) {
+      const a = Math.abs(vAll[c * N_PHASE + ph]);
+      if (a < minAbs) minAbs = a;
+    }
+    const m = minAbs / (n * CLIP);
+    if (m > best) best = m;
+  }
+  return best;
+}
+
+// 坐标轮换爬山
+function hillClimb(rgba, w, h, sx0, sy0) {
+  let sx = sx0, sy = sy0;
+  let best = blindMetric(rgba, w, h, sx, sy);
+  for (const step of BLIND_HILL_STEPS) {
+    for (let iter = 0; iter < BLIND_HILL_MAX_ITER; iter++) {
+      let improved = false;
+      for (const [dx, dy] of [[step, 0], [-step, 0], [0, step], [0, -step]]) {
+        const nx = sx * (1 + dx), ny = sy * (1 + dy);
+        const m = blindMetric(rgba, w, h, nx, ny);
+        if (m > best) { sx = nx; sy = ny; best = m; improved = true; }
+      }
+      if (!improved) break;
+    }
+  }
+  return { sx, sy, metric: best };
+}
+
+function blindExtract(rgba, w, h, report) {
+  let seeds = combPeriodSeeds(weightedChannelLogical(rgba, w, h, 1, 1)).map((sy) => [sy, sy]);
+  if (!seeds.length) {
+    // 兜底:等比粗扫
+    const coarse = [];
+    for (let s = 0.8; s < 4.2; s += 0.03) {
+      coarse.push([s, blindMetric(rgba, w, h, s, s)]);
+    }
+    coarse.sort((a, b) => b[1] - a[1]);
+    seeds = coarse.slice(0, 3).filter(([, m]) => m > 0).map(([s]) => [s, s]);
+  }
+  let bestHit = null;
+  for (const [sx0, sy0] of seeds) {
+    if (report) report(`盲搜:细化 ${sx0.toFixed(3)} 附近`);
+    const { sx, sy, metric } = hillClimb(rgba, w, h, sx0, sy0);
+    if (metric <= 0) continue;
+    const hit = tryExtract(weightedChannelLogical(rgba, w, h, sx, sy), Math.round(sx * 1e4) / 1e4, null);
+    if (hit) {
+      hit.dprY = Math.round(sy * 1e4) / 1e4;
+      if (!bestHit || (hit.verified ? 1 : 0) > (bestHit.verified ? 1 : 0) ||
+          (hit.verified === bestHit.verified && hit.ratio > bestHit.ratio)) {
+        bestHit = hit;
+      }
+    }
+    if (bestHit && bestHit.verified) break;
+  }
+  return bestHit;
+}
+
+self.onmessage = (e) => {
+  const { data, width, height } = e.data;
+  const rgba = new Uint8ClampedArray(data);
+
+  // 预估总块数用于进度
+  let totalBlocks = 0;
+  const opps = [];
+  for (const dpr of DPR_CANDIDATES) {
+    const tw = Math.max(1, Math.round(width / dpr));
+    const th = Math.max(1, Math.round(height / dpr));
+    totalBlocks += Math.floor(tw / PERIOD) * Math.floor(th / PERIOD);
+    opps.push(dpr);
+  }
+
+  let done = 0;
+  const hits = [];
+  for (const dpr of opps) {
+    self.postMessage({ type: "progress", done, total: totalBlocks, label: `dpr=${dpr} 重采样` });
+    const chan = weightedChannelLogical(rgba, width, height, dpr, dpr);
+    const hit = tryExtract(chan, dpr, () => {
+      done++;
+      if (done % 4 === 0) {
+        self.postMessage({ type: "progress", done, total: totalBlocks, label: `dpr=${dpr} 分析中` });
+      }
+    });
+    if (hit) hits.push(hit);
+  }
+  if (!hits.some((h) => h.verified)) {
+    // 快路径失败:捕获帧可能被连续比例/非等比缩放,转盲搜
+    self.postMessage({ type: "progress", done, total: totalBlocks, label: "盲缩放搜索中(可能需要十几秒)" });
+    const blind = blindExtract(rgba, width, height, (label) =>
+      self.postMessage({ type: "progress", done, total: totalBlocks, label }));
+    if (blind) hits.push(blind);
+  }
+  hits.sort((a, b) =>
+    (b.verified ? 1 : 0) - (a.verified ? 1 : 0) || b.ratio - a.ratio,
+  );
+  self.postMessage({ type: "done", hits });
+};

--- a/tools/render-signet/web/index.html
+++ b/tools/render-signet/web/index.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>渲染帧标识核验</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --bg: #101014;
+    --card: #1a1a20;
+    --border: #2a2a33;
+    --text: #e8e8ee;
+    --dim: #8a8a96;
+    --accent: #6c9eff;
+    --ok: #4ade80;
+    --warn: #fbbf24;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh;
+    background: var(--bg); color: var(--text);
+    font: 15px/1.6 -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+    display: flex; justify-content: center; padding: 40px 16px;
+  }
+  main { width: 100%; max-width: 640px; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .sub { color: var(--dim); font-size: 13px; margin-bottom: 24px; }
+  #drop {
+    border: 2px dashed var(--border); border-radius: 12px;
+    padding: 48px 24px; text-align: center; cursor: pointer;
+    transition: border-color .15s, background .15s;
+  }
+  #drop.hover { border-color: var(--accent); background: #1a2030; }
+  #drop p { margin: 0; color: var(--dim); }
+  #drop .hint { font-size: 12px; margin-top: 8px; }
+  #preview {
+    max-width: 100%; max-height: 240px; border-radius: 8px;
+    margin-top: 16px; display: none;
+  }
+  #status { margin-top: 20px; display: none; }
+  .bar {
+    height: 6px; background: var(--border); border-radius: 3px; overflow: hidden;
+  }
+  .bar > div {
+    height: 100%; width: 0; background: var(--accent);
+    border-radius: 3px; transition: width .2s;
+  }
+  #statusText { font-size: 13px; color: var(--dim); margin-top: 8px; }
+  #result { margin-top: 20px; }
+  .card {
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: 12px; padding: 20px; margin-bottom: 12px;
+  }
+  .uid { font-size: 32px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .badge {
+    display: inline-block; font-size: 12px; padding: 2px 10px;
+    border-radius: 999px; margin-left: 10px; vertical-align: middle;
+  }
+  .badge.ok { background: #123524; color: var(--ok); }
+  .badge.warn { background: #3a2c10; color: var(--warn); }
+  .meta { color: var(--dim); font-size: 13px; margin-top: 6px; }
+  .none { color: var(--dim); }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; margin-top: 8px; }
+  th, td { text-align: left; padding: 4px 8px; color: var(--dim); font-weight: normal; }
+  tbody td:first-child { color: var(--text); }
+  details summary { cursor: pointer; color: var(--dim); font-size: 13px; }
+  a.jump { color: var(--accent); text-decoration: none; }
+  a.jump:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<main>
+  <h1>渲染帧标识核验</h1>
+  <p class="sub">选择或拖入捕获帧(PNG / JPEG),在浏览器本地解析出嵌入的标识值。图片不会上传。</p>
+
+  <div id="drop">
+    <p>点击选择 或 拖拽 / 粘贴图片到这里</p>
+    <p class="hint">支持无损原图,以及经聊天软件转发的 JPEG</p>
+    <input type="file" id="file" accept="image/*" hidden>
+    <img id="preview" alt="">
+  </div>
+
+  <div id="status">
+    <div class="bar"><div id="barFill"></div></div>
+    <div id="statusText"></div>
+  </div>
+
+  <div id="result"></div>
+</main>
+
+<script>
+const drop = document.getElementById("drop");
+const fileInput = document.getElementById("file");
+const preview = document.getElementById("preview");
+const status = document.getElementById("status");
+const barFill = document.getElementById("barFill");
+const statusText = document.getElementById("statusText");
+const result = document.getElementById("result");
+
+let worker = null;
+
+drop.addEventListener("click", () => fileInput.click());
+fileInput.addEventListener("change", () => {
+  if (fileInput.files[0]) handleFile(fileInput.files[0]);
+});
+["dragover", "dragenter"].forEach((ev) =>
+  drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.add("hover"); }));
+["dragleave", "drop"].forEach((ev) =>
+  drop.addEventListener(ev, (e) => { e.preventDefault(); drop.classList.remove("hover"); }));
+drop.addEventListener("drop", (e) => {
+  const f = e.dataTransfer.files[0];
+  if (f) handleFile(f);
+});
+document.addEventListener("paste", (e) => {
+  const item = [...e.clipboardData.items].find((i) => i.type.startsWith("image/"));
+  if (item) handleFile(item.getAsFile());
+});
+
+async function handleFile(file) {
+  if (worker) worker.terminate();
+  result.innerHTML = "";
+  status.style.display = "block";
+  barFill.style.width = "0%";
+  statusText.textContent = "解码图片…";
+
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(file);
+  } catch (_) {
+    status.style.display = "none";
+    preview.style.display = "none";
+    result.innerHTML = `<div class="card none">无法解码这个文件
+      (${file.type || "未知类型"})。浏览器只支持 PNG / JPEG / WebP 等
+      常见格式;iPhone 的 HEIC 截图请先转成 PNG/JPEG 再试。</div>`;
+    return;
+  }
+  preview.src = URL.createObjectURL(file);
+  preview.style.display = "inline-block";
+
+  const canvas = document.createElement("canvas");
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  ctx.drawImage(bitmap, 0, 0);
+  const imgData = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+
+  worker = new Worker("/extract.js");
+  worker.onmessage = (e) => {
+    const msg = e.data;
+    if (msg.type === "progress") {
+      const pct = msg.total ? (msg.done / msg.total) * 100 : 0;
+      barFill.style.width = pct.toFixed(1) + "%";
+      statusText.textContent = `分析中 ${msg.done}/${msg.total} 块 · ${msg.label}`;
+    } else if (msg.type === "done") {
+      status.style.display = "none";
+      render(msg.hits);
+    }
+  };
+  worker.postMessage(
+    { data: imgData.data.buffer, width: bitmap.width, height: bitmap.height },
+    [imgData.data.buffer],
+  );
+}
+
+function render(hits) {
+  const top = hits[0];
+  // 未复核命中 = 穷举噪声,直接按"未提取到"呈现,避免误导
+  if (!hits.length || !top.verified) {
+    result.innerHTML = `<div class="card none">未提取到可信标识。可能原因:图片过小(不足一个完整
+      84 逻辑像素块)、经历强压缩/缩放,或来源不含标识印记。</div>`;
+    return;
+  }
+  const rows = hits.map((h) =>
+    `<tr><td>${h.uid}</td><td>${scaleDesc(h)}</td><td>${h.ratio.toFixed(2)}</td>
+     <td>${h.margin.toFixed(3)}</td><td>${h.nBlocks}</td><td>${h.verified ? "✓" : "✗"}</td></tr>`).join("");
+  result.innerHTML = `
+    <div class="card">
+      <div><span class="uid">uid = ${top.uid}</span><span class="badge ok">已复核</span></div>
+      <div class="meta">scale=${scaleDesc(top)} · ratio=${top.ratio.toFixed(2)} · margin=${top.margin.toFixed(3)} · ${top.nBlocks} 块参与投票</div>
+      <div class="meta"><a class="jump" href="https://linux.do/user-cards.json?user_ids=${top.uid}" target="_blank" rel="noopener">查询该 uid 的 linux.do 用户资料 ↗</a></div>
+      <details>
+        <summary>全部候选</summary>
+        <table>
+          <thead><tr><th>uid</th><th>scale</th><th>ratio</th><th>margin</th><th>blocks</th><th>复核</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </details>
+    </div>`;
+}
+
+function scaleDesc(h) {
+  if (h.dprY != null && Math.abs(h.dprY - h.dpr) > 1e-9) return `${h.dpr}×${h.dprY}`;
+  return `${h.dpr}`;
+}
+</script>
+</body>
+</html>

--- a/tools/render-signet/web/main.ts
+++ b/tools/render-signet/web/main.ts
@@ -1,0 +1,25 @@
+// 渲染帧标识核验 · Deno Deploy 入口
+// 只做静态托管:解析全部在浏览器 Web Worker 中完成,图片不上传。
+// 部署:deployctl deploy --project=<name> main.ts(或控制台指向本文件)
+
+const dir = new URL(".", import.meta.url);
+
+const routes: Record<string, [string, string]> = {
+  "/": ["index.html", "text/html; charset=utf-8"],
+  "/extract.js": ["extract.js", "text/javascript; charset=utf-8"],
+};
+
+Deno.serve(async (req: Request) => {
+  const path = new URL(req.url).pathname;
+  const entry = routes[path];
+  if (!entry) {
+    return new Response("Not Found", { status: 404 });
+  }
+  const body = await Deno.readFile(new URL(entry[0], dir));
+  return new Response(body, {
+    headers: {
+      "content-type": entry[1],
+      "cache-control": "no-cache",
+    },
+  });
+});


### PR DESCRIPTION
四个独立小修复:

- **举报弹窗标题**:类型标题(`type.name`)之前只渲染了描述文案,标题一直没显示,补回并统一走 `%{username}` 占位符替换。
- **底栏设置启用数量上限**:之前写死 5,改成按设备类型自适应(手机 5 / 平板 7 / 桌面不设上限)。
- **富媒体编辑器附件上传**:插入菜单新增「上传文件」,不限图片/音视频,走通用 `uploadFile` 接口,按 Discourse 标准附件语法 `[文件名|attachment](upload://...)` 插入;选择器限制成站点白名单扩展名,避免选完了才 422;上传失败提示改用项目内 `ToastService`(m3e 风格)。
- **Win+V 剪贴板历史粘贴**:子模块指针更新到 [fluxdo_render#15](https://github.com/Lingyan000/fluxdo_render/pull/15) 的修复(抖动式 Ctrl 抬起不清补偿窗口)。

## 测试

`flutter analyze` + `flutter build windows --release` 均在本分支(基于最新 `dev`)验证通过。