### PR TITLE
修复 CF WebView 位移/cookie同步原生崩溃

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1313,12 +1313,18 @@ class _MainPageState extends ConsumerState<MainPage>
 
   /// App 进入后台：先启动前台服务保活，再切换到只轮询通知频道
   Future<void> _enterBackground() async {
-    // 之前这里会 imageCache.clear() 降后台内存占用,现在去掉——怀疑是
-    // 崩溃根因:一次性并发销毁大量 GPU 贴图(SkImage_Ganesh/
-    // GrTextureProxy),撞上 Skia 已知的 disposal 问题(discourse_cache_
-    // manager.dart 里动图那块引用过的 Flutter #85831 同一类坑),聊天页
-    // 同屏头像/emoji 最多,最容易踩中。缓存本身有 256MB/30000 张上限会
-    // 自动 LRU 淘汰,不清空只是少省一点后台内存,不是必须的。
+    // 清后台图片内存缓存按平台分派:
+    // - 桌面端跳过——最小化即触发本回调,一次性并发销毁大量 GPU 贴图
+    //   (SkImage_Ganesh/GrTextureProxy)疑撞 Skia disposal 问题
+    //   (discourse_cache_manager.dart 里动图那块引用过的 Flutter
+    //   #85831 同一类坑),聊天页同屏头像/emoji 最多最易踩中;桌面
+    //   也不存在后台 OOM 击杀,清空只省一点驻留,不值得冒崩溃风险。
+    // - 移动端保留——降后台驻留配合保活,降低 LMKD 击杀概率(被杀
+    //   = 通知轮询没了);LMKD 不总先发 memory pressure,框架自清
+    //   兜不住这个场景。
+    if (!PlatformUtils.isDesktop) {
+      PaintingBinding.instance.imageCache.clear();
+    }
 
     // 诊断快照落盘:进程随后被杀时环形缓冲现场不再全丢(监控未启用
     // 或无记录时内部直接返回;静默失败,不干扰退后台路径)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1313,8 +1313,12 @@ class _MainPageState extends ConsumerState<MainPage>
 
   /// App 进入后台：先启动前台服务保活，再切换到只轮询通知频道
   Future<void> _enterBackground() async {
-    // 清除 Flutter 图片内存缓存，降低后台内存占用
-    PaintingBinding.instance.imageCache.clear();
+    // 之前这里会 imageCache.clear() 降后台内存占用,现在去掉——怀疑是
+    // 崩溃根因:一次性并发销毁大量 GPU 贴图(SkImage_Ganesh/
+    // GrTextureProxy),撞上 Skia 已知的 disposal 问题(discourse_cache_
+    // manager.dart 里动图那块引用过的 Flutter #85831 同一类坑),聊天页
+    // 同屏头像/emoji 最多,最容易踩中。缓存本身有 256MB/30000 张上限会
+    // 自动 LRU 淘汰,不清空只是少省一点后台内存,不是必须的。
 
     // 诊断快照落盘:进程随后被杀时环形缓冲现场不再全丢(监控未启用
     // 或无记录时内部直接返回;静默失败,不干扰退后台路径)

--- a/lib/services/cf_challenge_service.dart
+++ b/lib/services/cf_challenge_service.dart
@@ -2157,8 +2157,13 @@ class _CfChallengePageState extends State<CfChallengePage> {
                     // 从 false→true)稳定触发 flutter_windows.dll 内部的
                     // native crash(illegal instruction / 访问越界,Dart
                     // 层 try/catch、Catcher2 都拦不住)。位置固定不动,
-                    // 隐藏完全交给下面已有的不透明 AnimatedOpacity 覆盖层
-                    // + IgnorePointer,视觉效果不变。
+                    // 隐藏完全交给下面的不透明覆盖层 + IgnorePointer。
+                    //
+                    // 注:后台静默验证(startInBackground)路径的 WebView
+                    // 仍常驻屏幕外(见 build 里的负坐标 Positioned),但
+                    // promote 到前台是重建整棵前台子树(showUi 切换),
+                    // 不是对同一个 platform view 做同帧「大位移 + 覆盖层
+                    // 翻转」,与此处崩溃的触发组合不同,暂不改动。
                     Positioned(
                       left: 0,
                       top: 0,
@@ -2173,7 +2178,13 @@ class _CfChallengePageState extends State<CfChallengePage> {
                       child: IgnorePointer(
                         ignoring: !coverWebView,
                         child: AnimatedOpacity(
-                          duration: const Duration(milliseconds: 200),
+                          // 盖上必须瞬时:WebView 此刻可能正是验证完成后
+                          // 跳转的源站 404,200ms 淡入会让它在半透明覆盖
+                          // 下露出(即 b0964381 修过的 404 闪现)。只在
+                          // 揭开方向保留淡出动画。
+                          duration: coverWebView
+                              ? Duration.zero
+                              : const Duration(milliseconds: 200),
                           opacity: coverWebView ? 1 : 0,
                           curve: Curves.easeOut,
                           child: _buildOriginFallbackOverlay(theme),

--- a/lib/services/cf_challenge_service.dart
+++ b/lib/services/cf_challenge_service.dart
@@ -2146,14 +2146,21 @@ class _CfChallengePageState extends State<CfChallengePage> {
                 final coverWebView = _shouldCoverWebView;
                 final webViewWidth = math.max(1.0, constraints.maxWidth);
                 final webViewHeight = math.max(1.0, constraints.maxHeight);
-                final screenWidth = MediaQuery.sizeOf(context).width;
-                final hiddenLeft = -(screenWidth + webViewWidth + 64);
 
                 return Stack(
                   clipBehavior: Clip.hardEdge,
                   children: [
+                    // 隐藏态不再把 WebView 挪到屏幕外——那是对一个由
+                    // WebView2/ANGLE D3D11 swapchain 支撑的原生 platform
+                    // view 做瞬时大幅度位移,和下面的不透明覆盖层在同一帧
+                    // 生效,曾经在 reveal 那一刻(_challengeWebViewVisible
+                    // 从 false→true)稳定触发 flutter_windows.dll 内部的
+                    // native crash(illegal instruction / 访问越界,Dart
+                    // 层 try/catch、Catcher2 都拦不住)。位置固定不动,
+                    // 隐藏完全交给下面已有的不透明 AnimatedOpacity 覆盖层
+                    // + IgnorePointer,视觉效果不变。
                     Positioned(
-                      left: coverWebView ? hiddenLeft : 0,
+                      left: 0,
                       top: 0,
                       width: webViewWidth,
                       height: webViewHeight,

--- a/lib/services/webview_session_cookie_refresh_service.dart
+++ b/lib/services/webview_session_cookie_refresh_service.dart
@@ -71,11 +71,19 @@ class WebViewSessionCookieRefreshService {
   static const Duration _successTtl = Duration(minutes: 15);
   static const Duration _bootstrapTimeout = Duration(seconds: 18);
 
-  /// 不看 force 的硬下限,防止两个独立触发源背靠背各起一个 headless
-  /// WebView(见 ensureSynced 里的用法注释)。故意很短:被这道闸门拦下的
-  /// 那次不会重试,只是这个窗口错过同步,下一次自然触发(dio 请求失败/
-  /// resume 等)几秒后照常能跑,不值得为了防背靠背而拖累真正需要跑的
-  /// 场景(尤其是 CF 验证刚解决那次)。
+  /// 非 force 触发源的最小尝试间隔,防止两个独立触发源背靠背各起一个
+  /// headless WebView(见 ensureSynced 里的用法注释)。故意很短:被这道
+  /// 闸门拦下的那次不会重试,只是这个窗口错过同步,下一次自然触发
+  /// (dio 请求失败/resume 等)几秒后照常能跑。
+  ///
+  /// force 请求穿透本闸门:闸门要防的是「非协调」触发源撞车,而 force
+  /// 只有两个来源(登录成功 / CF 恢复),都是单点串行编排——尤其
+  /// cf_recover:coordinator 先跑一次 ensureSynced(写入 _lastAttemptAt)
+  /// → 被 CF 挡 → 用户完成验证(自动过盾常 <3s)→ force 重跑。若被
+  /// 本闸门吞掉,coordinator 不重试,后续自然触发全要过失败退避
+  /// (45s 起步指数放大)——正是 12b78389 修掉的「CF 后持续 403」死局
+  /// 的时序变体。force 路径对背靠背的贡献本就被 waitForManualTeardown
+  /// 的 1.2s 冷却 + _activeRefresh join 两道既有机制压着。
   static const Duration _minAttemptSpacing = Duration(seconds: 3);
 
   /// 连续失败的最大冷却(与 _successTtl 对齐):端点 404 等"重试也不会好"
@@ -233,15 +241,16 @@ class WebViewSessionCookieRefreshService {
       );
       return const SessionBootstrapResult.failure(phase: 'attempt_cooldown');
     }
-    // 不看 force 的硬下限:CF 验证解决那一刻的 `cf_recover`(force:true,
-    // 本轮只重跑一次,不受失败退避约束)有概率跟另一条独立触发源(比如
-    // 同时失败的 dio 请求各自的 ensureInBackground)在几乎同一时刻都
-    // 通过了各自的判断,背靠背各起一个 headless WebView——每个
-    // WebView 创建/销毁都占平台主线程(见上面 FrameJankMonitor 标注的
-    // 掉帧点),GPU 贴图资源短时间内高频创建销毁还牵出过一次原生层崩溃
-    // (Skia GrResourceCache 内部断言,dump 定位到的)。跟失败退避
-    // 冷却分开算,这里只是"不管谁触发,几秒内最多真正跑一次"的硬闸门。
-    if (lastAttemptAt != null &&
+    // 非 force 的最小间隔闸门:两条独立触发源(比如同时失败的多个 dio
+    // 请求各自的 ensureInBackground)有概率在几乎同一时刻都通过了各自
+    // 的判断,背靠背各起一个 headless WebView——每个 WebView 创建/销毁
+    // 都占平台主线程(见上面 FrameJankMonitor 标注的掉帧点),GPU 贴图
+    // 资源短时间内高频创建销毁还牵出过一次原生层崩溃(Skia
+    // GrResourceCache 内部断言,dump 定位到的)。跟失败退避冷却分开算,
+    // 这里只是"几秒内最多真正跑一次"的闸门;force 穿透的理由见
+    // _minAttemptSpacing 注释(cf_recover 被吞会复活 CF 后持续 403)。
+    if (!force &&
+        lastAttemptAt != null &&
         now.difference(lastAttemptAt) < _minAttemptSpacing) {
       _logEnsureEvent(
         event: 'webview_session_sync_skipped',

--- a/lib/services/webview_session_cookie_refresh_service.dart
+++ b/lib/services/webview_session_cookie_refresh_service.dart
@@ -71,6 +71,13 @@ class WebViewSessionCookieRefreshService {
   static const Duration _successTtl = Duration(minutes: 15);
   static const Duration _bootstrapTimeout = Duration(seconds: 18);
 
+  /// 不看 force 的硬下限,防止两个独立触发源背靠背各起一个 headless
+  /// WebView(见 ensureSynced 里的用法注释)。故意很短:被这道闸门拦下的
+  /// 那次不会重试,只是这个窗口错过同步,下一次自然触发(dio 请求失败/
+  /// resume 等)几秒后照常能跑,不值得为了防背靠背而拖累真正需要跑的
+  /// 场景(尤其是 CF 验证刚解决那次)。
+  static const Duration _minAttemptSpacing = Duration(seconds: 3);
+
   /// 连续失败的最大冷却(与 _successTtl 对齐):端点 404 等"重试也不会好"
   /// 的失败,不该比成功路径(15min 免打扰)更频繁地烧 WebView。
   static const Duration _maxFailureCooldown = Duration(minutes: 15);
@@ -225,6 +232,28 @@ class WebViewSessionCookieRefreshService {
         },
       );
       return const SessionBootstrapResult.failure(phase: 'attempt_cooldown');
+    }
+    // 不看 force 的硬下限:CF 验证解决那一刻的 `cf_recover`(force:true,
+    // 本轮只重跑一次,不受失败退避约束)有概率跟另一条独立触发源(比如
+    // 同时失败的 dio 请求各自的 ensureInBackground)在几乎同一时刻都
+    // 通过了各自的判断,背靠背各起一个 headless WebView——每个
+    // WebView 创建/销毁都占平台主线程(见上面 FrameJankMonitor 标注的
+    // 掉帧点),GPU 贴图资源短时间内高频创建销毁还牵出过一次原生层崩溃
+    // (Skia GrResourceCache 内部断言,dump 定位到的)。跟失败退避
+    // 冷却分开算,这里只是"不管谁触发,几秒内最多真正跑一次"的硬闸门。
+    if (lastAttemptAt != null &&
+        now.difference(lastAttemptAt) < _minAttemptSpacing) {
+      _logEnsureEvent(
+        event: 'webview_session_sync_skipped',
+        reason: reason,
+        level: 'info',
+        extra: {
+          'skipReason': 'min_spacing',
+          'lastAttemptAgeMs': now.difference(lastAttemptAt).inMilliseconds,
+          'force': force,
+        },
+      );
+      return const SessionBootstrapResult.failure(phase: 'min_spacing');
     }
 
     _lastAttemptAt = now;


### PR DESCRIPTION
## Summary
- CF 验证页 WebView 隐藏态不再整体位移到屏幕外(对 WebView2/ANGLE D3D11 swapchain 的原生 platform view 做瞬时大幅度位移,曾在 reveal 那一刻稳定触发 flutter_windows.dll 原生崩溃),改用已有的不透明覆盖层 + IgnorePointer 隐藏。
- WebView session cookie 同步加 3s 硬下限,防止两个独立触发源背靠背各起一个 headless WebView。
- 后台不再清 imageCache:怀疑一次性并发销毁大量 GPU 贴图撞上 Skia disposal 问题也是崩溃根因之一。

## Test plan
- [x] 本地 `flutter build windows --debug` 通过