### PR TITLE
私聊(Discourse Chat 插件 DM)功能引入 + 未读/崩溃/onebox/贴纸等修复

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -896,6 +896,7 @@ class _MainPageState extends ConsumerState<MainPage>
   ProviderSubscription<void>? _messageBusSub;
   ProviderSubscription<void>? _notificationChannelSub;
   ProviderSubscription<void>? _notificationAlertChannelSub;
+  ProviderSubscription<void>? _chatNotificationAlertChannelSub;
   ProviderSubscription<AsyncValue<bool>>? _connectivitySub;
   bool _messageBusInitialized = false;
   int? _lastTappedIndex;
@@ -1000,6 +1001,11 @@ class _MainPageState extends ConsumerState<MainPage>
             notificationAlertChannelProvider,
             (_, _) {},
           );
+          _chatNotificationAlertChannelSub?.close();
+          _chatNotificationAlertChannelSub = ref.listenManual<void>(
+            chatNotificationAlertChannelProvider,
+            (_, _) {},
+          );
         });
       } else if (user == null) {
         _messageBusInitialized = false;
@@ -1009,6 +1015,8 @@ class _MainPageState extends ConsumerState<MainPage>
         _notificationChannelSub = null;
         _notificationAlertChannelSub?.close();
         _notificationAlertChannelSub = null;
+        _chatNotificationAlertChannelSub?.close();
+        _chatNotificationAlertChannelSub = null;
       }
     }, fireImmediately: true);
   }
@@ -1170,6 +1178,7 @@ class _MainPageState extends ConsumerState<MainPage>
     _messageBusSub?.close();
     _notificationChannelSub?.close();
     _notificationAlertChannelSub?.close();
+    _chatNotificationAlertChannelSub?.close();
     _connectivitySub?.close();
     super.dispose();
   }

--- a/lib/models/chat/chat_channel.dart
+++ b/lib/models/chat/chat_channel.dart
@@ -1,0 +1,217 @@
+import '../mention_user.dart';
+import '../../utils/time_utils.dart';
+
+/// 频道内当前用户的成员关系（未读数/免打扰状态等）
+class ChatMembership {
+  final bool following;
+  final bool muted;
+  final bool starred;
+  final int unreadCount;
+  final int unreadMentions;
+  final int? lastReadMessageId;
+
+  /// 通知级别,对应 `Chat::UserChatChannelMembership::NOTIFICATION_LEVELS`
+  /// (never=0, mention=1, always=2)。
+  final int notificationLevel;
+
+  const ChatMembership({
+    this.following = false,
+    this.muted = false,
+    this.starred = false,
+    this.unreadCount = 0,
+    this.unreadMentions = 0,
+    this.lastReadMessageId,
+    this.notificationLevel = 2,
+  });
+
+  /// `starred` 字段核对过 Discourse 源码
+  /// `Chat::BaseChannelMembershipSerializer`,任意频道(含 DM)都能收藏,
+  /// 通过 `PUT /chat/api/channels/:id/memberships/me` 切换
+  /// (`Chat::UpdateUserChannelMembership`)。
+  factory ChatMembership.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return const ChatMembership();
+    return ChatMembership(
+      following: json['following'] as bool? ?? false,
+      muted: json['muted'] as bool? ?? false,
+      starred: json['starred'] as bool? ?? false,
+      unreadCount: json['unread_count'] as int? ?? 0,
+      unreadMentions: json['unread_mentions'] as int? ?? 0,
+      lastReadMessageId: json['last_read_message_id'] as int?,
+      notificationLevel: _parseNotificationLevel(json['notification_level']),
+    );
+  }
+
+  /// 序列化端给的是枚举名字符串("never"/"mention"/"always"),
+  /// 但也兼容数字形态。
+  static int _parseNotificationLevel(dynamic value) {
+    if (value is int) return value;
+    switch (value) {
+      case 'never':
+        return 0;
+      case 'mention':
+        return 1;
+      case 'always':
+        return 2;
+    }
+    return 2;
+  }
+
+  ChatMembership copyWith({
+    bool? following,
+    bool? muted,
+    bool? starred,
+    int? unreadCount,
+    int? unreadMentions,
+    int? lastReadMessageId,
+    int? notificationLevel,
+  }) {
+    return ChatMembership(
+      following: following ?? this.following,
+      muted: muted ?? this.muted,
+      starred: starred ?? this.starred,
+      unreadCount: unreadCount ?? this.unreadCount,
+      unreadMentions: unreadMentions ?? this.unreadMentions,
+      lastReadMessageId: lastReadMessageId ?? this.lastReadMessageId,
+      notificationLevel: notificationLevel ?? this.notificationLevel,
+    );
+  }
+}
+
+/// 频道最后一条消息的摘要，用于列表页预览
+class ChatLastMessage {
+  final int? id;
+  final String? message;
+  final DateTime? createdAt;
+
+  const ChatLastMessage({this.id, this.message, this.createdAt});
+
+  /// 实测线上接口里,刚创建、还没人发过消息的频道会给一个
+  /// `{id: null, message: null, ...}` 的空壳 last_message,不是完全省略
+  /// 这个字段——所以字段本身用 `as int?`,不能假设非空。
+  factory ChatLastMessage.fromJson(Map<String, dynamic> json) {
+    return ChatLastMessage(
+      id: json['id'] as int?,
+      message: json['message'] as String?,
+      createdAt: TimeUtils.parseUtcTime(json['created_at'] as String?),
+    );
+  }
+}
+
+/// Chat 插件的频道(DM 或公共频道,按 [chatableType] 区分)
+class ChatChannel {
+  final int id;
+  final String? title;
+  final String? slug;
+  final String chatableType;
+  final int? chatableId;
+  final String? description;
+  final bool threadingEnabled;
+  final bool isGroup;
+
+  /// 公共频道挂靠的类别名(chatable_type == Category 时)
+  final String? categoryName;
+
+  /// 频道成员数(memberships_count)
+  final int? membershipsCount;
+
+  /// 能力位,来自序列化 meta(scope 按当前用户算好):没权限的设置项
+  /// UI 直接不显示,而不是点了 403。
+  final bool canModerate;
+  final bool canManagePins;
+  final List<MentionUser> participants;
+  final ChatLastMessage? lastMessage;
+  final ChatMembership membership;
+  final int? messageBusLastId;
+
+  const ChatChannel({
+    required this.id,
+    this.title,
+    this.slug,
+    required this.chatableType,
+    this.chatableId,
+    this.description,
+    this.threadingEnabled = false,
+    this.isGroup = false,
+    this.categoryName,
+    this.membershipsCount,
+    this.canModerate = false,
+    this.canManagePins = false,
+    this.participants = const [],
+    this.lastMessage,
+    this.membership = const ChatMembership(),
+    this.messageBusLastId,
+  });
+
+  /// 是否是私聊(DM)频道;否则是分类挂靠的公共频道(chatable_type: Category)。
+  bool get isDirectMessage => chatableType == 'DirectMessage';
+
+  factory ChatChannel.fromJson(Map<String, dynamic> json) {
+    final chatable = json['chatable'] as Map<String, dynamic>?;
+    final usersJson = chatable?['users'] as List<dynamic>? ?? const [];
+    final meta = json['meta'] as Map<String, dynamic>?;
+    final messageBusLastIds = meta?['message_bus_last_ids'] as Map<String, dynamic>?;
+
+    return ChatChannel(
+      id: json['id'] as int,
+      title: json['title'] as String?,
+      slug: json['slug'] as String?,
+      chatableType: json['chatable_type'] as String? ?? 'DirectMessage',
+      chatableId: json['chatable_id'] as int?,
+      description: json['description'] as String?,
+      threadingEnabled: json['threading_enabled'] as bool? ?? false,
+      categoryName: json['chatable_type'] == 'Category'
+          ? (chatable?['name'] as String?)
+          : null,
+      membershipsCount: json['memberships_count'] as int?,
+      canModerate: meta?['can_moderate'] as bool? ?? false,
+      canManagePins: meta?['can_manage_pins'] as bool? ?? false,
+      isGroup: chatable?['group'] as bool? ?? usersJson.length > 1,
+      participants: usersJson
+          .map((e) => MentionUser.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      lastMessage: json['last_message'] != null
+          ? ChatLastMessage.fromJson(json['last_message'] as Map<String, dynamic>)
+          : null,
+      membership: ChatMembership.fromJson(json['current_user_membership'] as Map<String, dynamic>?),
+      // 频道内新消息推送(`/chat/{id}/new-messages`)对应的是 meta 里的
+      // `new_messages` 这个子键,不是 `channel_message_bus_last_id`(那个是
+      // 频道根 MessageBus 频道的 last id,语义不同,订阅新消息用错键会导致
+      // 服务端从错误的位置起播积压消息)。
+      messageBusLastId: messageBusLastIds?['new_messages'] as int?,
+    );
+  }
+
+  ChatChannel copyWith({
+    ChatLastMessage? lastMessage,
+    ChatMembership? membership,
+    bool? threadingEnabled,
+  }) {
+    return ChatChannel(
+      id: id,
+      title: title,
+      slug: slug,
+      chatableType: chatableType,
+      chatableId: chatableId,
+      description: description,
+      threadingEnabled: threadingEnabled ?? this.threadingEnabled,
+      isGroup: isGroup,
+      categoryName: categoryName,
+      membershipsCount: membershipsCount,
+      canModerate: canModerate,
+      canManagePins: canManagePins,
+      participants: participants,
+      lastMessage: lastMessage ?? this.lastMessage,
+      membership: membership ?? this.membership,
+      messageBusLastId: messageBusLastId,
+    );
+  }
+
+  /// 除当前用户外的对方（单聊场景），拿不到时兜底取第一个
+  MentionUser? otherParticipant(String currentUsername) {
+    if (participants.isEmpty) return null;
+    for (final p in participants) {
+      if (p.username != currentUsername) return p;
+    }
+    return participants.first;
+  }
+}

--- a/lib/models/chat/chat_channel.dart
+++ b/lib/models/chat/chat_channel.dart
@@ -102,6 +102,8 @@ class ChatChannel {
   final int id;
   final String? title;
   final String? slug;
+  /// 群聊自定义图标(表情短代码,不带冒号),没设置过为 null
+  final String? emoji;
   final String chatableType;
   final int? chatableId;
   final String? description;
@@ -127,6 +129,7 @@ class ChatChannel {
     required this.id,
     this.title,
     this.slug,
+    this.emoji,
     required this.chatableType,
     this.chatableId,
     this.description,
@@ -155,6 +158,7 @@ class ChatChannel {
       id: json['id'] as int,
       title: json['title'] as String?,
       slug: json['slug'] as String?,
+      emoji: json['emoji'] as String?,
       chatableType: json['chatable_type'] as String? ?? 'DirectMessage',
       chatableId: json['chatable_id'] as int?,
       description: json['description'] as String?,
@@ -185,11 +189,15 @@ class ChatChannel {
     ChatLastMessage? lastMessage,
     ChatMembership? membership,
     bool? threadingEnabled,
+    String? title,
+    String? slug,
+    String? emoji,
   }) {
     return ChatChannel(
       id: id,
-      title: title,
-      slug: slug,
+      title: title ?? this.title,
+      slug: slug ?? this.slug,
+      emoji: emoji ?? this.emoji,
       chatableType: chatableType,
       chatableId: chatableId,
       description: description,

--- a/lib/models/chat/chat_message.dart
+++ b/lib/models/chat/chat_message.dart
@@ -11,18 +11,25 @@ class ChatReaction {
   final String emoji;
   final int count;
   final bool reacted;
+  /// 最多 5 个(服务端 `reactions.take(5)`),数量超过 5 时仅展示前几个
+  final List<ChatMessageUser> users;
 
   const ChatReaction({
     required this.emoji,
     required this.count,
     required this.reacted,
+    this.users = const [],
   });
 
   factory ChatReaction.fromJson(Map<String, dynamic> json) {
+    final usersJson = json['users'] as List<dynamic>? ?? const [];
     return ChatReaction(
       emoji: json['emoji'] as String,
       count: json['count'] as int? ?? 0,
       reacted: json['reacted'] as bool? ?? false,
+      users: usersJson
+          .map((u) => ChatMessageUser.fromJson(u as Map<String, dynamic>))
+          .toList(),
     );
   }
 }
@@ -87,15 +94,34 @@ class ChatThreadInfo {
   final int id;
   final String? title;
   final int replyCount;
+  /// 以下三个来自 `preview`(`Chat::ThreadPreviewSerializer`),服务端要
+  /// `include_thread_preview` opt 才会给,没有就是 null,UI 要能优雅降级。
+  final String? lastReplyExcerpt;
+  final ChatMessageUser? lastReplyUser;
+  final DateTime? lastReplyCreatedAt;
 
-  const ChatThreadInfo({required this.id, this.title, this.replyCount = 0});
+  const ChatThreadInfo({
+    required this.id,
+    this.title,
+    this.replyCount = 0,
+    this.lastReplyExcerpt,
+    this.lastReplyUser,
+    this.lastReplyCreatedAt,
+  });
 
   factory ChatThreadInfo.fromJson(Map<String, dynamic> json) {
     final preview = json['preview'] as Map<String, dynamic>?;
+    final lastReplyUserJson = preview?['last_reply_user'] as Map<String, dynamic>?;
     return ChatThreadInfo(
       id: json['id'] as int,
       title: json['title'] as String?,
       replyCount: (preview?['reply_count'] ?? json['reply_count']) as int? ?? 0,
+      lastReplyExcerpt: preview?['last_reply_excerpt'] as String?,
+      lastReplyUser: lastReplyUserJson == null
+          ? null
+          : ChatMessageUser.fromJson(lastReplyUserJson),
+      lastReplyCreatedAt:
+          TimeUtils.parseUtcTime(preview?['last_reply_created_at'] as String?),
     );
   }
 }

--- a/lib/models/chat/chat_message.dart
+++ b/lib/models/chat/chat_message.dart
@@ -1,0 +1,244 @@
+import '../mention_user.dart';
+import '../../utils/time_utils.dart';
+
+/// Chat 插件消息里的发送者，字段和 MentionUser 一致，直接复用其解析逻辑
+typedef ChatMessageUser = MentionUser;
+
+/// 消息上的一个表情回应聚合(同一 emoji 的所有人合并成一条)。核对过
+/// Discourse 源码 `Chat::MessageSerializer#reactions`:按 emoji 分组,
+/// `reacted` 是当前用户是否在其中。
+class ChatReaction {
+  final String emoji;
+  final int count;
+  final bool reacted;
+
+  const ChatReaction({
+    required this.emoji,
+    required this.count,
+    required this.reacted,
+  });
+
+  factory ChatReaction.fromJson(Map<String, dynamic> json) {
+    return ChatReaction(
+      emoji: json['emoji'] as String,
+      count: json['count'] as int? ?? 0,
+      reacted: json['reacted'] as bool? ?? false,
+    );
+  }
+}
+
+/// 被回复消息的摘要(`Chat::InReplyToSerializer`:id/cooked/excerpt/user)。
+class ChatInReplyTo {
+  final int id;
+  final String? excerpt;
+  final String? username;
+
+  const ChatInReplyTo({required this.id, this.excerpt, this.username});
+
+  factory ChatInReplyTo.fromJson(Map<String, dynamic> json) {
+    final user = json['user'] as Map<String, dynamic>?;
+    return ChatInReplyTo(
+      id: json['id'] as int,
+      excerpt: json['excerpt'] as String?,
+      username: user?['username'] as String?,
+    );
+  }
+}
+
+/// 消息附带的上传文件(标准 `UploadSerializer`)。图片/附件**不在 cooked
+/// 里**——官方 `Chat::MessageSerializer` 把 uploads 单独序列化,网页端也是
+/// 在正文下方单独渲染的,不解析这个字段就永远"收不到图片"。
+class ChatUpload {
+  final int? id;
+  final String url;
+  final String? originalFilename;
+  final String? extension;
+  final int? width;
+  final int? height;
+
+  const ChatUpload({
+    this.id,
+    required this.url,
+    this.originalFilename,
+    this.extension,
+    this.width,
+    this.height,
+  });
+
+  factory ChatUpload.fromJson(Map<String, dynamic> json) {
+    return ChatUpload(
+      id: json['id'] as int?,
+      url: json['url'] as String? ?? '',
+      originalFilename: json['original_filename'] as String?,
+      extension: json['extension'] as String?,
+      width: json['width'] as int?,
+      height: json['height'] as int?,
+    );
+  }
+
+  bool get isImage => const {
+        'png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'bmp',
+      }.contains(extension?.toLowerCase());
+}
+
+/// 消息串信息(线程原始消息上的 `thread` 字段,`Chat::ThreadSerializer`:
+/// id/title/reply_count + preview.reply_count)。
+class ChatThreadInfo {
+  final int id;
+  final String? title;
+  final int replyCount;
+
+  const ChatThreadInfo({required this.id, this.title, this.replyCount = 0});
+
+  factory ChatThreadInfo.fromJson(Map<String, dynamic> json) {
+    final preview = json['preview'] as Map<String, dynamic>?;
+    return ChatThreadInfo(
+      id: json['id'] as int,
+      title: json['title'] as String?,
+      replyCount: (preview?['reply_count'] ?? json['reply_count']) as int? ?? 0,
+    );
+  }
+}
+
+/// 消息上的书签(`Chat::MessageSerializer` 的 `bookmark` 字段,当前用户
+/// 给这条消息加过书签才有)。
+class ChatBookmark {
+  final int id;
+  final String? name;
+  final DateTime? reminderAt;
+
+  const ChatBookmark({required this.id, this.name, this.reminderAt});
+
+  factory ChatBookmark.fromJson(Map<String, dynamic> json) {
+    return ChatBookmark(
+      id: json['id'] as int,
+      name: json['name'] as String?,
+      reminderAt: TimeUtils.parseUtcTime(json['reminder_at'] as String?),
+    );
+  }
+}
+
+/// Chat 插件的单条消息
+class ChatMessage {
+  final int id;
+  final int channelId;
+  final String? message;
+  final String? cooked;
+  final String? excerpt;
+  final DateTime? createdAt;
+  final DateTime? deletedAt;
+  final int? threadId;
+  final bool edited;
+  final ChatMessageUser? user;
+  final int? inReplyToId;
+  final ChatInReplyTo? inReplyTo;
+  final bool pinned;
+  final List<ChatReaction> reactions;
+  final List<ChatUpload> uploads;
+
+  /// 搜索接口(include_channel)会附带所属频道的标题,普通消息流没有
+  final String? channelTitle;
+
+  /// 消息串:线程"原始消息"上带完整 thread 对象;线程内回复只带
+  /// thread_id(+ thread_title)。
+  final ChatThreadInfo? thread;
+  final String? threadTitle;
+
+  /// 当前用户给这条消息加的书签(没加过为 null)
+  final ChatBookmark? bookmark;
+
+  const ChatMessage({
+    required this.id,
+    required this.channelId,
+    this.message,
+    this.cooked,
+    this.excerpt,
+    this.createdAt,
+    this.deletedAt,
+    this.threadId,
+    this.edited = false,
+    this.user,
+    this.inReplyToId,
+    this.inReplyTo,
+    this.pinned = false,
+    this.reactions = const [],
+    this.uploads = const [],
+    this.channelTitle,
+    this.thread,
+    this.threadTitle,
+    this.bookmark,
+  });
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) {
+    final inReplyTo = json['in_reply_to'] as Map<String, dynamic>?;
+    final reactionsJson = json['reactions'] as List<dynamic>? ?? const [];
+    return ChatMessage(
+      id: json['id'] as int,
+      channelId: json['chat_channel_id'] as int,
+      message: json['message'] as String?,
+      cooked: json['cooked'] as String?,
+      excerpt: json['excerpt'] as String?,
+      createdAt: TimeUtils.parseUtcTime(json['created_at'] as String?),
+      deletedAt: TimeUtils.parseUtcTime(json['deleted_at'] as String?),
+      threadId: json['thread_id'] as int?,
+      edited: json['edited'] as bool? ?? false,
+      user: json['user'] != null
+          ? ChatMessageUser.fromJson(json['user'] as Map<String, dynamic>)
+          : null,
+      inReplyToId: inReplyTo?['id'] as int?,
+      inReplyTo: inReplyTo != null ? ChatInReplyTo.fromJson(inReplyTo) : null,
+      pinned: json['pinned'] as bool? ?? false,
+      reactions: reactionsJson
+          .map((e) => ChatReaction.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      uploads: (json['uploads'] as List<dynamic>? ?? const [])
+          .map((e) => ChatUpload.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      channelTitle:
+          (json['channel'] as Map<String, dynamic>?)?['title'] as String?,
+      thread: json['thread'] is Map<String, dynamic>
+          ? ChatThreadInfo.fromJson(json['thread'] as Map<String, dynamic>)
+          : null,
+      threadTitle: json['thread_title'] as String?,
+      bookmark: json['bookmark'] is Map<String, dynamic>
+          ? ChatBookmark.fromJson(json['bookmark'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  bool get isDeleted => deletedAt != null;
+
+  ChatMessage copyWith({
+    List<ChatReaction>? reactions,
+    bool? pinned,
+    DateTime? deletedAt,
+    bool clearDeletedAt = false,
+    ChatBookmark? bookmark,
+    bool clearBookmark = false,
+  }) {
+    return ChatMessage(
+      id: id,
+      channelId: channelId,
+      message: message,
+      cooked: cooked,
+      excerpt: excerpt,
+      createdAt: createdAt,
+      deletedAt: clearDeletedAt ? null : (deletedAt ?? this.deletedAt),
+      threadId: threadId,
+      edited: edited,
+      user: user,
+      inReplyToId: inReplyToId,
+      inReplyTo: inReplyTo,
+      pinned: pinned ?? this.pinned,
+      reactions: reactions ?? this.reactions,
+      uploads: uploads,
+      channelTitle: channelTitle,
+      thread: thread,
+      threadTitle: threadTitle,
+      bookmark: clearBookmark ? null : (bookmark ?? this.bookmark),
+    );
+  }
+
+  ChatMessage copyWithReactions(List<ChatReaction> newReactions) =>
+      copyWith(reactions: newReactions);
+}

--- a/lib/models/mention_user.dart
+++ b/lib/models/mention_user.dart
@@ -33,6 +33,7 @@ class UserCustomStatus {
 
 /// 用户提及搜索结果中的用户
 class MentionUser {
+  final int? id;
   final String username;
   final String? name;
   final String? avatarTemplate;
@@ -40,6 +41,7 @@ class MentionUser {
   final UserCustomStatus? status;
 
   const MentionUser({
+    this.id,
     required this.username,
     this.name,
     this.avatarTemplate,
@@ -49,6 +51,7 @@ class MentionUser {
 
   factory MentionUser.fromJson(Map<String, dynamic> json) {
     return MentionUser(
+      id: json['id'] as int?,
       username: json['username'] as String,
       name: json['name'] as String?,
       avatarTemplate: json['avatar_template'] as String?,
@@ -65,6 +68,11 @@ class MentionUser {
     final url = avatarTemplate!.replaceAll('{size}', size.toString());
     return UrlHelper.resolveUrlWithCdn(url);
   }
+
+  /// 展示名:优先真实姓名,姓名为空(很多用户没填,服务端给的是空字符串
+  /// 不是 null)则退到用户名。**不要**用 `name ?? username` 代替——`??`
+  /// 只在 null 时才回退,空字符串会直接把用户名顶掉,显示成空白。
+  String get displayName => name?.isNotEmpty == true ? name! : username;
 }
 
 /// 用户提及搜索结果中的群组

--- a/lib/models/mention_user.dart
+++ b/lib/models/mention_user.dart
@@ -15,18 +15,36 @@ List<String> extractMentionNames(String text) {
   return names.toList();
 }
 
+/// 用户自定义状态(站点开启 enable_user_status 时序列化端附带的
+/// `status: {emoji, description, ends_at}`)。
+class UserCustomStatus {
+  final String? emoji;
+  final String? description;
+
+  const UserCustomStatus({this.emoji, this.description});
+
+  factory UserCustomStatus.fromJson(Map<String, dynamic> json) {
+    return UserCustomStatus(
+      emoji: json['emoji'] as String?,
+      description: json['description'] as String?,
+    );
+  }
+}
+
 /// 用户提及搜索结果中的用户
 class MentionUser {
   final String username;
   final String? name;
   final String? avatarTemplate;
   final int? priorityGroup;
+  final UserCustomStatus? status;
 
   const MentionUser({
     required this.username,
     this.name,
     this.avatarTemplate,
     this.priorityGroup,
+    this.status,
   });
 
   factory MentionUser.fromJson(Map<String, dynamic> json) {
@@ -35,6 +53,9 @@ class MentionUser {
       name: json['name'] as String?,
       avatarTemplate: json['avatar_template'] as String?,
       priorityGroup: json['priority_group'] as int?,
+      status: json['status'] is Map<String, dynamic>
+          ? UserCustomStatus.fromJson(json['status'] as Map<String, dynamic>)
+          : null,
     );
   }
 

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -2169,6 +2169,9 @@ class FlagType {
   /// 是否适用于帖子
   bool get appliesToPost => appliesTo.contains('Post');
 
+  /// 是否适用于聊天消息(Chat 插件)
+  bool get appliesToChatMessage => appliesTo.contains('Chat::Message');
+
   /// 默认的举报类型列表（作为后备）
   static List<FlagType> get defaultTypes => [
     FlagType(

--- a/lib/navigation/nav_action_bus.dart
+++ b/lib/navigation/nav_action_bus.dart
@@ -193,5 +193,6 @@ class NavEntryIds {
   static const String drafts = 'drafts';
   static const String notifications = 'notifications';
   static const String messages = 'messages';
+  static const String chat = 'chat';
   static const String seeking = 'seeking';
 }

--- a/lib/navigation/nav_entry_registry.dart
+++ b/lib/navigation/nav_entry_registry.dart
@@ -7,6 +7,7 @@ import '../models/user.dart';
 import '../pages/bookmarks_page.dart';
 import '../pages/browsing_history_page.dart';
 import '../pages/drafts_page.dart';
+import '../pages/chat/dm_channel_list_page.dart';
 import '../pages/private_messages_page.dart';
 import '../pages/profile_page.dart';
 import '../pages/seeking_page.dart';
@@ -88,6 +89,15 @@ class NavEntryRegistry {
         label: (ctx) => ctx.l10n.nav_messages,
         pageBuilder: (ctx, isActive) =>
             PrivateMessagesPage(isActive: isActive),
+        requiresLogin: true,
+      ),
+      NavEntry(
+        id: NavEntryIds.chat,
+        kind: NavEntryKind.page,
+        iconData: Symbols.chat_rounded,
+        selectedIconData: Symbols.chat_rounded,
+        label: (ctx) => '聊天',
+        pageBuilder: (ctx, isActive) => DmChannelListPage(isActive: isActive),
         requiresLogin: true,
       ),
       NavEntry(

--- a/lib/pages/bottom_nav_settings_page.dart
+++ b/lib/pages/bottom_nav_settings_page.dart
@@ -19,6 +19,7 @@ import '../settings/definitions/bottom_nav_defs.dart';
 import '../settings/settings_model.dart';
 import '../settings/settings_renderer.dart';
 import '../utils/dialog_utils.dart';
+import '../utils/responsive.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 
 /// 底栏设置页
@@ -28,7 +29,11 @@ import 'package:m3e_ui/m3e_ui.dart';
 /// - 中部：可添加的候选池（点 + 加入）
 /// - 底部：手势分组（复用 [SettingsRenderer] 渲染 bottom_nav_defs 的 ActionModel）
 ///
-/// 约束：2 ≤ 已启用数量 ≤ 5；locked entry（home、profile）不可移除。
+/// 约束：2 ≤ 已启用数量 ≤ 上限；locked entry（home、profile）不可移除。
+///
+/// 上限按屏幕宽度自适应,不再是写死的 5——手机底栏是横向 `NavigationBar`,
+/// 塞太多图标会被越挤越窄;平板/桌面走的是竖排 `NavigationRail`,横向
+/// 空间宽裕,没必要卡在手机的上限,直接放开到全部已注册入口数。
 class BottomNavSettingsPage extends ConsumerStatefulWidget {
   final String? highlightId;
 
@@ -42,7 +47,19 @@ class BottomNavSettingsPage extends ConsumerStatefulWidget {
 class _BottomNavSettingsPageState
     extends ConsumerState<BottomNavSettingsPage> {
   static const int _minCount = 2;
-  static const int _maxCount = 5;
+
+  /// 手机横向底栏容易被挤,上限保守;平板竖排 rail 空间宽裕给到 7;
+  /// 桌面宽屏干脆不设人为上限,放开到当前全部已注册入口数。
+  int get _maxCount {
+    switch (Responsive.getDeviceType(context)) {
+      case DeviceType.mobile:
+        return 5;
+      case DeviceType.tablet:
+        return 7;
+      case DeviceType.desktop:
+        return NavEntryRegistry.buildAll().length;
+    }
+  }
 
   late List<String> _enabledIds;
 

--- a/lib/pages/chat/chat_search_dialog.dart
+++ b/lib/pages/chat/chat_search_dialog.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:m3e_ui/m3e_ui.dart';
+
+import '../../constants.dart';
+import '../../models/chat/chat_message.dart';
+import '../../providers/core_providers.dart';
+import '../../utils/time_utils.dart';
+import '../../widgets/common/smart_avatar.dart';
+
+/// 聊天搜索弹窗(`GET /chat/api/search`):[channelId] 非空时只搜该频道。
+/// 支持 相关/最新 两种排序(对应接口的 sort=relevance|latest)。
+/// 返回用户点选的那条消息。
+Future<ChatMessage?> showChatSearchDialog(
+  BuildContext context, {
+  int? channelId,
+}) {
+  return showDialog<ChatMessage>(
+    context: context,
+    builder: (_) => _ChatSearchDialog(channelId: channelId),
+  );
+}
+
+class _ChatSearchDialog extends ConsumerStatefulWidget {
+  const _ChatSearchDialog({this.channelId});
+
+  final int? channelId;
+
+  @override
+  ConsumerState<_ChatSearchDialog> createState() => _ChatSearchDialogState();
+}
+
+class _ChatSearchDialogState extends ConsumerState<_ChatSearchDialog> {
+  final TextEditingController _controller = TextEditingController();
+  Timer? _debounce;
+  Future<List<ChatMessage>>? _future;
+  String _sort = 'relevance';
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _search({bool immediate = false}) {
+    _debounce?.cancel();
+    void run() {
+      if (!mounted) return;
+      final query = _controller.text.trim();
+      setState(() {
+        _future = query.isEmpty
+            ? null
+            : ref.read(discourseServiceProvider).searchChatMessages(
+                  query,
+                  channelId: widget.channelId,
+                  sort: _sort,
+                );
+      });
+    }
+
+    if (immediate) {
+      run();
+    } else {
+      _debounce = Timer(const Duration(milliseconds: 400), run);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(widget.channelId != null ? '搜索本频道' : '搜索聊天'),
+      content: SizedBox(
+        width: 460,
+        height: 460,
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              autofocus: true,
+              onChanged: (_) => _search(),
+              decoration: const InputDecoration(
+                hintText: '搜索消息…',
+                prefixIcon: Icon(Icons.search_rounded),
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                SegmentedButton<String>(
+                  showSelectedIcon: false,
+                  style: const ButtonStyle(
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  segments: const [
+                    ButtonSegment(value: 'relevance', label: Text('相关')),
+                    ButtonSegment(value: 'latest', label: Text('最新')),
+                  ],
+                  selected: {_sort},
+                  onSelectionChanged: (selection) {
+                    _sort = selection.first;
+                    _search(immediate: true);
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: _future == null
+                  ? const Center(
+                      child: Text('输入关键词搜索聊天记录',
+                          style: TextStyle(color: Colors.grey)))
+                  : FutureBuilder<List<ChatMessage>>(
+                      future: _future,
+                      builder: (ctx, snapshot) {
+                        if (snapshot.connectionState != ConnectionState.done) {
+                          return const Center(child: LoadingSpinner());
+                        }
+                        if (snapshot.hasError) {
+                          return Center(child: Text('搜索失败: ${snapshot.error}'));
+                        }
+                        final results = snapshot.data ?? const [];
+                        if (results.isEmpty) {
+                          return const Center(
+                              child: Text('没有匹配的消息',
+                                  style: TextStyle(color: Colors.grey)));
+                        }
+                        return ListView.builder(
+                          itemCount: results.length,
+                          itemBuilder: (ctx, index) {
+                            final msg = results[index];
+                            return ListTile(
+                              leading: SmartAvatar(
+                                imageUrl: msg.user?.getAvatarUrl(
+                                    AppConstants.baseUrl, size: 40),
+                                radius: 16,
+                                fallbackText:
+                                    (msg.user?.username ?? '?').isNotEmpty
+                                        ? msg.user!.username[0]
+                                        : '?',
+                              ),
+                              title: Text(
+                                msg.excerpt ?? msg.message ?? '',
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              subtitle: Text(
+                                '${msg.user?.name ?? msg.user?.username ?? ''}'
+                                '${msg.channelTitle != null ? ' · ${msg.channelTitle}' : ''}'
+                                ' · ${TimeUtils.formatCompactTime(msg.createdAt)}',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              onTap: () => Navigator.of(ctx).pop(msg),
+                            );
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('关闭'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/chat/chat_search_dialog.dart
+++ b/lib/pages/chat/chat_search_dialog.dart
@@ -149,7 +149,7 @@ class _ChatSearchDialogState extends ConsumerState<_ChatSearchDialog> {
                                 overflow: TextOverflow.ellipsis,
                               ),
                               subtitle: Text(
-                                '${msg.user?.name ?? msg.user?.username ?? ''}'
+                                '${msg.user?.displayName ?? ''}'
                                 '${msg.channelTitle != null ? ' · ${msg.channelTitle}' : ''}'
                                 ' · ${TimeUtils.formatCompactTime(msg.createdAt)}',
                                 maxLines: 1,

--- a/lib/pages/chat/dm_channel_detail_page.dart
+++ b/lib/pages/chat/dm_channel_detail_page.dart
@@ -12,6 +12,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -19,6 +20,7 @@ import 'package:super_clipboard/super_clipboard.dart';
 
 import '../../models/chat/chat_message.dart';
 import '../../models/emoji.dart';
+import '../../models/chat/chat_channel.dart';
 import '../../models/mention_user.dart';
 import '../../providers/core_providers.dart';
 import '../../providers/message_bus/chat_providers.dart';
@@ -46,20 +48,45 @@ import 'dm_thread_page.dart';
 import '../../widgets/markdown_editor/emoji_sticker_panel.dart';
 import '../../widgets/markdown_editor/markdown_toolbar.dart' show MarkdownToolbarState;
 import '../../constants.dart';
+import '../../providers/selected_topic_provider.dart';
+import '../../widgets/chat/chat_upload_view.dart';
+import '../../widgets/chat/group_channel_icon.dart';
+import '../../widgets/chat/overlay_anchor.dart';
+import '../../widgets/chat/reaction_chip.dart';
 
 /// 快速回应候选(对齐官方 chat 默认的常用表情,不用每次都翻表情面板)。
 const _quickReactionEmojis = ['+1', 'heart', 'joy', 'open_mouth', 'cry', 'tada'];
 
 /// 发送前暂存的附件(已上传拿到 id,等和文字一起随消息发出)。
+///
+/// 表情包走"伪上传":选中即入待发区(视觉上跟真附件一样,有缩略图/可
+/// 移除),但不占用一次真实上传(表情包本来就是站点已托管好的图,现上传
+/// 一份纯属浪费 CDN 存储和带宽)。真正发送时,伪上传项直接把它的
+/// markdown 拼进消息正文,继续用旧链接,不生成新 upload 记录。
 class _PendingUpload {
-  const _PendingUpload({required this.id, required this.name, this.localPath});
-  final int id;
+  const _PendingUpload({
+    this.id,
+    required this.name,
+    this.localPath,
+    this.stickerMarkdown,
+    this.stickerPreviewUrl,
+  });
+  final int? id;
   final String name;
 
-  /// 本地源文件路径,图片用来画缩略图预览
+  /// 本地源文件路径,真实附件图片用来画缩略图预览
   final String? localPath;
 
-  bool get isImage => const {
+  /// 非空 = 这是一个表情包伪上传项,值是发送时要拼进正文的 markdown
+  final String? stickerMarkdown;
+  /// 表情包预览图网络地址(伪上传没有本地文件,预览走网络图)
+  final String? stickerPreviewUrl;
+
+  bool get isSticker => stickerMarkdown != null;
+
+  bool get isImage =>
+      isSticker ||
+      const {
         '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp',
       }.contains(p.extension(name).toLowerCase());
 }
@@ -93,6 +120,10 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
   bool _sending = false;
   bool _uploading = false;
   int _lastMessageId = -1;
+  // dispose() 里不能再用 ref(Riverpod 会报"Using ref when a widget is about
+  // to or has been unmounted is unsafe"),这里在还活着的时候先把 notifier
+  // 存成字段,dispose 时直接用它,不经过 ref。
+  StateController<int?>? _activeChannelController;
 
   @override
   void initState() {
@@ -102,6 +133,16 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
       final position = _scrollController.position;
       if (position.pixels >= position.maxScrollExtent - 200) {
         ref.read(chatMessagesProvider(widget.channelId).notifier).loadOlder();
+      }
+    });
+    // 标记这个频道正被查看,避免频道列表订阅跟这里的已读清零打架(见
+    // activeChatChannelIdProvider 注释)。build 阶段不能直接改 provider,
+    // 挪到下一帧。
+    Future.microtask(() {
+      if (mounted) {
+        _activeChannelController =
+            ref.read(activeChatChannelIdProvider.notifier);
+        _activeChannelController!.state = widget.channelId;
       }
     });
   }
@@ -118,6 +159,16 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
 
   @override
   void dispose() {
+    // riverpod 连"dispose 阶段用存好的 StateController 直接改 state"都不让
+    // (会抛"Tried to modify a provider while the widget tree was building"),
+    // 得挪到当前这轮 build/unmount 锁定窗口之外。
+    final controller = _activeChannelController;
+    final id = widget.channelId;
+    if (controller != null) {
+      Future(() {
+        if (controller.state == id) controller.state = null;
+      });
+    }
     _inputController.dispose();
     _scrollController.dispose();
     _inputFocusNode.dispose();
@@ -134,9 +185,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
 
   void _showError(String prefix, Object e) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('$prefix: $e')),
-    );
+    ToastService.showError('$prefix: $e');
   }
 
   Future<void> _toggleStarred(bool current) async {
@@ -175,16 +224,25 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
     try {
       final service = ref.read(discourseServiceProvider);
       final editing = _editing;
+      // 表情包是伪上传:不占用 upload_ids,直接把 markdown 拼进正文,
+      // 沿用它本来的 CDN 链接,不产生新的 upload 记录。
+      final stickerMarkdowns = uploads
+          .where((u) => u.isSticker && u.stickerMarkdown != null)
+          .map((u) => u.stickerMarkdown!);
+      final realUploadIds =
+          uploads.where((u) => !u.isSticker).map((u) => u.id!).toList();
+      final combinedText =
+          [text, ...stickerMarkdowns].where((s) => s.isNotEmpty).join('\n');
       if (editing != null) {
         await ref
             .read(chatMessagesProvider(widget.channelId).notifier)
-            .editMessage(editing.id, text);
+            .editMessage(editing.id, combinedText);
       } else {
         await service.sendChatMessage(
           widget.channelId,
-          text,
+          combinedText,
           inReplyToId: _replyTo?.id,
-          uploadIds: uploads.map((u) => u.id).toList(),
+          uploadIds: realUploadIds.isEmpty ? null : realUploadIds,
         );
       }
       _inputController.clear();
@@ -196,7 +254,8 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
       // 发送成功后 MessageBus 会推回这条消息;兜底重拉一次最新消息,
       // 避免推送延迟导致用户以为没发出去。
       ref.invalidate(chatMessagesProvider(widget.channelId));
-    } catch (e) {
+    } catch (e, st) {
+      debugPrint('[ChatSend] 发送失败: $e\n$st');
       _showError('发送失败', e);
     } finally {
       if (mounted) {
@@ -307,7 +366,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
   Future<void> _showSummarizeDialog() async {
     await showDialog<void>(
       context: context,
-      builder: (ctx) => _ChatSummaryDialog(channelId: widget.channelId),
+      builder: (ctx) => ChatSummaryDialog(channelId: widget.channelId),
     );
   }
 
@@ -438,8 +497,8 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
     _inputController.selection = TextSelection.collapsed(offset: start + shortcode.length);
   }
 
-  Future<void> _showEmojiPicker() async {
-    final emoji = await _pickEmoji(allowSticker: true);
+  Future<void> _showEmojiPicker(BuildContext anchorContext) async {
+    final emoji = await _pickEmojiNear(anchorContext, allowSticker: true);
     if (emoji != null) _insertEmoji(emoji);
   }
 
@@ -491,7 +550,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
             child: Text(
               editing != null
                   ? '编辑消息'
-                  : '回复 ${replyTo!.user?.name ?? replyTo.user?.username ?? ''}: '
+                  : '回复 ${replyTo!.user?.displayName ?? ''}: '
                       '${replyTo.excerpt ?? replyTo.message ?? ''}',
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -546,6 +605,37 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                               size: 20),
                         ),
                       ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 2,
+                    right: 2,
+                    child: InkWell(
+                      onTap: () =>
+                          setState(() => _pendingUploads.remove(upload)),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.55),
+                          shape: BoxShape.circle,
+                        ),
+                        padding: const EdgeInsets.all(2),
+                        child: const Icon(Icons.close_rounded,
+                            size: 12, color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            else if (upload.isSticker && upload.stickerPreviewUrl != null)
+              Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: CachedImage(
+                      url: upload.stickerPreviewUrl!,
+                      width: 64,
+                      height: 64,
+                      fit: BoxFit.cover,
                     ),
                   ),
                   Positioned(
@@ -646,9 +736,12 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                         }
                         final members = snapshot.data ?? const [];
                         if (members.isEmpty) {
-                          return const Center(
+                          return Center(
                               child: Text('没有匹配的成员',
-                                  style: TextStyle(color: Colors.grey)));
+                                  style: TextStyle(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant)));
                         }
                         return ListView.builder(
                           itemCount: members.length,
@@ -770,6 +863,17 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                     _showMembers();
                   },
                 ),
+                if (channel.isGroup)
+                  ListTile(
+                    leading: const Icon(Icons.edit_outlined),
+                    title: const Text('编辑群信息'),
+                    subtitle: const Text('名称 / 缩略名 / 图标'),
+                    trailing: const Icon(Icons.chevron_right_rounded),
+                    onTap: () {
+                      Navigator.of(ctx).pop();
+                      _editChannelInfo(channel);
+                    },
+                  ),
                 const Divider(height: 1),
                 SwitchListTile(
                   secondary: const Icon(Icons.notifications_off_outlined),
@@ -841,13 +945,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                           '${AppConstants.baseUrl}/chat/c/${channel.slug ?? '-'}/${channel.id}',
                     ));
                     if (ctx.mounted) Navigator.of(ctx).pop();
-                    if (mounted) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(
-                            content: Text('已复制频道链接'),
-                            duration: Duration(seconds: 1)),
-                      );
-                    }
+                    if (mounted) ToastService.showSuccess('已复制频道链接');
                   },
                 ),
                 const Divider(height: 1),
@@ -866,6 +964,107 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
         },
       ),
     );
+  }
+
+  /// 编辑群聊名称/缩略名/图标。核对过源码
+  /// `Chat::Api::ChannelsController::CHANNEL_EDITABLE_PARAMS`:
+  /// `PUT /chat/api/channels/:id`,body 包在 `channel: {name, slug, emoji}` 下。
+  Future<void> _editChannelInfo(ChatChannel channel) async {
+    final nameController = TextEditingController(text: channel.title ?? '');
+    final slugController = TextEditingController(text: channel.slug ?? '');
+    String? emoji = channel.emoji;
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('编辑群信息'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(labelText: '群名称'),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: slugController,
+                  decoration: const InputDecoration(labelText: '缩略名(slug)'),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    const Text('图标'),
+                    const SizedBox(width: 12),
+                    Builder(
+                      builder: (btnCtx) => InkWell(
+                        borderRadius: BorderRadius.circular(8),
+                        onTap: () async {
+                          final picked = await _pickEmojiNear(btnCtx);
+                          if (picked != null) {
+                            setDialogState(() => emoji = picked.name);
+                          }
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.all(6),
+                          decoration: BoxDecoration(
+                            border: Border.all(
+                                color: Theme.of(ctx).colorScheme.outlineVariant),
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: emoji != null
+                              ? _ReactionEmoji(name: emoji!, size: 24)
+                              : const Icon(Icons.add_reaction_outlined, size: 24),
+                        ),
+                      ),
+                    ),
+                    if (emoji != null)
+                      IconButton(
+                        tooltip: '清除图标',
+                        icon: const Icon(Icons.close_rounded, size: 18),
+                        onPressed: () => setDialogState(() => emoji = null),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('取消'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (result != true || !mounted) return;
+
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.updateChatChannel(
+        widget.channelId,
+        name: nameController.text.trim(),
+        slug: slugController.text.trim(),
+        emoji: emoji ?? '',
+      );
+      if (!mounted) return;
+      ref.read(chatChannelListProvider.notifier).applyChannelInfo(
+            widget.channelId,
+            title: nameController.text.trim(),
+            slug: slugController.text.trim(),
+            emoji: emoji,
+          );
+      ToastService.showSuccess('群信息已更新');
+    } catch (e) {
+      _showError('更新群信息失败', e);
+    }
   }
 
   Future<void> _toggleThreading(bool current) async {
@@ -967,8 +1166,10 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
             }
             final pins = snapshot.data ?? const [];
             if (pins.isEmpty) {
-              return const Center(
-                child: Text('暂无置顶消息', style: TextStyle(color: Colors.grey)),
+              return Center(
+                child: Text('暂无置顶消息',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant)),
               );
             }
             return ListView.builder(
@@ -985,7 +1186,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                         : '?',
                   ),
                   title: Text(
-                    pin.user?.name ?? pin.user?.username ?? '',
+                    pin.user?.displayName ?? '',
                     style: Theme.of(ctx).textTheme.bodySmall,
                   ),
                   subtitle: Text(
@@ -1193,22 +1394,14 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
         await _bookmarkMessage(message);
       case 'copy':
         await Clipboard.setData(ClipboardData(text: message.message ?? ''));
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('已复制文本'), duration: Duration(seconds: 1)),
-          );
-        }
+        if (mounted) ToastService.showSuccess('已复制文本');
       case 'copy_link':
         // 官方消息链接格式:/chat/c/-/{channelId}/{messageId}(路由表里的
         // `get "#{base_c_route}/:message_id"`,channel_title 用 `-` 占位)。
         await Clipboard.setData(ClipboardData(
           text: '${AppConstants.baseUrl}/chat/c/-/${widget.channelId}/${message.id}',
         ));
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('已复制链接'), duration: Duration(seconds: 1)),
-          );
-        }
+        if (mounted) ToastService.showSuccess('已复制链接');
       case 'select':
         await showDialog<void>(
           context: context,
@@ -1263,35 +1456,66 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
         chatChannelId: widget.channelId,
         chatMessageId: message.id,
         onSuccess: () {
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('已提交举报')),
-            );
-          }
+          if (mounted) ToastService.showSuccess('已提交举报');
         },
       ),
     );
+  }
+
+  /// markdown 形如 `![name|WxHpx,30%](url)`(见 StickerItem.toMarkdown),
+  /// 拆出 name/url 存进伪上传项;拆不出来就整串当 name 兜底,url 为空的
+  /// 伪上传项发送时会被过滤掉(不会拼出裸文本堆里少一半的 markdown)。
+  static final _stickerMarkdownPattern = RegExp(r'^!\[([^|\]]+).*?\]\((.+)\)$');
+
+  void _addStickerAsPseudoUpload(String markdown) {
+    final match = _stickerMarkdownPattern.firstMatch(markdown);
+    setState(() {
+      _pendingUploads.add(_PendingUpload(
+        name: match?.group(1) ?? markdown,
+        stickerMarkdown: markdown,
+        stickerPreviewUrl: match?.group(2),
+      ));
+    });
   }
 
   /// 表情选择:复用编辑器同款 [EmojiStickerPanel](最近使用/分组/搜索/
   /// 表情包都有)。PC 端悬浮面板(compact + 内联搜索),移动端底部弹层。
   /// [allowSticker] 为 true 时(输入框场景)选表情包直接把 markdown 插进
   /// 输入框;回应场景表情包无意义,点了只关面板。
+  /// 悬浮条上"更多表情"点了之后,面板贴在点击位置附近弹出(而不是屏幕
+  /// 正中的对话框)——对齐官方网页端悬浮工具条的表现。列表一滚动就关掉,
+  /// 防止面板悬在半空跟着滚动内容一起错位造成误触。
+  Future<Emoji?> _pickEmojiNear(BuildContext anchorContext,
+      {bool allowSticker = false}) {
+    return showAnchoredPopup<Emoji>(
+      context: context,
+      anchorContext: anchorContext,
+      closeOnScroll: _scrollController,
+      builder: (ctx, close) => EmojiStickerPanel(
+        compact: true,
+        inlineSearch: true,
+        showStickerTab: allowSticker,
+        onEmojiSelected: (e) => close(e),
+        onStickerSelected: (markdown) {
+          close(null);
+          if (allowSticker) _addStickerAsPseudoUpload(markdown);
+        },
+      ),
+    );
+  }
+
   Future<Emoji?> _pickEmoji({bool allowSticker = false}) {
     Widget buildPanel(BuildContext ctx, {required bool compact}) {
       return EmojiStickerPanel(
         compact: compact,
         inlineSearch: compact,
+        // 私聊回应只认得 Discourse 标准 emoji,表情包(自定义贴纸)服务端
+        // 不识别——只有"插入到输入框"场景(allowSticker)才露出表情包页签。
+        showStickerTab: allowSticker,
         onEmojiSelected: (e) => Navigator.of(ctx).pop(e),
         onStickerSelected: (markdown) {
           Navigator.of(ctx).pop();
-          if (allowSticker) {
-            final text = _inputController.text;
-            _inputController.text = text.isEmpty ? markdown : '$text $markdown';
-            _inputController.selection = TextSelection.collapsed(
-                offset: _inputController.text.length);
-            _inputFocusNode.requestFocus();
-          }
+          if (allowSticker) _addStickerAsPseudoUpload(markdown);
         },
       );
     }
@@ -1358,6 +1582,22 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
         title: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            if (channel != null &&
+                channel.isGroup &&
+                (channel.emoji?.isNotEmpty ?? false)) ...[
+              GroupChannelIcon(emoji: channel.emoji!, radius: 16),
+              const SizedBox(width: 8),
+            ] else if (otherUser != null) ...[
+              SmartAvatar(
+                imageUrl: otherUser.getAvatarUrl(AppConstants.baseUrl, size: 64),
+                radius: 16,
+                fallbackText: otherUser.username,
+                isOnline: otherUser.id != null &&
+                    (ref.watch(chatOnlinePresenceProvider).value ?? const {})
+                        .contains(otherUser.id),
+              ),
+              const SizedBox(width: 8),
+            ],
             Flexible(child: Text(widget.title ?? '消息')),
             if (otherUser?.status != null) ...[
               const SizedBox(width: 6),
@@ -1411,8 +1651,10 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
             child: messagesAsync.when(
               data: (messages) {
                 if (messages.isEmpty) {
-                  return const Center(
-                    child: Text('暂无消息', style: TextStyle(color: Colors.grey)),
+                  return Center(
+                    child: Text('暂无消息',
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurfaceVariant)),
                   );
                 }
                 // reverse:true 是聊天列表的标准姿势:视口锚定在底部,上面的
@@ -1424,6 +1666,7 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                 return ListView.builder(
                   controller: _scrollController,
                   reverse: true,
+                  cacheExtent: 1200,
                   padding: const EdgeInsets.symmetric(vertical: 8),
                   // 多出的一项是列表顶端(reverse 的最后一项)的加载动画
                   itemCount: messages.length + 1,
@@ -1467,18 +1710,15 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                       onOpenMenu: () => _showMessageMenu(message, isOwn),
                       onReply: () => _startReply(message),
                       onBookmark: () => _bookmarkMessage(message),
-                      pickEmoji: _pickEmoji,
+                      pickEmoji: _pickEmojiNear,
                       onOpenThread: message.thread != null
-                          ? () => Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (_) => DmThreadPage(
-                                    channelId: widget.channelId,
-                                    threadId: message.thread!.id,
-                                    title: message.thread!.title ??
-                                        message.threadTitle ??
-                                        '消息串',
-                                  ),
-                                ),
+                          ? () => EmbeddedStackScope.openThread(
+                                context,
+                                widget.channelId,
+                                message.thread!.id,
+                                title: message.thread!.title ??
+                                    message.threadTitle ??
+                                    '消息串',
                               )
                           : null,
                     );
@@ -1510,10 +1750,12 @@ class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
                       icon: const Icon(Icons.add_circle_outline_rounded),
                     ),
                   ),
-                  IconButton(
-                    tooltip: '表情',
-                    onPressed: _showEmojiPicker,
-                    icon: const Icon(Icons.emoji_emotions_outlined),
+                  Builder(
+                    builder: (btnCtx) => IconButton(
+                      tooltip: '表情',
+                      onPressed: () => _showEmojiPicker(btnCtx),
+                      icon: const Icon(Icons.emoji_emotions_outlined),
+                    ),
                   ),
                   Expanded(
                     child: Focus(
@@ -1618,8 +1860,8 @@ class _ChatMessageBubble extends ConsumerStatefulWidget {
   final UserCustomStatus? userStatus;
   final VoidCallback? onShowStatus;
 
-  /// 打开表情选择器(PC 悬浮面板 / 移动端底部弹层,由页面统一提供)
-  final Future<Emoji?> Function() pickEmoji;
+  /// 打开表情选择器,贴在调用处按钮附近弹出(由页面统一提供)
+  final Future<Emoji?> Function(BuildContext anchorContext) pickEmoji;
 
   /// 这条消息开了消息串时,点"N 条回复"打开串;频道没开串则为 null
   final VoidCallback? onOpenThread;
@@ -1629,26 +1871,6 @@ class _ChatMessageBubble extends ConsumerStatefulWidget {
 }
 
 class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
-  bool _hoverBubble = false;
-  bool _hoverPanel = false;
-  final LayerLink _link = LayerLink();
-  final OverlayPortalController _portalController = OverlayPortalController();
-
-  /// 气泡或面板任意一个被悬浮就显示面板;都离开才收起(面板和气泡有
-  /// 几像素重叠,鼠标能连续移过去不断触)。
-  void _updateHover({bool? bubble, bool? panel}) {
-    setState(() {
-      if (bubble != null) _hoverBubble = bubble;
-      if (panel != null) _hoverPanel = panel;
-    });
-    final shouldShow = (_hoverBubble || _hoverPanel) && !message.isDeleted;
-    if (shouldShow && !_portalController.isShowing) {
-      _portalController.show();
-    } else if (!shouldShow && _portalController.isShowing) {
-      _portalController.hide();
-    }
-  }
-
   ChatMessage get message => widget.message;
   bool get isOwn => widget.isOwn;
   bool get showHeader => widget.showHeader;
@@ -1665,8 +1887,50 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
   /// 之前一刀切匹配 `<img` 导致带 emoji 的消息全部放弃测宽,渲染出来的
   /// 块级段落又默认填满可用宽度,于是"一个 emoji 的消息框长得离谱")。
   static final _contentImgPattern = RegExp(r'<img(?![^>]*class="[^"]*emoji)');
+  // 表情包(贴纸)markdown 会被 cook 成"就一个 <img>,外面顶多裹一层 <p>"
+  // 的极简 HTML——跟真的复杂内容(多张图/文字混排/表格等)区分开,不然
+  // 贴纸消息会被 `_hasComplexContent` 一刀切成"放弃测宽走满宽",气泡
+  // 背景比图片本身宽一大截,看着像一条很长的空条。
+  // 排除 emoji:纯 emoji 消息(尤其 only-emoji 放大展示)cooked 也是「就一个
+  // <img> 裹一层 <p>」的极简形状,跟贴纸完全同构——之前没排除,导致单个
+  // emoji 消息被误判成贴纸,套上贴纸的 180px 定宽气泡,20px 小图右边空出
+  // 一大截。
+  static final _singleImageCookedPattern = RegExp(
+    r'^\s*(?:<p>)?\s*<img(?![^>]*class="[^"]*emoji)[^>]*>\s*(?:</p>)?\s*$',
+    dotAll: true,
+  );
+
+  bool get _isSingleStickerImage {
+    final cooked = message.cooked;
+    if (cooked == null) return false;
+    return _singleImageCookedPattern.hasMatch(cooked);
+  }
+
+  /// 表情包(伪上传)跟文字拼在同一条消息发出时(`_send()` 里 `[text,
+  /// stickerMarkdown].join('\n')`),cooked 是「一段文字 + 一个贴纸 <img>」
+  /// 混排,不满足 [_isSingleStickerImage] 那个"纯图"的极简形状,会被当成
+  /// "复杂内容"直接放弃测宽走满宽——图片没多宽,气泡右边空一大截。这里
+  /// 单独识别"文字+恰好一张贴纸图,没有其它复杂块"这种组合,交给
+  /// [_measuredWidth] 按"文字宽度 + 贴纸定宽"去测,而不是放弃测宽。
+  bool get _isTextWithSingleSticker {
+    if (_isSingleStickerImage) return false;
+    final cooked = message.cooked;
+    if (cooked == null) return false;
+    if (cooked.contains('<table') ||
+        cooked.contains('<pre') ||
+        cooked.contains('<svg') ||
+        cooked.contains('<video') ||
+        cooked.contains('<audio') ||
+        cooked.contains('<iframe') ||
+        cooked.contains('class="onebox') ||
+        cooked.contains('<aside')) {
+      return false;
+    }
+    return _contentImgPattern.allMatches(cooked).length == 1;
+  }
 
   bool get _hasComplexContent {
+    if (_isSingleStickerImage || _isTextWithSingleSticker) return false;
     final cooked = message.cooked;
     if (cooked == null) return false;
     return _contentImgPattern.hasMatch(cooked) ||
@@ -1692,9 +1956,18 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
 
   double? _measuredWidth(BuildContext context, double maxContentWidth) {
     if (_hasComplexContent) return null;
-    final text = message.isDeleted ? '(消息已删除)' : (message.message ?? '');
+    // 贴纸:不量文字(原始 markdown 文本是图片链接,量出来的宽度跟实际
+    // 贴纸图片大小没关系),直接给个贴纸常见尺寸的定宽气泡。
+    if (_isSingleStickerImage) return 180.0.clamp(24.0, maxContentWidth);
+    var text = message.isDeleted ? '(消息已删除)' : (message.message ?? '');
     if (text.isEmpty && message.inReplyTo == null && message.uploads.isEmpty) {
       return null;
+    }
+    // 文字+贴纸组合:markdown 里那段 `![name|WxH,N%](url)` 图片语法量出来
+    // 一大截宽度但跟实际贴纸大小无关,量文字前先剥掉,贴纸自身的宽度
+    // 靠下面 _isTextWithSingleSticker 分支单独补偿。
+    if (_isTextWithSingleSticker) {
+      text = text.replaceAll(RegExp(r'!\[[^\]]*\]\([^)]*\)'), '').trim();
     }
 
     // emoji 会被 cook 成行内图片,量原始文本时把 `:joy:` 这类 shortcode
@@ -1721,6 +1994,9 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
       textScaler: MediaQuery.textScalerOf(context),
     )..layout(maxWidth: maxContentWidth);
     var width = painter.width + emojiCount * emojiWidth + 8;
+    // 贴纸本身按 180 常见尺寸算,气泡至少要装得下(取文字宽度和贴纸
+    // 宽度里较大的一个,不是简单相加——贴纸独占一行,不跟文字并排)。
+    if (_isTextWithSingleSticker) width = width < 180.0 ? 180.0 : width;
 
     // 带引用条的消息:引用条(单行小字 + ↩ 图标 + 内边距)也量一次,
     // 气泡取"正文 vs 引用条"里较宽的那个——之前直接放弃测宽,块级渲染
@@ -1824,46 +2100,25 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
                     (message.message?.isNotEmpty ?? false))
                   Text(message.message!),
                 if (message.isDeleted)
-                  const Text('(消息已删除)',
-                      style: TextStyle(color: Colors.grey)),
+                  Text('(消息已删除)',
+                      style: TextStyle(color: scheme.onSurfaceVariant)),
                 // 图片/附件不在 cooked 里(官方 MessageSerializer 单独给
                 // uploads 数组,网页端也是正文下方另行渲染),这里补上
                 if (!message.isDeleted)
                   for (final upload in message.uploads)
                     Padding(
                       padding: const EdgeInsets.only(top: 6),
-                      child: _ChatUploadView(upload: upload),
+                      child: ChatUploadView(upload: upload),
                     ),
-                // 消息串入口:线程原始消息下挂"N 条回复"胶囊
+                // 消息串入口:头像+最新回复预览的列表项样式,而不是纯文字胶囊
                 if (message.thread != null &&
                     widget.onOpenThread != null &&
                     !message.isDeleted)
                   Padding(
                     padding: const EdgeInsets.only(top: 6),
-                    child: InkWell(
-                      borderRadius: BorderRadius.circular(12),
-                      onTap: widget.onOpenThread,
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: scheme.surface.withValues(alpha: 0.6),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.forum_outlined,
-                                size: 13, color: scheme.primary),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${message.thread!.replyCount} 条回复',
-                              style: TextStyle(
-                                  fontSize: 12, color: scheme.primary),
-                            ),
-                          ],
-                        ),
-                      ),
+                    child: _ThreadEntryTile(
+                      thread: message.thread!,
+                      onTap: widget.onOpenThread!,
                     ),
                   ),
                 if ((message.edited || message.pinned) && !message.isDeleted)
@@ -1900,33 +2155,11 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
                 runSpacing: 4,
                 children: [
                   for (final reaction in message.reactions)
-                    InkWell(
-                      borderRadius: BorderRadius.circular(12),
+                    ReactionChip(
+                      reaction: reaction,
                       onTap: () => ref
                           .read(chatMessagesProvider(channelId).notifier)
                           .toggleReaction(message.id, reaction.emoji),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 6, vertical: 3),
-                        decoration: BoxDecoration(
-                          color: reaction.reacted
-                              ? scheme.primaryContainer
-                              : scheme.surfaceContainerHigh,
-                          borderRadius: BorderRadius.circular(12),
-                          border: reaction.reacted
-                              ? Border.all(color: scheme.primary, width: 1)
-                              : null,
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            _ReactionEmoji(name: reaction.emoji, size: 14),
-                            const SizedBox(width: 3),
-                            Text('${reaction.count}',
-                                style: const TextStyle(fontSize: 12)),
-                          ],
-                        ),
-                      ),
                     ),
                 ],
               );
@@ -1955,6 +2188,9 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
               fallbackText: (message.user?.username ?? '?').isNotEmpty
                   ? message.user!.username[0]
                   : '?',
+              isOnline: message.user?.id != null &&
+                  (ref.watch(chatOnlinePresenceProvider).value ?? const {})
+                      .contains(message.user!.id),
             ),
           ),
         );
@@ -1968,10 +2204,19 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
 
         // 锚点只挂在气泡本体上(不含头像上方的用户名/时间行)——否则悬浮
         // 面板会以整行(含头顶名字行)的顶部为基准,盖住名字/时间那一行。
-        final bubbleRow = CompositedTransformTarget(
-          link: _link,
-          child: tappableBubble,
-        );
+        // 不用 OverlayPortal/CompositedTransformFollower:两者都跟平行
+        // 视界 `_buildMasterPane` 的 GlobalKey 子树搬迁打架(见
+        // overlay_anchor.dart 顶部注释),改用手动 OverlayEntry 的
+        // HoverPopupAnchor。
+        final bubbleRow = message.isDeleted
+            ? tappableBubble
+            : HoverPopupAnchor(
+                alignRight: isOwn,
+                gap: -10,
+                popupBuilder: (overlayCtx, closePopup) => _buildHoverPanel(
+                    Theme.of(overlayCtx).colorScheme, closePopup),
+                child: tappableBubble,
+              );
 
         final children = <Widget>[
           if (!isOwn) ...[
@@ -1991,7 +2236,7 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
                       children: [
                         Flexible(
                           child: Text(
-                            message.user?.name ?? message.user?.username ?? '',
+                            message.user?.displayName ?? '',
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: Theme.of(context).textTheme.bodySmall,
@@ -2024,39 +2269,13 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
           if (isOwn) const SizedBox(width: 8),
         ];
 
-        // 悬浮面板浮在消息**上方**(对齐官方网页端 message-actions 的位
-        // 置)。不能用列表项内 Stack 负偏移——reverse 列表里上一行画得更
-        // 晚会盖住它;OverlayPortal 挂到应用 Overlay 层,永远在最上面。
-        return OverlayPortal(
-          controller: _portalController,
-          overlayChildBuilder: (overlayCtx) => CompositedTransformFollower(
-            link: _link,
-            showWhenUnlinked: false,
-            targetAnchor: isOwn ? Alignment.topRight : Alignment.topLeft,
-            followerAnchor: isOwn ? Alignment.bottomRight : Alignment.bottomLeft,
-            // 往下压几像素让面板和消息行有重叠,鼠标能连续移过去
-            offset: const Offset(0, 10),
-            child: Align(
-              alignment: isOwn ? Alignment.bottomRight : Alignment.bottomLeft,
-              child: MouseRegion(
-                onEnter: (_) => _updateHover(panel: true),
-                onExit: (_) => _updateHover(panel: false),
-                child: _buildHoverPanel(Theme.of(overlayCtx).colorScheme),
-              ),
-            ),
-          ),
-          child: MouseRegion(
-            onEnter: (_) => _updateHover(bubble: true),
-            onExit: (_) => _updateHover(bubble: false),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
-              child: Row(
-                mainAxisAlignment:
-                    isOwn ? MainAxisAlignment.end : MainAxisAlignment.start,
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: children,
-              ),
-            ),
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
+          child: Row(
+            mainAxisAlignment:
+                isOwn ? MainAxisAlignment.end : MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: children,
           ),
         );
       },
@@ -2065,7 +2284,7 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
 
   /// 悬浮小面板:最近用过的 3 个快捷回应 + 全量表情 + 书签 + 回复 + 更多。
   /// 桌面端 hover 出现;移动端没有 hover,长按气泡走完整底部菜单。
-  Widget _buildHoverPanel(ColorScheme scheme) {
+  Widget _buildHoverPanel(ColorScheme scheme, VoidCallback closePopup) {
     final recentReactions = ref.watch(recentChatReactionsProvider);
     return Material(
       elevation: 2,
@@ -2081,31 +2300,45 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
                 tooltip: ':$name:',
                 iconSize: 18,
                 visualDensity: VisualDensity.compact,
-                onPressed: () => ref
-                    .read(chatMessagesProvider(channelId).notifier)
-                    .toggleReaction(message.id, name),
+                onPressed: () {
+                  closePopup();
+                  ref
+                      .read(chatMessagesProvider(channelId).notifier)
+                      .toggleReaction(message.id, name);
+                },
                 icon: _ReactionEmoji(name: name, size: 18),
               ),
-            IconButton(
-              tooltip: '更多表情',
-              iconSize: 18,
-              visualDensity: VisualDensity.compact,
-              onPressed: () async {
-                final emoji = await widget.pickEmoji();
-                if (emoji != null) {
-                  unawaited(ref
-                      .read(chatMessagesProvider(channelId).notifier)
-                      .toggleReaction(message.id, emoji.name));
-                }
-              },
-              icon: Icon(Icons.add_reaction_outlined,
-                  color: scheme.onSurfaceVariant),
+            Builder(
+              builder: (btnCtx) => IconButton(
+                tooltip: '更多表情',
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                onPressed: () {
+                  // 先同步发起(拿 btnCtx 算锚点位置),再收起悬浮条——
+                  // 顺序反过来的话 closePopup 先把按钮所在的 Element 标脏,
+                  // 锚点计算可能读到过期位置。
+                  final future = widget.pickEmoji(btnCtx);
+                  closePopup();
+                  future.then((emoji) {
+                    if (emoji != null) {
+                      unawaited(ref
+                          .read(chatMessagesProvider(channelId).notifier)
+                          .toggleReaction(message.id, emoji.name));
+                    }
+                  });
+                },
+                icon: Icon(Icons.add_reaction_outlined,
+                    color: scheme.onSurfaceVariant),
+              ),
             ),
             IconButton(
               tooltip: message.bookmark != null ? '修改书签' : '书签',
               iconSize: 18,
               visualDensity: VisualDensity.compact,
-              onPressed: widget.onBookmark,
+              onPressed: () {
+                closePopup();
+                widget.onBookmark();
+              },
               icon: Icon(
                 message.bookmark != null
                     ? Icons.bookmark_rounded
@@ -2119,14 +2352,20 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
               tooltip: '回复',
               iconSize: 18,
               visualDensity: VisualDensity.compact,
-              onPressed: widget.onReply,
+              onPressed: () {
+                closePopup();
+                widget.onReply();
+              },
               icon: Icon(Icons.reply_rounded, color: scheme.onSurfaceVariant),
             ),
             IconButton(
               tooltip: '更多',
               iconSize: 18,
               visualDensity: VisualDensity.compact,
-              onPressed: onOpenMenu,
+              onPressed: () {
+                closePopup();
+                onOpenMenu();
+              },
               icon: Icon(Icons.more_vert_rounded, color: scheme.onSurfaceVariant),
             ),
           ],
@@ -2136,78 +2375,81 @@ class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
   }
 }
 
-/// 消息附带的上传文件:图片直接展示(限宽等比),其它文件画成附件卡片,
-/// 点击用系统方式打开源链接。
-class _ChatUploadView extends StatelessWidget {
-  const _ChatUploadView({required this.upload});
+/// 消息串入口:头像+最新回复预览的列表项样式(对齐左侧频道列表"头像+
+/// 最新消息"的观感),取代原来纯文字的"N 条回复"胶囊。`preview` 相关字段
+/// 服务端在消息列表接口固定 include_thread_preview:true,理论上总有值;
+/// 万一没有(比如串刚创建还没回复)就退化成只显示"N 条回复"。
+class _ThreadEntryTile extends StatelessWidget {
+  const _ThreadEntryTile({required this.thread, required this.onTap});
 
-  final ChatUpload upload;
-
-  String get _resolvedUrl {
-    final url = upload.url;
-    if (url.startsWith('//')) return 'https:$url';
-    if (url.startsWith('/')) return '${AppConstants.baseUrl}$url';
-    return url;
-  }
+  final ChatThreadInfo thread;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    if (upload.isImage) {
-      final width = upload.width;
-      final height = upload.height;
-      final aspect = (width != null && height != null && height > 0)
-          ? width / height
-          : null;
-      return GestureDetector(
-        onTap: () => ImageViewerPage.open(
-          context,
-          _resolvedUrl,
-          heroTag: 'chat_upload_${upload.id ?? upload.url}',
-          filenames: [upload.originalFilename],
-          // 对齐话题里点图的完整体验(分享/保存等操作)
-          enableShare: true,
-        ),
-        child: Hero(
-          tag: 'chat_upload_${upload.id ?? upload.url}',
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
-              child: aspect != null
-                  ? AspectRatio(
-                      aspectRatio: aspect,
-                      child: CachedImage(url: _resolvedUrl, fit: BoxFit.cover),
-                    )
-                  : CachedImage(url: _resolvedUrl, fit: BoxFit.contain),
+    final scheme = Theme.of(context).colorScheme;
+    final lastUser = thread.lastReplyUser;
+    final excerpt = thread.lastReplyExcerpt;
+
+    return Material(
+      color: scheme.surfaceContainerHigh,
+      borderRadius: BorderRadius.circular(12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 260),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (lastUser != null)
+                  SmartAvatar(
+                    imageUrl: lastUser.getAvatarUrl(AppConstants.baseUrl, size: 40),
+                    radius: 12,
+                    fallbackText:
+                        lastUser.displayName.isNotEmpty ? lastUser.displayName[0] : '?',
+                  )
+                else
+                  Icon(Icons.forum_outlined, size: 20, color: scheme.primary),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '${thread.replyCount} 条回复',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          color: scheme.primary,
+                        ),
+                      ),
+                      if (excerpt != null && excerpt.isNotEmpty)
+                        Text(
+                          excerpt,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: scheme.onSurfaceVariant,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                if (thread.lastReplyCreatedAt != null) ...[
+                  const SizedBox(width: 6),
+                  Text(
+                    TimeUtils.formatCompactTime(thread.lastReplyCreatedAt),
+                    style: TextStyle(fontSize: 10, color: scheme.onSurfaceVariant),
+                  ),
+                ],
+              ],
             ),
           ),
-        ),
-      );
-    }
-    return InkWell(
-      borderRadius: BorderRadius.circular(8),
-      onTap: () => launchUrl(Uri.parse(_resolvedUrl),
-          mode: LaunchMode.externalApplication),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceContainerLowest,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.attach_file_rounded, size: 18),
-            const SizedBox(width: 6),
-            Flexible(
-              child: Text(
-                upload.originalFilename ?? '附件',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(fontSize: 13),
-              ),
-            ),
-          ],
         ),
       ),
     );
@@ -2243,16 +2485,16 @@ class _ComposeMenuRow extends StatelessWidget {
 
 /// AI 频道总结弹窗:时间范围下拉 + 只读摘要区,对齐官方
 /// chat-modal-channel-summary 组件(纯展示,不写回输入框)。
-class _ChatSummaryDialog extends ConsumerStatefulWidget {
-  const _ChatSummaryDialog({required this.channelId});
+class ChatSummaryDialog extends ConsumerStatefulWidget {
+  const ChatSummaryDialog({super.key, required this.channelId});
 
   final int channelId;
 
   @override
-  ConsumerState<_ChatSummaryDialog> createState() => _ChatSummaryDialogState();
+  ConsumerState<ChatSummaryDialog> createState() => ChatSummaryDialogState();
 }
 
-class _ChatSummaryDialogState extends ConsumerState<_ChatSummaryDialog> {
+class ChatSummaryDialogState extends ConsumerState<ChatSummaryDialog> {
   static const _sinceOptions = [1, 3, 6, 12, 24, 72, 168];
   int? _sinceHours;
   bool _loading = false;

--- a/lib/pages/chat/dm_channel_detail_page.dart
+++ b/lib/pages/chat/dm_channel_detail_page.dart
@@ -1,0 +1,2341 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:fluxdo_render/editor.dart'
+    show
+        observeModifierKeyEvent,
+        primaryModifierHeldForReversibleAction,
+        shiftModifierHeld;
+import 'package:fluxdo_render/fluxdo_render.dart' show LocalDateRun;
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:m3e_ui/m3e_ui.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:super_clipboard/super_clipboard.dart';
+
+import '../../models/chat/chat_message.dart';
+import '../../models/emoji.dart';
+import '../../models/mention_user.dart';
+import '../../providers/core_providers.dart';
+import '../../providers/message_bus/chat_providers.dart';
+import '../../services/discourse_cache_manager.dart';
+import '../../services/emoji_handler.dart';
+import '../../services/toast_service.dart';
+import '../../utils/clipboard_image_native.dart';
+import '../../utils/fluxdo_render_callbacks.dart';
+import '../../utils/time_utils.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../widgets/common/cached_image.dart';
+import '../../widgets/common/error_view.dart';
+import '../../widgets/common/smart_avatar.dart';
+import '../../widgets/common/user_status_icon.dart';
+import '../../utils/platform_utils.dart';
+import '../../widgets/post/post_item/widgets/post_flag_sheet.dart';
+import '../../widgets/bookmark/bookmark_edit_sheet_launcher.dart';
+import '../../widgets/user/user_card.dart' show showUserCard;
+import '../../widgets/markdown_editor/rich_composer/local_date_edit_dialog.dart';
+import '../../widgets/markdown_editor/template_insert_dialog.dart';
+import '../image_viewer_page.dart';
+import 'chat_search_dialog.dart';
+import 'dm_thread_page.dart';
+import '../../widgets/markdown_editor/emoji_sticker_panel.dart';
+import '../../widgets/markdown_editor/markdown_toolbar.dart' show MarkdownToolbarState;
+import '../../constants.dart';
+
+/// 快速回应候选(对齐官方 chat 默认的常用表情,不用每次都翻表情面板)。
+const _quickReactionEmojis = ['+1', 'heart', 'joy', 'open_mouth', 'cry', 'tada'];
+
+/// 发送前暂存的附件(已上传拿到 id,等和文字一起随消息发出)。
+class _PendingUpload {
+  const _PendingUpload({required this.id, required this.name, this.localPath});
+  final int id;
+  final String name;
+
+  /// 本地源文件路径,图片用来画缩略图预览
+  final String? localPath;
+
+  bool get isImage => const {
+        '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp',
+      }.contains(p.extension(name).toLowerCase());
+}
+
+/// Chat 插件 DM 频道详情页:消息流 + 发送框。
+class DmChannelDetailPage extends ConsumerStatefulWidget {
+  const DmChannelDetailPage({
+    super.key,
+    required this.channelId,
+    this.title,
+    this.embeddedMode = false,
+    this.onEmbeddedBack,
+  });
+
+  final int channelId;
+  final String? title;
+
+  /// 嵌入平行视界右栏时为 true:不显示系统返回键,返回走 [onEmbeddedBack]
+  /// (同 [TagTopicsPage]/[CategoryTopicsPage] 的做法)。
+  final bool embeddedMode;
+  final VoidCallback? onEmbeddedBack;
+
+  @override
+  ConsumerState<DmChannelDetailPage> createState() => _DmChannelDetailPageState();
+}
+
+class _DmChannelDetailPageState extends ConsumerState<DmChannelDetailPage> {
+  final TextEditingController _inputController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final FocusNode _inputFocusNode = FocusNode();
+  bool _sending = false;
+  bool _uploading = false;
+  int _lastMessageId = -1;
+
+  @override
+  void initState() {
+    super.initState();
+    // reverse 列表里"顶部"是 maxScrollExtent 方向:快滚到顶就拉更早的消息
+    _scrollController.addListener(() {
+      final position = _scrollController.position;
+      if (position.pixels >= position.maxScrollExtent - 200) {
+        ref.read(chatMessagesProvider(widget.channelId).notifier).loadOlder();
+      }
+    });
+  }
+
+  /// 发送前暂存的附件:选文件/粘贴图片先上传拿 id 挂在输入框上方,
+  /// 点发送时随文字一起发出(而不是一粘贴/一选中就立刻单独发一条)。
+  final List<_PendingUpload> _pendingUploads = [];
+
+  /// 正在回复的消息(显示在输入框上方,发送时带 in_reply_to_id)。
+  ChatMessage? _replyTo;
+
+  /// 正在编辑的消息(发送按钮变成"保存编辑")。
+  ChatMessage? _editing;
+
+  @override
+  void dispose() {
+    _inputController.dispose();
+    _scrollController.dispose();
+    _inputFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottomSoon() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      // 列表是 reverse:true,offset 0 就是最底(最新消息)。
+      _scrollController.jumpTo(0);
+    });
+  }
+
+  void _showError(String prefix, Object e) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$prefix: $e')),
+    );
+  }
+
+  Future<void> _toggleStarred(bool current) async {
+    final next = !current;
+    // 乐观更新:先改本地状态,失败再改回来,星标这种低风险操作不值得
+    // 等接口回来再动 UI。
+    ref.read(chatChannelListProvider.notifier).applyStarred(widget.channelId, next);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.setChatChannelStarred(widget.channelId, next);
+    } catch (e) {
+      if (!mounted) return;
+      ref.read(chatChannelListProvider.notifier).applyStarred(widget.channelId, current);
+      _showError('收藏失败', e);
+    }
+  }
+
+  Future<void> _toggleMuted(bool current) async {
+    final next = !current;
+    ref.read(chatChannelListProvider.notifier).applyMuted(widget.channelId, next);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.setChatChannelMuted(widget.channelId, next);
+    } catch (e) {
+      if (!mounted) return;
+      ref.read(chatChannelListProvider.notifier).applyMuted(widget.channelId, current);
+      _showError('设置静音失败', e);
+    }
+  }
+
+  Future<void> _send() async {
+    final text = _inputController.text.trim();
+    final uploads = List<_PendingUpload>.from(_pendingUploads);
+    if ((text.isEmpty && uploads.isEmpty) || _sending) return;
+    setState(() => _sending = true);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      final editing = _editing;
+      if (editing != null) {
+        await ref
+            .read(chatMessagesProvider(widget.channelId).notifier)
+            .editMessage(editing.id, text);
+      } else {
+        await service.sendChatMessage(
+          widget.channelId,
+          text,
+          inReplyToId: _replyTo?.id,
+          uploadIds: uploads.map((u) => u.id).toList(),
+        );
+      }
+      _inputController.clear();
+      setState(() {
+        _pendingUploads.clear();
+        _replyTo = null;
+        _editing = null;
+      });
+      // 发送成功后 MessageBus 会推回这条消息;兜底重拉一次最新消息,
+      // 避免推送延迟导致用户以为没发出去。
+      ref.invalidate(chatMessagesProvider(widget.channelId));
+    } catch (e) {
+      _showError('发送失败', e);
+    } finally {
+      if (mounted) {
+        setState(() => _sending = false);
+        // 发完焦点回到输入框,连续聊天不用每条都点一下
+        _inputFocusNode.requestFocus();
+      }
+    }
+  }
+
+  /// 上传一段字节流,成功后挂进待发附件区(不直接发送)。
+  Future<void> _uploadBytesAsAttachment(Uint8List bytes, String ext) async {
+    if (_uploading) return;
+    setState(() => _uploading = true);
+    try {
+      final tempDir = await getTemporaryDirectory();
+      final fileName = 'paste_${DateTime.now().millisecondsSinceEpoch}.$ext';
+      final tempFile = File(p.join(tempDir.path, fileName));
+      await tempFile.writeAsBytes(bytes);
+      await _uploadPathAsAttachment(tempFile.path);
+    } catch (e) {
+      _showError('上传图片失败', e);
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  Future<void> _uploadPathAsAttachment(String path) async {
+    final service = ref.read(discourseServiceProvider);
+    final result = await service.uploadFile(path);
+    final uploadId = result.id;
+    if (uploadId == null) throw Exception('上传成功但未返回附件 id');
+    if (!mounted) return;
+    setState(() {
+      _pendingUploads.add(_PendingUpload(
+        id: uploadId,
+        name: p.basename(path),
+        localPath: path,
+      ));
+    });
+  }
+
+  /// 选一个文件上传后挂进待发附件区,和输入框文字一起随消息发出。
+  Future<void> _pickAndAttachFile() async {
+    if (_uploading) return;
+    final picked = await FilePicker.platform.pickFiles(withData: false);
+    final path = picked?.files.single.path;
+    if (path == null || !mounted) return;
+    setState(() => _uploading = true);
+    try {
+      await _uploadPathAsAttachment(path);
+    } catch (e) {
+      _showError('上传文件失败', e);
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  /// 在输入框光标处插入一段文字,替换掉当前选区(没有选区就是插入)。
+  void _insertTextAtCursor(String text) {
+    final value = _inputController.value;
+    final selection = value.selection.isValid
+        ? value.selection
+        : TextSelection.collapsed(offset: value.text.length);
+    final newText = value.text.replaceRange(selection.start, selection.end, text);
+    _inputController.value = value.copyWith(
+      text: newText,
+      selection: TextSelection.collapsed(offset: selection.start + text.length),
+    );
+    _inputFocusNode.requestFocus();
+  }
+
+  /// `[date=… time=… timezone="…"]` BBCode 重建,和富文本编辑器
+  /// (rich_composer_editor.dart 的 `_serializeLocalDate`)同一套属性名——
+  /// 聊天输入框是纯文本框,没有编辑器原子,只能直接拼 BBCode 文本。
+  String _serializeLocalDate(LocalDateRun n) {
+    final buf = StringBuffer('[date=${n.date}');
+    if (n.time != null) buf.write(' time=${n.time}');
+    if (n.timezone != null) buf.write(' timezone="${n.timezone}"');
+    if (n.format != null) buf.write(' format="${n.format}"');
+    if (n.timezones.isNotEmpty) {
+      buf.write(' timezones="${n.timezones.join('|')}"');
+    }
+    if (n.displayedTimezone != null) {
+      buf.write(' displayedTimezone="${n.displayedTimezone}"');
+    }
+    if (n.countdown) buf.write(' countdown="true"');
+    buf.write(']');
+    return buf.toString();
+  }
+
+  Future<void> _insertDateTime() async {
+    final run = await showLocalDateEditDialog(context);
+    if (run == null || !mounted) return;
+    _insertTextAtCursor(_serializeLocalDate(run));
+  }
+
+  Future<void> _insertTemplate() async {
+    final template = await showTemplateInsertDialog(context);
+    if (template == null || !mounted) return;
+    _insertTextAtCursor(template.content);
+  }
+
+  /// AI 总结频道近期消息(discourse-ai 插件,`POST
+  /// /discourse-ai/summarization/channels/:id.json`):弹窗选时间范围,
+  /// 展示只读摘要文本——对齐官方 chat-modal-channel-summary 组件的交互
+  /// (不写回输入框,纯展示)。
+  Future<void> _showSummarizeDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => _ChatSummaryDialog(channelId: widget.channelId),
+    );
+  }
+
+  Future<void> _showComposeMenu(BuildContext anchorContext) async {
+    final btnBox = anchorContext.findRenderObject() as RenderBox?;
+    final overlay = Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (btnBox == null || overlay == null) return;
+    final btnRect =
+        btnBox.localToGlobal(Offset.zero, ancestor: overlay) & btnBox.size;
+    final scheme = Theme.of(context).colorScheme;
+
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        btnRect.left,
+        btnRect.top - 8,
+        overlay.size.width - btnRect.right,
+        overlay.size.height - btnRect.top + 8,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: scheme.outlineVariant.withValues(alpha: 0.5)),
+      ),
+      color: scheme.surfaceContainerLow,
+      constraints: const BoxConstraints(maxWidth: 220),
+      items: const [
+        PopupMenuItem(value: 'file', child: _ComposeMenuRow(icon: Icons.attach_file_rounded, label: '附加文件')),
+        PopupMenuItem(value: 'date', child: _ComposeMenuRow(icon: Icons.event_rounded, label: '插入日期/时间')),
+        PopupMenuItem(value: 'template', child: _ComposeMenuRow(icon: Icons.description_outlined, label: '插入模板')),
+        PopupMenuItem(value: 'summarize', child: _ComposeMenuRow(icon: Icons.auto_awesome_rounded, label: '总结消息')),
+      ],
+    );
+    if (selected == null || !mounted) return;
+    switch (selected) {
+      case 'file':
+        await _pickAndAttachFile();
+      case 'date':
+        await _insertDateTime();
+      case 'template':
+        await _insertTemplate();
+      case 'summarize':
+        await _showSummarizeDialog();
+    }
+  }
+
+  /// Ctrl+V(mac 上是 Cmd+V)时先看剪贴板里有没有图片——有就上传挂到
+  /// 待发附件区;没有(纯文本/没有剪贴板访问)放行给 TextField 走默认
+  /// 粘贴,不吞事件。复用富文本编辑器同款的两段式图片读取
+  /// (super_clipboard 常规格式 + Windows 原生 CF_DIB 兜底)。
+  KeyEventResult _handlePasteKey(FocusNode node, KeyEvent event) {
+    // 必须把每个按键喂给修饰键补偿窗口——Win+V 注入的 `V` 自身不带 Ctrl
+    // 修饰位,可逆动作判定靠的是"刚收到过 Ctrl 按下"这个窗口;编辑器页
+    // 是在页面级喂的,聊天页之前没喂,判定永远为假,Win+V 就一直死着。
+    observeModifierKeyEvent(event);
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+
+    // Enter 发送,Shift+Enter 换行(拦下不带修饰键的 Enter,不让编辑框
+    // 插换行;Shift+Enter 放行走默认多行输入行为)。
+    final isEnter = event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter;
+    if (isEnter && !HardwareKeyboard.instance.isShiftPressed) {
+      _send();
+      return KeyEventResult.handled;
+    }
+
+    // 粘贴是可逆动作,用吃补偿窗口的那版修饰键判定(同富文本编辑器):
+    // Win+V 剪贴板历史注入的 `V` 键事件不带 Ctrl 修饰位,只认
+    // HardwareKeyboard 真实状态会让整条 Win+V 粘图路径失效。
+    final isPasteCombo = event.logicalKey == LogicalKeyboardKey.keyV &&
+        !shiftModifierHeld() &&
+        !HardwareKeyboard.instance.isAltPressed &&
+        primaryModifierHeldForReversibleAction(event);
+    if (!isPasteCombo) return KeyEventResult.ignored;
+
+    unawaited(_maybePasteImage());
+    return KeyEventResult.ignored; // 是否真有图片要异步才知道,先放行文本粘贴兜底
+  }
+
+  static const _pastedImageExtensions = {
+    '.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.avif',
+  };
+
+  /// 对齐富文本编辑器验证过的完整粘图链:super_clipboard 常规格式 →
+  /// Windows 原生 CF_DIB 兜底(Win+V 剪贴板历史的 OLE data object 在
+  /// super_clipboard 枚举不到位图) → 文件路径粘贴(CF_HDROP)。
+  /// 不做"有文本就早退"——之前那个 plainText 早退把 Win+V 路径整个
+  /// 挡死了(编辑器的成熟实现里没有这个判断)。
+  Future<void> _maybePasteImage() async {
+    final clipboard = SystemClipboard.instance;
+    if (clipboard == null) return;
+    final reader = await clipboard.read();
+    final img = await MarkdownToolbarState.readImageFromReader(reader);
+    if (img != null) {
+      unawaited(_uploadBytesAsAttachment(img.$1, img.$2));
+      return;
+    }
+    final native = readClipboardImageNative();
+    if (native != null) {
+      unawaited(_uploadBytesAsAttachment(native, 'png'));
+      return;
+    }
+    for (final item in reader.items) {
+      if (!item.canProvide(Formats.fileUri)) continue;
+      final uri = await item.readValue(Formats.fileUri);
+      if (uri == null) continue;
+      final path = uri.toFilePath(windows: Platform.isWindows);
+      if (_pastedImageExtensions.contains(p.extension(path).toLowerCase())) {
+        setState(() => _uploading = true);
+        try {
+          await _uploadPathAsAttachment(path);
+        } catch (e) {
+          _showError('上传图片失败', e);
+        } finally {
+          if (mounted) setState(() => _uploading = false);
+        }
+      }
+    }
+  }
+
+  void _insertEmoji(Emoji emoji) {
+    final text = _inputController.text;
+    final selection = _inputController.selection;
+    final shortcode = ':${emoji.name}:';
+    final start = selection.start >= 0 ? selection.start : text.length;
+    final end = selection.end >= 0 ? selection.end : text.length;
+    final newText = text.replaceRange(start, end, shortcode);
+    _inputController.text = newText;
+    _inputController.selection = TextSelection.collapsed(offset: start + shortcode.length);
+  }
+
+  Future<void> _showEmojiPicker() async {
+    final emoji = await _pickEmoji(allowSticker: true);
+    if (emoji != null) _insertEmoji(emoji);
+  }
+
+  void _startReply(ChatMessage message) {
+    setState(() {
+      _editing = null;
+      _replyTo = message;
+    });
+    _inputFocusNode.requestFocus();
+  }
+
+  void _startEdit(ChatMessage message) {
+    setState(() {
+      _replyTo = null;
+      _editing = message;
+      _pendingUploads.clear();
+    });
+    _inputController.text = message.message ?? '';
+    _inputController.selection =
+        TextSelection.collapsed(offset: _inputController.text.length);
+    _inputFocusNode.requestFocus();
+  }
+
+  void _cancelComposeExtras() {
+    setState(() {
+      _replyTo = null;
+      if (_editing != null) {
+        _editing = null;
+        _inputController.clear();
+      }
+    });
+  }
+
+  /// 输入框上方的状态条:回复某条 / 正在编辑 / 待发附件。
+  Widget? _buildComposeExtras(ColorScheme scheme) {
+    final children = <Widget>[];
+    final replyTo = _replyTo;
+    final editing = _editing;
+    if (replyTo != null || editing != null) {
+      children.add(Row(
+        children: [
+          Icon(
+            editing != null ? Icons.edit_rounded : Icons.reply_rounded,
+            size: 16,
+            color: scheme.primary,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              editing != null
+                  ? '编辑消息'
+                  : '回复 ${replyTo!.user?.name ?? replyTo.user?.username ?? ''}: '
+                      '${replyTo.excerpt ?? replyTo.message ?? ''}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: 12, color: scheme.onSurfaceVariant),
+            ),
+          ),
+          InkWell(
+            onTap: _cancelComposeExtras,
+            child: const Padding(
+              padding: EdgeInsets.all(4),
+              child: Icon(Icons.close_rounded, size: 16),
+            ),
+          ),
+        ],
+      ));
+    }
+    if (_pendingUploads.isNotEmpty) {
+      children.add(Wrap(
+        spacing: 6,
+        runSpacing: 4,
+        children: [
+          for (final upload in _pendingUploads)
+            // 图片给缩略图预览(右上角小 × 移除),其它文件保持 chip
+            if (upload.isImage && upload.localPath != null)
+              Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: GestureDetector(
+                      onTap: () {
+                        // 待发图也能点开大图预览(本地文件字节直接喂查看器)
+                        final bytes = File(upload.localPath!).readAsBytesSync();
+                        Navigator.of(context).push(
+                          PageRouteBuilder(
+                            opaque: false,
+                            barrierColor: Colors.transparent,
+                            pageBuilder: (_, animation, secondaryAnimation) =>
+                                ImageViewerPage(imageBytes: bytes),
+                          ),
+                        );
+                      },
+                      child: Image.file(
+                        File(upload.localPath!),
+                        width: 64,
+                        height: 64,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, e, s) => Container(
+                          width: 64,
+                          height: 64,
+                          color: scheme.surfaceContainerHighest,
+                          child: const Icon(Icons.broken_image_outlined,
+                              size: 20),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 2,
+                    right: 2,
+                    child: InkWell(
+                      onTap: () =>
+                          setState(() => _pendingUploads.remove(upload)),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.55),
+                          shape: BoxShape.circle,
+                        ),
+                        padding: const EdgeInsets.all(2),
+                        child: const Icon(Icons.close_rounded,
+                            size: 12, color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            else
+              InputChip(
+                avatar: const Icon(Icons.attach_file_rounded, size: 16),
+                label: Text(upload.name, style: const TextStyle(fontSize: 12)),
+                visualDensity: VisualDensity.compact,
+                onDeleted: () => setState(() => _pendingUploads.remove(upload)),
+              ),
+        ],
+      ));
+    }
+    if (children.isEmpty) return null;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      color: scheme.surfaceContainerLow,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < children.length; i++) ...[
+            if (i > 0) const SizedBox(height: 4),
+            children[i],
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// 成员列表(对齐官方"成员"标签页):走服务端分页搜索接口
+  /// `GET /chat/api/channels/:id/memberships?username=`,常规频道几万
+  /// 成员也能查,不做本地过滤。
+  Future<void> _showMembers() async {
+    final service = ref.read(discourseServiceProvider);
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) {
+        Timer? debounce;
+        Future<List<MentionUser>> future = service.fetchChatChannelMembers(widget.channelId);
+        return StatefulBuilder(
+          builder: (ctx, setSheetState) {
+            return SizedBox(
+              height: 460,
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+                    child: TextField(
+                      autofocus: false,
+                      onChanged: (v) {
+                        debounce?.cancel();
+                        debounce = Timer(const Duration(milliseconds: 400), () {
+                          setSheetState(() {
+                            future = service.fetchChatChannelMembers(
+                              widget.channelId,
+                              username: v.trim(),
+                            );
+                          });
+                        });
+                      },
+                      decoration: const InputDecoration(
+                        hintText: '查找成员',
+                        prefixIcon: Icon(Icons.search_rounded),
+                        isDense: true,
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  Expanded(
+                    child: FutureBuilder<List<MentionUser>>(
+                      future: future,
+                      builder: (ctx, snapshot) {
+                        if (snapshot.connectionState != ConnectionState.done) {
+                          return const Center(child: LoadingSpinner());
+                        }
+                        if (snapshot.hasError) {
+                          return Center(child: Text('加载成员失败: ${snapshot.error}'));
+                        }
+                        final members = snapshot.data ?? const [];
+                        if (members.isEmpty) {
+                          return const Center(
+                              child: Text('没有匹配的成员',
+                                  style: TextStyle(color: Colors.grey)));
+                        }
+                        return ListView.builder(
+                          itemCount: members.length,
+                          itemBuilder: (ctx, index) {
+                            final user = members[index];
+                            return ListTile(
+                              leading: SmartAvatar(
+                                imageUrl: user.getAvatarUrl(
+                                    AppConstants.baseUrl, size: 40),
+                                radius: 16,
+                                fallbackText: user.username.isNotEmpty
+                                    ? user.username[0]
+                                    : '?',
+                              ),
+                              title: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Flexible(
+                                    child: Text(
+                                      user.name?.isNotEmpty == true
+                                          ? user.name!
+                                          : user.username,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                  if (user.status != null) ...[
+                                    const SizedBox(width: 6),
+                                    UserStatusIcon(status: user.status, size: 14),
+                                  ],
+                                ],
+                              ),
+                              subtitle: Text(user.username),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  /// 点状态图标时弹出完整状态内容(悬浮 Tooltip 之外的触屏可达路径)。
+  void _showUserStatus(MentionUser user) {
+    final status = user.status;
+    if (status == null) return;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(user.name?.isNotEmpty == true ? user.name! : user.username),
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            UserStatusIcon(status: status, size: 22),
+            const SizedBox(width: 8),
+            Flexible(child: Text(status.description ?? '')),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('关闭'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 频道设置面板:免打扰 / 推送通知级别 / 离开频道(对齐官方网页端的
+  /// 频道设置页,DM 和公共频道通用)。
+  Future<void> _showChannelSettings() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (ctx) => Consumer(
+        builder: (ctx, sheetRef, _) {
+          final channels = sheetRef.watch(chatChannelListProvider).value;
+          final channel =
+              channels?.where((c) => c.id == widget.channelId).firstOrNull;
+          if (channel == null) {
+            return const SizedBox(height: 120, child: Center(child: Text('频道信息未加载')));
+          }
+          final membership = channel.membership;
+          final scheme = Theme.of(ctx).colorScheme;
+          return SafeArea(
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                ListTile(
+                  title: Text(
+                    channel.isDirectMessage ? '私聊设置' : '频道设置',
+                    style: Theme.of(ctx).textTheme.titleMedium,
+                  ),
+                  subtitle: Text(widget.title ?? channel.title ?? ''),
+                  trailing: IconButton(
+                    tooltip: membership.starred ? '取消收藏' : '收藏',
+                    icon: Icon(
+                      membership.starred
+                          ? Icons.star_rounded
+                          : Icons.star_border_rounded,
+                      color: membership.starred ? Colors.amber : null,
+                    ),
+                    onPressed: () => _toggleStarred(membership.starred),
+                  ),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.group_outlined),
+                  title: Text(
+                    '成员 (${channel.membershipsCount ?? channel.participants.length})',
+                  ),
+                  trailing: const Icon(Icons.chevron_right_rounded),
+                  onTap: () {
+                    Navigator.of(ctx).pop();
+                    _showMembers();
+                  },
+                ),
+                const Divider(height: 1),
+                SwitchListTile(
+                  secondary: const Icon(Icons.notifications_off_outlined),
+                  title: const Text('将频道设为免打扰'),
+                  value: membership.muted,
+                  onChanged: (_) => _toggleMuted(membership.muted),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.notifications_active_outlined),
+                  title: const Text('发送推送通知'),
+                  trailing: DropdownButton<int>(
+                    value: membership.notificationLevel,
+                    underline: const SizedBox.shrink(),
+                    items: const [
+                      DropdownMenuItem(value: 0, child: Text('从不')),
+                      DropdownMenuItem(value: 1, child: Text('仅提及')),
+                      DropdownMenuItem(value: 2, child: Text('所有活动')),
+                    ],
+                    onChanged: (level) {
+                      if (level != null) _setNotificationLevel(level);
+                    },
+                  ),
+                ),
+                // 消息串开关:DM 里成员就能改(UpdateChannel 对 DM 放行,
+                // 实测 meta.can_moderate 在 DM 里是 false,不能拿它当门槛);
+                // 公共频道才需要管理权限,没权限就不显示,免得点了 403。
+                if (channel.isDirectMessage || channel.canModerate)
+                  SwitchListTile(
+                    secondary: const Icon(Icons.forum_outlined),
+                    title: const Text('消息串'),
+                    subtitle: const Text(
+                      '启用后,对聊天消息的回复将创建单独的对话,与主频道并存',
+                      style: TextStyle(fontSize: 12),
+                    ),
+                    value: channel.threadingEnabled,
+                    onChanged: (_) =>
+                        _toggleThreading(channel.threadingEnabled),
+                  ),
+                ListTile(
+                  leading: const Icon(Icons.push_pin_outlined),
+                  title: const Text('置顶消息'),
+                  trailing: const Icon(Icons.chevron_right_rounded),
+                  onTap: () {
+                    Navigator.of(ctx).pop();
+                    _showPinnedMessages();
+                  },
+                ),
+                const Divider(height: 1),
+                // 频道信息(对照官方网页端的"频道信息"区)
+                if ((channel.description ?? '').isNotEmpty)
+                  ListTile(
+                    leading: const Icon(Icons.notes_rounded),
+                    title: const Text('描述'),
+                    subtitle: Text(channel.description!),
+                  ),
+                if (channel.categoryName != null)
+                  ListTile(
+                    leading: const Icon(Icons.category_outlined),
+                    title: const Text('类别'),
+                    trailing: Text(channel.categoryName!,
+                        style: Theme.of(ctx).textTheme.bodyMedium),
+                  ),
+                ListTile(
+                  leading: const Icon(Icons.link_rounded),
+                  title: const Text('复制频道链接'),
+                  onTap: () async {
+                    await Clipboard.setData(ClipboardData(
+                      text:
+                          '${AppConstants.baseUrl}/chat/c/${channel.slug ?? '-'}/${channel.id}',
+                    ));
+                    if (ctx.mounted) Navigator.of(ctx).pop();
+                    if (mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                            content: Text('已复制频道链接'),
+                            duration: Duration(seconds: 1)),
+                      );
+                    }
+                  },
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  leading: Icon(Icons.logout_rounded, color: scheme.error),
+                  title: Text('离开频道',
+                      style: TextStyle(color: scheme.error)),
+                  onTap: () {
+                    Navigator.of(ctx).pop();
+                    _confirmLeaveChannel();
+                  },
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _toggleThreading(bool current) async {
+    final next = !current;
+    ref
+        .read(chatChannelListProvider.notifier)
+        .applyThreadingEnabled(widget.channelId, next);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.setChatChannelThreadingEnabled(widget.channelId, next);
+    } catch (e) {
+      if (!mounted) return;
+      ref
+          .read(chatChannelListProvider.notifier)
+          .applyThreadingEnabled(widget.channelId, current);
+      _showError('设置消息串失败', e);
+    }
+  }
+
+  Future<void> _setNotificationLevel(int level) async {
+    final old = ref
+        .read(chatChannelListProvider)
+        .value
+        ?.where((c) => c.id == widget.channelId)
+        .firstOrNull
+        ?.membership
+        .notificationLevel;
+    ref
+        .read(chatChannelListProvider.notifier)
+        .applyNotificationLevel(widget.channelId, level);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.setChatChannelNotificationLevel(widget.channelId, level);
+    } catch (e) {
+      if (!mounted) return;
+      if (old != null) {
+        ref
+            .read(chatChannelListProvider.notifier)
+            .applyNotificationLevel(widget.channelId, old);
+      }
+      _showError('设置通知级别失败', e);
+    }
+  }
+
+  Future<void> _confirmLeaveChannel() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('离开频道'),
+        content: const Text('确定要离开这个频道吗?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('取消'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('离开'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.leaveChatChannel(widget.channelId);
+      if (!mounted) return;
+      ref.read(chatChannelListProvider.notifier).removeChannel(widget.channelId);
+      if (widget.embeddedMode) {
+        widget.onEmbeddedBack?.call();
+      } else {
+        Navigator.of(context).maybePop();
+      }
+    } catch (e) {
+      _showError('离开频道失败', e);
+    }
+  }
+
+  /// 查看频道置顶消息列表(顺手把"有新置顶"的红点标掉)。
+  Future<void> _showPinnedMessages() async {
+    final service = ref.read(discourseServiceProvider);
+    unawaited(service.markChatChannelPinsRead(widget.channelId).catchError((_) {}));
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) => SizedBox(
+        height: 420,
+        child: FutureBuilder<List<ChatMessage>>(
+          future: service.fetchChatChannelPins(widget.channelId),
+          builder: (ctx, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: LoadingSpinner());
+            }
+            if (snapshot.hasError) {
+              return Center(child: Text('加载置顶消息失败: ${snapshot.error}'));
+            }
+            final pins = snapshot.data ?? const [];
+            if (pins.isEmpty) {
+              return const Center(
+                child: Text('暂无置顶消息', style: TextStyle(color: Colors.grey)),
+              );
+            }
+            return ListView.builder(
+              itemCount: pins.length,
+              itemBuilder: (ctx, index) {
+                final pin = pins[index];
+                return ListTile(
+                  leading: SmartAvatar(
+                    imageUrl:
+                        pin.user?.getAvatarUrl(AppConstants.baseUrl, size: 40),
+                    radius: 16,
+                    fallbackText: (pin.user?.username ?? '?').isNotEmpty
+                        ? pin.user!.username[0]
+                        : '?',
+                  ),
+                  title: Text(
+                    pin.user?.name ?? pin.user?.username ?? '',
+                    style: Theme.of(ctx).textTheme.bodySmall,
+                  ),
+                  subtitle: Text(
+                    pin.excerpt ?? pin.message ?? '',
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: IconButton(
+                    tooltip: '取消置顶',
+                    icon: const Icon(Icons.push_pin_rounded, size: 18),
+                    onPressed: () async {
+                      Navigator.of(ctx).pop();
+                      try {
+                        await ref
+                            .read(chatMessagesProvider(widget.channelId).notifier)
+                            .togglePinned(pin.id);
+                      } catch (e) {
+                        _showError('取消置顶失败', e);
+                      }
+                    },
+                  ),
+                  onTap: () => Navigator.of(ctx).pop(),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  /// 消息书签:没加过 → 创建后弹编辑面板(名称/提醒,同帖子书签流程);
+  /// 已加过 → 直接打开编辑面板(可改名/改提醒/右下角删除)。
+  Future<void> _bookmarkMessage(ChatMessage message) async {
+    final notifier = ref.read(chatMessagesProvider(widget.channelId).notifier);
+    final existing = message.bookmark;
+    int bookmarkId;
+    try {
+      if (existing == null) {
+        final service = ref.read(discourseServiceProvider);
+        bookmarkId = await service.bookmarkChatMessage(message.id);
+        notifier.applyBookmark(message.id, ChatBookmark(id: bookmarkId));
+        ToastService.showSuccess('已加入书签');
+      } else {
+        bookmarkId = existing.id;
+      }
+    } on DioException catch (e) {
+      final errors = (e.response?.data is Map)
+          ? ((e.response!.data as Map)['errors'] as List?)
+          : null;
+      ToastService.showError(errors?.firstOrNull?.toString() ?? '加书签失败');
+      return;
+    } catch (e) {
+      ToastService.showError('加书签失败: $e');
+      return;
+    }
+    if (!mounted) return;
+
+    final result = await showBookmarkEditSheetWithCachedNames(
+      context,
+      ref,
+      bookmarkId: bookmarkId,
+      initialName: existing?.name,
+      initialReminderAt: existing?.reminderAt,
+      source: 'chat_message_bookmark',
+    );
+    if (result == null || !mounted) return;
+    if (result.deleted) {
+      notifier.applyBookmark(message.id, null);
+    } else {
+      notifier.applyBookmark(
+        message.id,
+        ChatBookmark(
+          id: bookmarkId,
+          name: result.name,
+          reminderAt: result.reminderAt,
+        ),
+      );
+    }
+  }
+
+  // ---- 消息操作菜单 ----
+
+  Future<void> _showMessageMenu(ChatMessage message, bool isOwn) async {
+    final notifier = ref.read(chatMessagesProvider(widget.channelId).notifier);
+    // 置顶需要 meta.can_manage_pins,没权限不显示入口
+    final canManagePins = ref
+            .read(chatChannelListProvider)
+            .value
+            ?.where((c) => c.id == widget.channelId)
+            .firstOrNull
+            ?.canManagePins ??
+        false;
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (!message.isDeleted)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 4,
+                  children: [
+                    for (final name in _quickReactionEmojis)
+                      IconButton(
+                        onPressed: () => Navigator.of(ctx).pop('react:$name'),
+                        icon: _ReactionEmoji(name: name, size: 26),
+                      ),
+                    IconButton(
+                      tooltip: '更多表情',
+                      onPressed: () => Navigator.of(ctx).pop('react_more'),
+                      icon: const Icon(Icons.add_reaction_outlined),
+                    ),
+                  ],
+                ),
+              ),
+            if (!message.isDeleted) const Divider(height: 1),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.reply_rounded),
+                title: const Text('回复'),
+                onTap: () => Navigator.of(ctx).pop('reply'),
+              ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.copy_rounded),
+                title: const Text('复制文本'),
+                onTap: () => Navigator.of(ctx).pop('copy'),
+              ),
+            ListTile(
+              leading: const Icon(Icons.link_rounded),
+              title: const Text('复制链接'),
+              onTap: () => Navigator.of(ctx).pop('copy_link'),
+            ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: Icon(message.bookmark != null
+                    ? Icons.bookmark_rounded
+                    : Icons.bookmark_border_rounded),
+                title: Text(message.bookmark != null ? '修改书签' : '书签'),
+                onTap: () => Navigator.of(ctx).pop('bookmark'),
+              ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.select_all_rounded),
+                title: const Text('选择文本'),
+                onTap: () => Navigator.of(ctx).pop('select'),
+              ),
+            if (!message.isDeleted && canManagePins)
+              ListTile(
+                leading: Icon(message.pinned
+                    ? Icons.push_pin_rounded
+                    : Icons.push_pin_outlined),
+                title: Text(message.pinned ? '取消置顶' : '置顶'),
+                onTap: () => Navigator.of(ctx).pop('pin'),
+              ),
+            if (isOwn && !message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.edit_rounded),
+                title: const Text('编辑'),
+                onTap: () => Navigator.of(ctx).pop('edit'),
+              ),
+            if (isOwn && !message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.delete_outline_rounded),
+                title: const Text('删除'),
+                onTap: () => Navigator.of(ctx).pop('delete'),
+              ),
+            if (isOwn && message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.restore_rounded),
+                title: const Text('恢复'),
+                onTap: () => Navigator.of(ctx).pop('restore'),
+              ),
+            if (!isOwn && !message.isDeleted)
+              ListTile(
+                leading: Icon(Icons.flag_outlined,
+                    color: Theme.of(ctx).colorScheme.error),
+                title: Text('举报',
+                    style: TextStyle(color: Theme.of(ctx).colorScheme.error)),
+                onTap: () => Navigator.of(ctx).pop('flag'),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (action == null || !mounted) return;
+
+    if (action.startsWith('react:')) {
+      unawaited(notifier.toggleReaction(message.id, action.substring(6)));
+      return;
+    }
+    switch (action) {
+      case 'react_more':
+        final emoji = await _pickEmoji();
+        if (emoji != null) {
+          unawaited(notifier.toggleReaction(message.id, emoji.name));
+        }
+      case 'reply':
+        _startReply(message);
+      case 'bookmark':
+        await _bookmarkMessage(message);
+      case 'copy':
+        await Clipboard.setData(ClipboardData(text: message.message ?? ''));
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('已复制文本'), duration: Duration(seconds: 1)),
+          );
+        }
+      case 'copy_link':
+        // 官方消息链接格式:/chat/c/-/{channelId}/{messageId}(路由表里的
+        // `get "#{base_c_route}/:message_id"`,channel_title 用 `-` 占位)。
+        await Clipboard.setData(ClipboardData(
+          text: '${AppConstants.baseUrl}/chat/c/-/${widget.channelId}/${message.id}',
+        ));
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('已复制链接'), duration: Duration(seconds: 1)),
+          );
+        }
+      case 'select':
+        await showDialog<void>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('选择文本'),
+            content: SelectableText(message.message ?? ''),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('关闭'),
+              ),
+            ],
+          ),
+        );
+      case 'pin':
+        try {
+          await notifier.togglePinned(message.id);
+        } catch (e) {
+          _showError('置顶操作失败', e);
+        }
+      case 'edit':
+        _startEdit(message);
+      case 'delete':
+        try {
+          await notifier.deleteMessage(message.id);
+        } catch (e) {
+          _showError('删除失败', e);
+        }
+      case 'restore':
+        try {
+          await notifier.restoreMessage(message.id);
+        } catch (e) {
+          _showError('恢复失败', e);
+        }
+      case 'flag':
+        await _showFlagDialog(message);
+    }
+  }
+
+  /// 举报:复用全应用同一套举报组件(理由列表来自站点 post_action_types,
+  /// 按 applies_to 含 Chat::Message 过滤,和话题/私信举报同源同 UI)。
+  Future<void> _showFlagDialog(ChatMessage message) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      enableDrag: false,
+      builder: (ctx) => PostFlagSheet(
+        postId: message.id,
+        postUsername: message.user?.username ?? '',
+        service: ref.read(discourseServiceProvider),
+        chatChannelId: widget.channelId,
+        chatMessageId: message.id,
+        onSuccess: () {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('已提交举报')),
+            );
+          }
+        },
+      ),
+    );
+  }
+
+  /// 表情选择:复用编辑器同款 [EmojiStickerPanel](最近使用/分组/搜索/
+  /// 表情包都有)。PC 端悬浮面板(compact + 内联搜索),移动端底部弹层。
+  /// [allowSticker] 为 true 时(输入框场景)选表情包直接把 markdown 插进
+  /// 输入框;回应场景表情包无意义,点了只关面板。
+  Future<Emoji?> _pickEmoji({bool allowSticker = false}) {
+    Widget buildPanel(BuildContext ctx, {required bool compact}) {
+      return EmojiStickerPanel(
+        compact: compact,
+        inlineSearch: compact,
+        onEmojiSelected: (e) => Navigator.of(ctx).pop(e),
+        onStickerSelected: (markdown) {
+          Navigator.of(ctx).pop();
+          if (allowSticker) {
+            final text = _inputController.text;
+            _inputController.text = text.isEmpty ? markdown : '$text $markdown';
+            _inputController.selection = TextSelection.collapsed(
+                offset: _inputController.text.length);
+            _inputFocusNode.requestFocus();
+          }
+        },
+      );
+    }
+
+    if (PlatformUtils.isDesktop) {
+      return showDialog<Emoji>(
+        context: context,
+        builder: (ctx) => Dialog(
+          clipBehavior: Clip.antiAlias,
+          child: SizedBox(
+            width: 420,
+            height: 480,
+            child: buildPanel(ctx, compact: true),
+          ),
+        ),
+      );
+    }
+    return showModalBottomSheet<Emoji>(
+      context: context,
+      isScrollControlled: true,
+      builder: (ctx) => SizedBox(
+        height: 360,
+        child: buildPanel(ctx, compact: false),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final messagesAsync = ref.watch(chatMessagesProvider(widget.channelId));
+    final currentUsername = ref.watch(
+      currentUserProvider.select((s) => s.value?.username),
+    );
+    final scheme = Theme.of(context).colorScheme;
+
+    // **最后一条**消息变了(首次加载/新消息进来)才滚到底;往上翻加载
+    // 更早的消息是往列表头部插,不能触发滚底,不然翻着翻着被拽回去。
+    messagesAsync.whenData((messages) {
+      final lastId = messages.isEmpty ? -1 : messages.last.id;
+      if (lastId != _lastMessageId) {
+        _lastMessageId = lastId;
+        _scrollToBottomSoon();
+      }
+    });
+
+    // 收藏/静音状态从频道列表 provider 里取(详情页本身不单独拉频道详情),
+    // 列表还没加载过(比如直接从通知点进来)时找不到,对应按钮就不显示。
+    final channels = ref.watch(chatChannelListProvider).value;
+    final channel = channels?.where((c) => c.id == widget.channelId).firstOrNull;
+
+    final composeExtras = _buildComposeExtras(scheme);
+
+    final otherUser = (channel != null && channel.isDirectMessage && currentUsername != null)
+        ? channel.otherParticipant(currentUsername)
+        : null;
+
+    return Scaffold(
+      appBar: AppBar(
+        // 跟应用其它页面一致:不要 M3 滚动下的 surface tint 灰底
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
+        elevation: 0,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(child: Text(widget.title ?? '消息')),
+            if (otherUser?.status != null) ...[
+              const SizedBox(width: 6),
+              UserStatusIcon(
+                status: otherUser!.status,
+                size: 16,
+                onTap: () => _showUserStatus(otherUser),
+              ),
+            ],
+          ],
+        ),
+        automaticallyImplyLeading: !widget.embeddedMode,
+        leading: widget.embeddedMode && widget.onEmbeddedBack != null
+            ? BackButton(onPressed: widget.onEmbeddedBack)
+            : null,
+        actions: [
+          if (channel != null) ...[
+            IconButton(
+              tooltip: channel.membership.starred ? '取消收藏' : '收藏',
+              icon: Icon(
+                channel.membership.starred
+                    ? Icons.star_rounded
+                    : Icons.star_border_rounded,
+                color: channel.membership.starred ? Colors.amber : null,
+              ),
+              onPressed: () => _toggleStarred(channel.membership.starred),
+            ),
+            IconButton(
+              tooltip: '搜索本频道',
+              icon: const Icon(Icons.search_rounded),
+              onPressed: () =>
+                  showChatSearchDialog(context, channelId: widget.channelId),
+            ),
+            IconButton(
+              tooltip: '置顶消息',
+              icon: const Icon(Icons.push_pin_outlined),
+              onPressed: _showPinnedMessages,
+            ),
+            IconButton(
+              tooltip: '频道设置',
+              icon: const Icon(Icons.settings_outlined),
+              onPressed: _showChannelSettings,
+            ),
+          ],
+        ],
+      ),
+      body: Column(
+        children: [
+          if (_uploading) const LinearProgressIndicator(minHeight: 2),
+          Expanded(
+            child: messagesAsync.when(
+              data: (messages) {
+                if (messages.isEmpty) {
+                  return const Center(
+                    child: Text('暂无消息', style: TextStyle(color: Colors.grey)),
+                  );
+                }
+                // reverse:true 是聊天列表的标准姿势:视口锚定在底部,上面的
+                // 内容(图片加载、附件条出现等)高度变化不会把当前位置顶跑
+                // ——之前"粘贴图片后列表跳到最上面"就是正向列表在布局高度
+                // 突变时 offset 失锚导致的。
+                final loadingOlder =
+                    ref.watch(chatLoadingOlderProvider(widget.channelId));
+                return ListView.builder(
+                  controller: _scrollController,
+                  reverse: true,
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  // 多出的一项是列表顶端(reverse 的最后一项)的加载动画
+                  itemCount: messages.length + 1,
+                  itemBuilder: (context, index) {
+                    if (index == messages.length) {
+                      return AnimatedSize(
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeOut,
+                        child: loadingOlder
+                            ? const Padding(
+                                padding: EdgeInsets.symmetric(vertical: 10),
+                                child: Center(child: LoadingSpinner(size: 22)),
+                              )
+                            : const SizedBox(width: double.infinity, height: 0),
+                      );
+                    }
+                    final chronoIndex = messages.length - 1 - index;
+                    final message = messages[chronoIndex];
+                    final previous =
+                        chronoIndex > 0 ? messages[chronoIndex - 1] : null;
+                    final isOwn = currentUsername != null &&
+                        message.user?.username == currentUsername;
+                    final showHeader = previous == null ||
+                        previous.user?.username != message.user?.username;
+                    // 消息 user 序列化里不一定带 status,拿频道成员表兜底
+                    final senderInChannel = channel?.participants
+                        .where((p) => p.username == message.user?.username)
+                        .firstOrNull;
+                    final statusUser = message.user?.status != null
+                        ? message.user
+                        : senderInChannel;
+                    return _ChatMessageBubble(
+                      channelId: widget.channelId,
+                      message: message,
+                      isOwn: isOwn,
+                      showHeader: showHeader,
+                      userStatus: statusUser?.status,
+                      onShowStatus: statusUser != null
+                          ? () => _showUserStatus(statusUser)
+                          : null,
+                      onOpenMenu: () => _showMessageMenu(message, isOwn),
+                      onReply: () => _startReply(message),
+                      onBookmark: () => _bookmarkMessage(message),
+                      pickEmoji: _pickEmoji,
+                      onOpenThread: message.thread != null
+                          ? () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => DmThreadPage(
+                                    channelId: widget.channelId,
+                                    threadId: message.thread!.id,
+                                    title: message.thread!.title ??
+                                        message.threadTitle ??
+                                        '消息串',
+                                  ),
+                                ),
+                              )
+                          : null,
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: LoadingSpinner()),
+              error: (error, stack) => ErrorView(
+                error: error,
+                stackTrace: stack,
+                onRetry: () => ref.invalidate(chatMessagesProvider(widget.channelId)),
+              ),
+            ),
+          ),
+          ?composeExtras,
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Builder(
+                    builder: (btnCtx) => IconButton(
+                      tooltip: '更多',
+                      onPressed: (_uploading || _editing != null)
+                          ? null
+                          : () => _showComposeMenu(btnCtx),
+                      icon: const Icon(Icons.add_circle_outline_rounded),
+                    ),
+                  ),
+                  IconButton(
+                    tooltip: '表情',
+                    onPressed: _showEmojiPicker,
+                    icon: const Icon(Icons.emoji_emotions_outlined),
+                  ),
+                  Expanded(
+                    child: Focus(
+                      onKeyEvent: _handlePasteKey,
+                      // M3E 风格:填充式圆角胶囊输入框,无描边
+                      child: TextField(
+                        controller: _inputController,
+                        focusNode: _inputFocusNode,
+                        minLines: 1,
+                        maxLines: 5,
+                        textInputAction: TextInputAction.send,
+                        onSubmitted: (_) => _send(),
+                        decoration: InputDecoration(
+                          hintText: _editing != null ? '编辑消息…' : '发送消息',
+                          filled: true,
+                          fillColor: Theme.of(context)
+                              .colorScheme
+                              .surfaceContainerHigh,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(24),
+                            borderSide: BorderSide.none,
+                          ),
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16, vertical: 10),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton.filled(
+                    tooltip: _editing != null ? '保存编辑' : '发送',
+                    onPressed: _sending ? null : _send,
+                    icon: _sending
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: LoadingSpinner(size: 18),
+                          )
+                        : Icon(_editing != null
+                            ? Icons.check_rounded
+                            : Icons.send_rounded),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 按 emoji 名字渲染成真正的表情图片(跟正文/表情选择器同一套资源+缓存),
+/// 不用裸 unicode 字符——Windows 默认字体对大部分 emoji 只有轮廓/缺字形,
+/// 裸文本渲染出来是方块或黑白轮廓,跟应用其它地方的彩色表情对不上。
+class _ReactionEmoji extends StatelessWidget {
+  const _ReactionEmoji({required this.name, this.size = 16});
+
+  final String name;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image(
+      image: emojiImageProvider(EmojiHandler().getEmojiUrl(name)),
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      errorBuilder: (context, error, stack) => Text(
+        ':$name:',
+        style: TextStyle(fontSize: size * 0.6),
+      ),
+    );
+  }
+}
+
+/// 聊天气泡:自己发的靠右、主题色底,别人发的靠左、灰底,贴近常见聊天
+/// App 的观感,而不是像帖子列表那样整行左对齐。
+class _ChatMessageBubble extends ConsumerStatefulWidget {
+  const _ChatMessageBubble({
+    required this.channelId,
+    required this.message,
+    required this.isOwn,
+    required this.showHeader,
+    required this.onOpenMenu,
+    required this.onReply,
+    required this.onBookmark,
+    required this.pickEmoji,
+    this.userStatus,
+    this.onShowStatus,
+    this.onOpenThread,
+  });
+
+  final int channelId;
+  final ChatMessage message;
+  final bool isOwn;
+  final bool showHeader;
+  final VoidCallback onOpenMenu;
+  final VoidCallback onReply;
+  final VoidCallback onBookmark;
+  final UserCustomStatus? userStatus;
+  final VoidCallback? onShowStatus;
+
+  /// 打开表情选择器(PC 悬浮面板 / 移动端底部弹层,由页面统一提供)
+  final Future<Emoji?> Function() pickEmoji;
+
+  /// 这条消息开了消息串时,点"N 条回复"打开串;频道没开串则为 null
+  final VoidCallback? onOpenThread;
+
+  @override
+  ConsumerState<_ChatMessageBubble> createState() => _ChatMessageBubbleState();
+}
+
+class _ChatMessageBubbleState extends ConsumerState<_ChatMessageBubble> {
+  bool _hoverBubble = false;
+  bool _hoverPanel = false;
+  final LayerLink _link = LayerLink();
+  final OverlayPortalController _portalController = OverlayPortalController();
+
+  /// 气泡或面板任意一个被悬浮就显示面板;都离开才收起(面板和气泡有
+  /// 几像素重叠,鼠标能连续移过去不断触)。
+  void _updateHover({bool? bubble, bool? panel}) {
+    setState(() {
+      if (bubble != null) _hoverBubble = bubble;
+      if (panel != null) _hoverPanel = panel;
+    });
+    final shouldShow = (_hoverBubble || _hoverPanel) && !message.isDeleted;
+    if (shouldShow && !_portalController.isShowing) {
+      _portalController.show();
+    } else if (!shouldShow && _portalController.isShowing) {
+      _portalController.hide();
+    }
+  }
+
+  ChatMessage get message => widget.message;
+  bool get isOwn => widget.isOwn;
+  bool get showHeader => widget.showHeader;
+  int get channelId => widget.channelId;
+  VoidCallback get onOpenMenu => widget.onOpenMenu;
+
+  /// cooked 里含图片/表格/代码块/onebox 等复杂块时不做宽度测量,直接给
+  /// 最大宽度让内容自己排(图片网格等场景内部用了 LayoutBuilder,不支持
+  /// intrinsic 测量——之前用 IntrinsicWidth 收缩气泡,布局期直接抛
+  /// "LayoutBuilder does not support returning intrinsic dimensions",
+  /// release 下不红屏,整个 body 连输入栏一起画成空白,就是"直接不显示
+  /// 信息了"的根因)。
+  /// 真正的内容图片(排除 emoji——emoji 也 cook 成 `<img class="emoji">`,
+  /// 之前一刀切匹配 `<img` 导致带 emoji 的消息全部放弃测宽,渲染出来的
+  /// 块级段落又默认填满可用宽度,于是"一个 emoji 的消息框长得离谱")。
+  static final _contentImgPattern = RegExp(r'<img(?![^>]*class="[^"]*emoji)');
+
+  bool get _hasComplexContent {
+    final cooked = message.cooked;
+    if (cooked == null) return false;
+    return _contentImgPattern.hasMatch(cooked) ||
+        cooked.contains('<table') ||
+        cooked.contains('<pre') ||
+        cooked.contains('<svg') ||
+        cooked.contains('<video') ||
+        cooked.contains('<audio') ||
+        cooked.contains('<iframe') ||
+        cooked.contains('class="onebox') ||
+        cooked.contains('<aside');
+  }
+
+  /// 纯文本消息按原始文字用 TextPainter 量一个"内容宽度",让短消息气泡
+  /// 收缩到贴内容,长消息在 maxWidth 处换行。量的是 raw message 而不是
+  /// cooked(近似值,够用),加一点余量容纳行内表情图片等稍宽的元素。
+  static final _shortcodePattern = RegExp(r':[a-zA-Z0-9_+\-]+(?::t\d)?:');
+  // 覆盖常见 emoji 平面:杂项符号/装饰符号区 + SMP 的 surrogate pair 区
+  // (U+1F000–U+1FFFF)。不追求学术级精确,量宽度用的近似值足够。
+  static final _unicodeEmojiPattern =
+      RegExp(r'[☀-➿⬀-⯿]|[\uD83C-\uD83E][\uDC00-\uDFFF]');
+  static final _emojiJoinerPattern = RegExp(r'[️‍]');
+
+  double? _measuredWidth(BuildContext context, double maxContentWidth) {
+    if (_hasComplexContent) return null;
+    final text = message.isDeleted ? '(消息已删除)' : (message.message ?? '');
+    if (text.isEmpty && message.inReplyTo == null && message.uploads.isEmpty) {
+      return null;
+    }
+
+    // emoji 会被 cook 成行内图片,量原始文本时把 `:joy:` 这类 shortcode
+    // 和裸 unicode emoji 都剔掉,改按"每个 emoji 一张定宽图"补偿——不然
+    // ":distorted_face:" 按 16 个字符量出一大截宽度,渲染出来却只有一张
+    // 小图,气泡右边就空一块(被吐槽"单emoji独立成行后面还有空白")。
+    var emojiCount = _shortcodePattern.allMatches(text).length;
+    var stripped = text.replaceAll(_shortcodePattern, '');
+    emojiCount += _unicodeEmojiPattern.allMatches(stripped).length;
+    stripped = stripped
+        .replaceAll(_unicodeEmojiPattern, '')
+        .replaceAll(_emojiJoinerPattern, '');
+
+    // 纯 emoji 消息 Discourse 会放大显示(cooked 里带 only-emoji class)
+    final emojiWidth =
+        (message.cooked?.contains('only-emoji') ?? false) ? 34.0 : 22.0;
+
+    final style = DefaultTextStyle.of(context).style.merge(
+          Theme.of(context).textTheme.bodyMedium,
+        );
+    final painter = TextPainter(
+      text: TextSpan(text: stripped, style: style),
+      textDirection: TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: maxContentWidth);
+    var width = painter.width + emojiCount * emojiWidth + 8;
+
+    // 带引用条的消息:引用条(单行小字 + ↩ 图标 + 内边距)也量一次,
+    // 气泡取"正文 vs 引用条"里较宽的那个——之前直接放弃测宽,块级渲染
+    // 一填满就成了通栏,又被抓到"带回复的消息长度不对"。
+    final inReplyTo = message.inReplyTo;
+    if (inReplyTo != null && !message.isDeleted) {
+      final quotePainter = TextPainter(
+        text: TextSpan(
+          text: '${inReplyTo.username ?? ''}: ${inReplyTo.excerpt ?? ''}',
+          style: style.copyWith(fontSize: 12),
+        ),
+        maxLines: 1,
+        textDirection: TextDirection.ltr,
+        textScaler: MediaQuery.textScalerOf(context),
+      )..layout(maxWidth: maxContentWidth);
+      // 12 图标 + 4 间距 + 16 引用条内边距 + 少许余量
+      final quoteWidth = quotePainter.width + 12 + 4 + 16 + 6;
+      if (quoteWidth > width) width = quoteWidth;
+    }
+
+    // 带图片/附件:附件块最宽 320,气泡至少要容得下它
+    if (message.uploads.isNotEmpty) {
+      const uploadWidth = 320.0;
+      if (uploadWidth > width) width = uploadWidth;
+    }
+
+    return width.clamp(24.0, maxContentWidth);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final callbacks = FluxdoRenderCallbacks.generic(
+      heroTagNamespace: 'chat_msg_${message.id}',
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const horizontalPadding = 12.0;
+        final maxBubbleWidth =
+            (constraints.maxWidth * 0.72 - 72).clamp(160.0, 560.0);
+        final maxContentWidth = maxBubbleWidth - horizontalPadding * 2;
+        final contentWidth = _measuredWidth(context, maxContentWidth);
+
+        final bubble = Container(
+          width: contentWidth != null ? contentWidth + horizontalPadding * 2 : null,
+          constraints: BoxConstraints(maxWidth: maxBubbleWidth),
+          padding: const EdgeInsets.symmetric(
+              horizontal: horizontalPadding, vertical: 8),
+          decoration: BoxDecoration(
+            color: isOwn ? scheme.primaryContainer : scheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.only(
+              topLeft: const Radius.circular(16),
+              topRight: const Radius.circular(16),
+              bottomLeft: Radius.circular(isOwn ? 16 : 4),
+              bottomRight: Radius.circular(isOwn ? 4 : 16),
+            ),
+          ),
+          child: DefaultTextStyle.merge(
+            style: TextStyle(
+              color: isOwn ? scheme.onPrimaryContainer : scheme.onSurface,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (message.inReplyTo != null && !message.isDeleted)
+                  // 引用条:不要通栏、不要"前端味"的左竖线,一行紧凑摘要
+                  Container(
+                    margin: const EdgeInsets.only(bottom: 6),
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: scheme.surface.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.reply_rounded,
+                            size: 12, color: scheme.onSurfaceVariant),
+                        const SizedBox(width: 4),
+                        Flexible(
+                          child: Text(
+                            '${message.inReplyTo!.username ?? ''}: '
+                            '${message.inReplyTo!.excerpt ?? ''}',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: scheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                if (!message.isDeleted &&
+                    (message.cooked?.isNotEmpty ?? false))
+                  callbacks.render(cookedHtml: message.cooked!, compact: true)
+                else if (!message.isDeleted &&
+                    (message.message?.isNotEmpty ?? false))
+                  Text(message.message!),
+                if (message.isDeleted)
+                  const Text('(消息已删除)',
+                      style: TextStyle(color: Colors.grey)),
+                // 图片/附件不在 cooked 里(官方 MessageSerializer 单独给
+                // uploads 数组,网页端也是正文下方另行渲染),这里补上
+                if (!message.isDeleted)
+                  for (final upload in message.uploads)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: _ChatUploadView(upload: upload),
+                    ),
+                // 消息串入口:线程原始消息下挂"N 条回复"胶囊
+                if (message.thread != null &&
+                    widget.onOpenThread != null &&
+                    !message.isDeleted)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: InkWell(
+                      borderRadius: BorderRadius.circular(12),
+                      onTap: widget.onOpenThread,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: scheme.surface.withValues(alpha: 0.6),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.forum_outlined,
+                                size: 13, color: scheme.primary),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${message.thread!.replyCount} 条回复',
+                              style: TextStyle(
+                                  fontSize: 12, color: scheme.primary),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                if ((message.edited || message.pinned) && !message.isDeleted)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (message.pinned) ...[
+                          Icon(Icons.push_pin_rounded,
+                              size: 11, color: scheme.onSurfaceVariant),
+                          const SizedBox(width: 2),
+                        ],
+                        if (message.edited)
+                          Text(
+                            '(已编辑)',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: scheme.onSurfaceVariant,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+
+        final reactionsRow = message.reactions.isEmpty
+            ? null
+            : Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: [
+                  for (final reaction in message.reactions)
+                    InkWell(
+                      borderRadius: BorderRadius.circular(12),
+                      onTap: () => ref
+                          .read(chatMessagesProvider(channelId).notifier)
+                          .toggleReaction(message.id, reaction.emoji),
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 6, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: reaction.reacted
+                              ? scheme.primaryContainer
+                              : scheme.surfaceContainerHigh,
+                          borderRadius: BorderRadius.circular(12),
+                          border: reaction.reacted
+                              ? Border.all(color: scheme.primary, width: 1)
+                              : null,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            _ReactionEmoji(name: reaction.emoji, size: 14),
+                            const SizedBox(width: 3),
+                            Text('${reaction.count}',
+                                style: const TextStyle(fontSize: 12)),
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              );
+
+        // 点头像弹用户资料卡(同帖子楼层头像的行为)
+        final avatar = Builder(
+          builder: (avatarCtx) => GestureDetector(
+            onTap: message.user == null
+                ? null
+                : () {
+                    final box = avatarCtx.findRenderObject() as RenderBox?;
+                    if (box == null || !box.hasSize) return;
+                    showUserCard(
+                      context: avatarCtx,
+                      anchorRect: box.localToGlobal(Offset.zero) & box.size,
+                      username: message.user!.username,
+                      nameFallback: message.user!.name,
+                      avatarFallbackUrl: message.user!
+                          .getAvatarUrl(AppConstants.baseUrl, size: 144),
+                    );
+                  },
+            child: SmartAvatar(
+              imageUrl:
+                  message.user?.getAvatarUrl(AppConstants.baseUrl, size: 40),
+              radius: 16,
+              fallbackText: (message.user?.username ?? '?').isNotEmpty
+                  ? message.user!.username[0]
+                  : '?',
+            ),
+          ),
+        );
+
+
+        final tappableBubble = GestureDetector(
+          onLongPress: onOpenMenu,
+          onSecondaryTap: onOpenMenu,
+          child: bubble,
+        );
+
+        // 锚点只挂在气泡本体上(不含头像上方的用户名/时间行)——否则悬浮
+        // 面板会以整行(含头顶名字行)的顶部为基准,盖住名字/时间那一行。
+        final bubbleRow = CompositedTransformTarget(
+          link: _link,
+          child: tappableBubble,
+        );
+
+        final children = <Widget>[
+          if (!isOwn) ...[
+            showHeader ? avatar : const SizedBox(width: 32),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: Column(
+              crossAxisAlignment:
+                  isOwn ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+              children: [
+                if (showHeader)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 2, left: 4, right: 4),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            message.user?.name ?? message.user?.username ?? '',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ),
+                        if (widget.userStatus != null) ...[
+                          const SizedBox(width: 4),
+                          UserStatusIcon(
+                            status: widget.userStatus,
+                            size: 13,
+                            onTap: widget.onShowStatus,
+                          ),
+                        ],
+                        Text(
+                          ' · ${TimeUtils.formatCompactTime(message.createdAt)}',
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
+                  ),
+                bubbleRow,
+                if (reactionsRow != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: reactionsRow,
+                  ),
+              ],
+            ),
+          ),
+          if (isOwn) const SizedBox(width: 8),
+        ];
+
+        // 悬浮面板浮在消息**上方**(对齐官方网页端 message-actions 的位
+        // 置)。不能用列表项内 Stack 负偏移——reverse 列表里上一行画得更
+        // 晚会盖住它;OverlayPortal 挂到应用 Overlay 层,永远在最上面。
+        return OverlayPortal(
+          controller: _portalController,
+          overlayChildBuilder: (overlayCtx) => CompositedTransformFollower(
+            link: _link,
+            showWhenUnlinked: false,
+            targetAnchor: isOwn ? Alignment.topRight : Alignment.topLeft,
+            followerAnchor: isOwn ? Alignment.bottomRight : Alignment.bottomLeft,
+            // 往下压几像素让面板和消息行有重叠,鼠标能连续移过去
+            offset: const Offset(0, 10),
+            child: Align(
+              alignment: isOwn ? Alignment.bottomRight : Alignment.bottomLeft,
+              child: MouseRegion(
+                onEnter: (_) => _updateHover(panel: true),
+                onExit: (_) => _updateHover(panel: false),
+                child: _buildHoverPanel(Theme.of(overlayCtx).colorScheme),
+              ),
+            ),
+          ),
+          child: MouseRegion(
+            onEnter: (_) => _updateHover(bubble: true),
+            onExit: (_) => _updateHover(bubble: false),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 3),
+              child: Row(
+                mainAxisAlignment:
+                    isOwn ? MainAxisAlignment.end : MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: children,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// 悬浮小面板:最近用过的 3 个快捷回应 + 全量表情 + 书签 + 回复 + 更多。
+  /// 桌面端 hover 出现;移动端没有 hover,长按气泡走完整底部菜单。
+  Widget _buildHoverPanel(ColorScheme scheme) {
+    final recentReactions = ref.watch(recentChatReactionsProvider);
+    return Material(
+      elevation: 2,
+      borderRadius: BorderRadius.circular(20),
+      color: scheme.surfaceContainerLowest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final name in recentReactions)
+              IconButton(
+                tooltip: ':$name:',
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                onPressed: () => ref
+                    .read(chatMessagesProvider(channelId).notifier)
+                    .toggleReaction(message.id, name),
+                icon: _ReactionEmoji(name: name, size: 18),
+              ),
+            IconButton(
+              tooltip: '更多表情',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: () async {
+                final emoji = await widget.pickEmoji();
+                if (emoji != null) {
+                  unawaited(ref
+                      .read(chatMessagesProvider(channelId).notifier)
+                      .toggleReaction(message.id, emoji.name));
+                }
+              },
+              icon: Icon(Icons.add_reaction_outlined,
+                  color: scheme.onSurfaceVariant),
+            ),
+            IconButton(
+              tooltip: message.bookmark != null ? '修改书签' : '书签',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: widget.onBookmark,
+              icon: Icon(
+                message.bookmark != null
+                    ? Icons.bookmark_rounded
+                    : Icons.bookmark_border_rounded,
+                color: message.bookmark != null
+                    ? scheme.primary
+                    : scheme.onSurfaceVariant,
+              ),
+            ),
+            IconButton(
+              tooltip: '回复',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: widget.onReply,
+              icon: Icon(Icons.reply_rounded, color: scheme.onSurfaceVariant),
+            ),
+            IconButton(
+              tooltip: '更多',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: onOpenMenu,
+              icon: Icon(Icons.more_vert_rounded, color: scheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 消息附带的上传文件:图片直接展示(限宽等比),其它文件画成附件卡片,
+/// 点击用系统方式打开源链接。
+class _ChatUploadView extends StatelessWidget {
+  const _ChatUploadView({required this.upload});
+
+  final ChatUpload upload;
+
+  String get _resolvedUrl {
+    final url = upload.url;
+    if (url.startsWith('//')) return 'https:$url';
+    if (url.startsWith('/')) return '${AppConstants.baseUrl}$url';
+    return url;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (upload.isImage) {
+      final width = upload.width;
+      final height = upload.height;
+      final aspect = (width != null && height != null && height > 0)
+          ? width / height
+          : null;
+      return GestureDetector(
+        onTap: () => ImageViewerPage.open(
+          context,
+          _resolvedUrl,
+          heroTag: 'chat_upload_${upload.id ?? upload.url}',
+          filenames: [upload.originalFilename],
+          // 对齐话题里点图的完整体验(分享/保存等操作)
+          enableShare: true,
+        ),
+        child: Hero(
+          tag: 'chat_upload_${upload.id ?? upload.url}',
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
+              child: aspect != null
+                  ? AspectRatio(
+                      aspectRatio: aspect,
+                      child: CachedImage(url: _resolvedUrl, fit: BoxFit.cover),
+                    )
+                  : CachedImage(url: _resolvedUrl, fit: BoxFit.contain),
+            ),
+          ),
+        ),
+      );
+    }
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => launchUrl(Uri.parse(_resolvedUrl),
+          mode: LaunchMode.externalApplication),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerLowest,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.attach_file_rounded, size: 18),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                upload.originalFilename ?? '附件',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 13),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ComposeMenuRow extends StatelessWidget {
+  const _ComposeMenuRow({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        Container(
+          width: 26,
+          height: 26,
+          decoration: BoxDecoration(
+            color: scheme.surfaceContainerHighest.withValues(alpha: 0.6),
+            borderRadius: BorderRadius.circular(6),
+          ),
+          child: Icon(icon, size: 15, color: scheme.onSurfaceVariant),
+        ),
+        const SizedBox(width: 10),
+        Text(label, style: const TextStyle(fontSize: 13)),
+      ],
+    );
+  }
+}
+
+/// AI 频道总结弹窗:时间范围下拉 + 只读摘要区,对齐官方
+/// chat-modal-channel-summary 组件(纯展示,不写回输入框)。
+class _ChatSummaryDialog extends ConsumerStatefulWidget {
+  const _ChatSummaryDialog({required this.channelId});
+
+  final int channelId;
+
+  @override
+  ConsumerState<_ChatSummaryDialog> createState() => _ChatSummaryDialogState();
+}
+
+class _ChatSummaryDialogState extends ConsumerState<_ChatSummaryDialog> {
+  static const _sinceOptions = [1, 3, 6, 12, 24, 72, 168];
+  int? _sinceHours;
+  bool _loading = false;
+  String? _error;
+  final Map<int, String> _cache = {};
+
+  Future<void> _summarize(int since) async {
+    setState(() {
+      _sinceHours = since;
+      _error = null;
+    });
+    if (_cache.containsKey(since)) return;
+    setState(() => _loading = true);
+    try {
+      final summary = await ref
+          .read(discourseServiceProvider)
+          .summarizeChatChannel(widget.channelId, since);
+      if (!mounted) return;
+      setState(() => _cache[since] = summary);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = '总结失败: $e');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  String _label(int hours) {
+    if (hours < 24) return '过去 $hours 小时';
+    return '过去 ${hours ~/ 24} 天';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final summary = _sinceHours == null ? null : _cache[_sinceHours];
+    return AlertDialog(
+      title: const Text('总结消息'),
+      content: SizedBox(
+        width: 420,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('选择要总结的时间范围', style: TextStyle(color: Colors.grey)),
+            const SizedBox(height: 8),
+            DropdownButtonFormField<int>(
+              initialValue: _sinceHours,
+              isExpanded: true,
+              decoration: const InputDecoration(
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (final h in _sinceOptions)
+                  DropdownMenuItem(value: h, child: Text(_label(h))),
+              ],
+              onChanged: (v) {
+                if (v != null) _summarize(v);
+              },
+            ),
+            const SizedBox(height: 12),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 80, maxHeight: 320),
+              child: SingleChildScrollView(
+                child: _loading
+                    ? const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 24),
+                        child: Center(child: LoadingSpinner()),
+                      )
+                    : _error != null
+                        ? Text(_error!, style: TextStyle(color: Theme.of(context).colorScheme.error))
+                        : Text(summary ?? '选择时间范围以生成总结'),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('关闭'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/chat/dm_channel_list_page.dart
+++ b/lib/pages/chat/dm_channel_list_page.dart
@@ -10,10 +10,13 @@ import '../../providers/core_providers.dart';
 import '../../providers/message_bus/chat_providers.dart';
 import '../../providers/selected_topic_provider.dart';
 import '../../utils/time_utils.dart';
+import '../../widgets/chat/group_channel_icon.dart';
 import '../../widgets/common/smart_avatar.dart';
 import '../../widgets/common/error_view.dart';
 import '../../widgets/common/user_status_icon.dart';
 import '../../widgets/desktop_refresh_indicator.dart';
+import '../../widgets/layout/auto_restore_master_detail_route.dart';
+import '../../widgets/layout/full_screen_pane_stack.dart';
 import '../../widgets/layout/master_detail_layout.dart';
 import '../../widgets/layout/pane_empty_state.dart';
 import '../../widgets/post/pm_recipient_field.dart';
@@ -36,7 +39,83 @@ class DmChannelListPage extends ConsumerStatefulWidget {
 }
 
 class _DmChannelListPageState extends ConsumerState<DmChannelListPage> {
-  Key _keyForChat(int channelId) => ValueKey('chat_$channelId');
+  // GlobalKey(不是 ValueKey!):频道详情页在"右栏独占"/"master 预览位"/
+  // "三栏布局中间列"之间来回切换时,父级插槽类型不一样(不同 slot 用
+  // ValueKey 保不住 State——具体表现是开消息串那一刻频道消息列表的
+  // ScrollController 被重建,聊天记录跳回最底下)。GlobalKey 跨树位置
+  // 迁移也能保住同一个 Element/State,滚动位置才不丢。
+  final Map<int, GlobalKey> _chatKeys = {};
+  Key _keyForChat(int channelId) =>
+      _chatKeys.putIfAbsent(channelId, () => GlobalKey());
+
+  // 折叠屏/窗口拖窄跨越双栏阈值时的"别丢界面"兜底,对齐
+  // profile_page.dart 的 `_maybeMigratePaneToFullScreen`:双栏→单栏那
+  // 一刻,如果右栏正开着内容,`selectedChatProvider` 里的栈状态本身
+  // 没丢(单栏分支只是不渲染它),但用户看到的就是一个光秃秃的列表。
+  // 用 [AutoRestoreMasterDetailRoute] + [FullScreenPaneStack] 把当前
+  // 栈顶(不管是频道/消息串还是从聊天内容里点出去的话题/资料等任意
+  // 层)当全屏页面 push 出去——provider 栈原样保留,折回双栏时
+  // AutoRestoreMasterDetailRoute 会自己把这个临时路由摘掉,不留痕迹。
+  bool _paneAutoSwitching = false;
+
+  void _maybeMigratePaneToFullScreen(SelectedTopicState selectedChat) {
+    if (_paneAutoSwitching) return;
+    if (!selectedChat.hasSelection) return;
+    if (!widget.isActive) return;
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return;
+    _paneAutoSwitching = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        _paneAutoSwitching = false;
+        return;
+      }
+      // 一帧内又变宽(折叠屏铰链抖动):provider 里的 pane 会由宽屏
+      // build 直接渲染,不用迁移。
+      if (MasterDetailLayout.canShowBothPanesFor(context)) {
+        _paneAutoSwitching = false;
+        return;
+      }
+      Navigator.of(context)
+          .push<void>(
+            MaterialPageRoute(
+              builder: (_) => AutoRestoreMasterDetailRoute(
+                child: FullScreenPaneStack(
+                  stackProvider: selectedChatProvider,
+                  builder: (_, entry, onBack) => PaneContentWidget(
+                    // 特意用普通 ValueKey,不复用 `_keyForChat`/
+                    // `_keyForThread` 的 GlobalKey——那两个还同时被宽屏
+                    // 布局的正常插槽用着,折叠屏抖动的那一帧宽屏布局和
+                    // 这个全屏临时路由可能同时挂载在树上,同一个
+                    // GlobalKey 被两处同时占用是非法状态(表现为红屏
+                    // "Multiple widgets used the same GlobalKey",严重时
+                    // 拖累原生层触发 flutter_windows.dll 内部断言崩溃)。
+                    // 全屏路由本来就是临时的,不需要跟宽屏插槽共享
+                    // Element/滚动位置。
+                    key: ValueKey(
+                      'chat_fullscreen_${entry.kind}_'
+                      '${entry.chatChannelId}_${entry.chatThreadId}_${entry.username}',
+                    ),
+                    entry: entry,
+                    stackProvider: selectedChatProvider,
+                    parentActive: true,
+                    onBack: onBack,
+                  ),
+                ),
+              ),
+            ),
+          )
+          .whenComplete(() {
+            if (mounted) _paneAutoSwitching = false;
+          });
+    });
+  }
+
+  // 同理:消息串面板也可能在"三栏布局第三列"和"退化成两栏时的独占右栏"
+  // 之间切换插槽,同一个 GlobalKey 处理。
+  final Map<int, GlobalKey> _threadKeys = {};
+  Key _keyForThread(int threadId) =>
+      _threadKeys.putIfAbsent(threadId, () => GlobalKey());
 
   /// 平行视界压栈时:左侧显示栈里"上一层"内容,右侧显示新顶替的内容。
   Widget _buildMasterPane(SelectedTopicState selectedChat, Widget list) {
@@ -48,7 +127,9 @@ class _DmChannelListPageState extends ConsumerState<DmChannelListPage> {
         PaneContentWidget(
           key: previous.kind == PaneKind.chat
               ? _keyForChat(previous.chatChannelId!)
-              : ValueKey('master_${previous.kind}_${previous.username}'),
+              : previous.kind == PaneKind.chatThread
+                  ? _keyForThread(previous.chatThreadId!)
+                  : ValueKey('master_${previous.kind}_${previous.username}'),
           entry: previous,
           stackProvider: selectedChatProvider,
           truncateOnPush: true,
@@ -77,7 +158,7 @@ class _DmChannelListPageState extends ConsumerState<DmChannelListPage> {
           : channel.participants.firstOrNull;
       final title = channel.isGroup
           ? (channel.title ?? '群聊')
-          : (other?.name ?? other?.username);
+          : other?.displayName;
       _openChannel(channel.id, title);
     } catch (e) {
       if (!mounted) return;
@@ -228,23 +309,81 @@ class _DmChannelListPageState extends ConsumerState<DmChannelListPage> {
 
     final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
     final selectedChat = ref.watch(selectedChatProvider);
-    if (!canShowDetailPane) return listScaffold;
+    if (!canShowDetailPane) {
+      _maybeMigratePaneToFullScreen(selectedChat);
+      return listScaffold;
+    }
+
+    // 消息串挂在自己所属的频道正上方(栈顶是串,栈顶下面正好是它所属的
+    // 频道)时,走真三栏:频道列表 | 频道正文(保持挂载,不走 master 预览
+    // 位那套 Offstage/切换插槽逻辑)| 消息串。用户要的是"频道右边已经
+    // 有东西(串)时,串在当前平行视界内部再开一层",而不是顶掉频道——
+    // 跟其它 kind(话题/资料等)压栈会顶替右栏的语义不一样,单独开分支。
+    final stack = selectedChat.stack;
+    final topEntry = selectedChat.topEntry;
+    final ownThreadOnTop = stack.length >= 2 &&
+        topEntry != null &&
+        topEntry.kind == PaneKind.chatThread &&
+        stack[stack.length - 2].kind == PaneKind.chat &&
+        stack[stack.length - 2].chatChannelId == topEntry.chatChannelId;
+
+    if (ownThreadOnTop) {
+      final channelEntry = stack[stack.length - 2];
+      return EmbeddedStackScope(
+        stackProvider: selectedChatProvider,
+        child: Row(
+          children: [
+            SizedBox(
+              width: 340,
+              child: listScaffold,
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(
+              child: PaneContentWidget(
+                key: _keyForChat(channelEntry.chatChannelId!),
+                entry: channelEntry,
+                stackProvider: selectedChatProvider,
+                parentActive: widget.isActive,
+                truncateOnPush: true,
+                onBack: () => ref.read(selectedChatProvider.notifier).pop(),
+              ),
+            ),
+            const VerticalDivider(width: 1),
+            SizedBox(
+              width: 380,
+              child: PaneContentWidget(
+                key: _keyForThread(topEntry.chatThreadId!),
+                entry: topEntry,
+                stackProvider: selectedChatProvider,
+                parentActive: widget.isActive,
+                onBack: () => ref.read(selectedChatProvider.notifier).pop(),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     // 单层(左列表右聊天)时列表窄一点好看;一旦压栈(左边变成话题等
     // 正文内容)就回到 1:1——不然从私聊里点话题、再点新话题后,左栏的
     // 话题被挤成私聊列表那么窄。
-    final masterRatio = selectedChat.isStacked ? 0.5 : 0.32;
+    final masterRatio = selectedChat.isStacked ? 0.551 : 0.288;
 
     return EmbeddedStackScope(
       stackProvider: selectedChatProvider,
       child: MasterDetailLayout(
         preferredMasterRatio: masterRatio,
+        // 默认 maxMasterRatio 是 0.3——不放宽的话 preferredMasterRatio 传
+        // 再大也会在 _clampMasterWidth 里被摁回 0.3,之前调宽度全是白改。
+        maxMasterRatio: 0.6,
         master: _buildMasterPane(selectedChat, listScaffold),
         detail: selectedChat.hasSelection
             ? PaneContentWidget(
                 key: selectedChat.kind == PaneKind.chat
                     ? _keyForChat(selectedChat.topEntry!.chatChannelId!)
-                    : ValueKey('${selectedChat.kind}_${selectedChat.username}'),
+                    : selectedChat.kind == PaneKind.chatThread
+                        ? _keyForThread(selectedChat.topEntry!.chatThreadId!)
+                        : ValueKey('${selectedChat.kind}_${selectedChat.username}'),
                 entry: selectedChat.topEntry!,
                 stackProvider: selectedChatProvider,
                 parentActive: widget.isActive,
@@ -325,15 +464,22 @@ class _DmChannelTile extends StatelessWidget {
         : channel.participants.firstOrNull;
     final displayName = channel.isGroup
         ? (channel.title ?? '群聊')
-        : (other?.name ?? other?.username ?? channel.title ?? '未知用户');
+        : (other?.displayName ?? channel.title ?? '未知用户');
     final unread = channel.membership.unreadCount;
 
     return ListTile(
-      leading: SmartAvatar(
-        imageUrl: other?.getAvatarUrl(AppConstants.baseUrl, size: 48),
-        radius: 22,
-        fallbackText: displayName.isNotEmpty ? displayName[0] : '?',
-      ),
+      leading: channel.isGroup && (channel.emoji?.isNotEmpty ?? false)
+          ? GroupChannelIcon(emoji: channel.emoji!, radius: 22)
+          : Consumer(
+              builder: (context, ref, _) => SmartAvatar(
+                imageUrl: other?.getAvatarUrl(AppConstants.baseUrl, size: 48),
+                radius: 22,
+                fallbackText: displayName.isNotEmpty ? displayName[0] : '?',
+                isOnline: other?.id != null &&
+                    (ref.watch(chatOnlinePresenceProvider).value ?? const {})
+                        .contains(other!.id),
+              ),
+            ),
       title: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/pages/chat/dm_channel_list_page.dart
+++ b/lib/pages/chat/dm_channel_list_page.dart
@@ -1,0 +1,558 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:m3e_ui/m3e_ui.dart';
+
+import '../../constants.dart';
+import '../../models/chat/chat_channel.dart';
+import '../../providers/core_providers.dart';
+import '../../providers/message_bus/chat_providers.dart';
+import '../../providers/selected_topic_provider.dart';
+import '../../utils/time_utils.dart';
+import '../../widgets/common/smart_avatar.dart';
+import '../../widgets/common/error_view.dart';
+import '../../widgets/common/user_status_icon.dart';
+import '../../widgets/desktop_refresh_indicator.dart';
+import '../../widgets/layout/master_detail_layout.dart';
+import '../../widgets/layout/pane_empty_state.dart';
+import '../../widgets/post/pm_recipient_field.dart';
+import '../topics_screen.dart' show PaneContentWidget;
+import 'chat_search_dialog.dart';
+import 'dm_channel_detail_page.dart';
+
+/// Chat 插件 DM 频道列表页,与"私信"入口平级。
+///
+/// 平行视界:宽屏双栏下跟私信列表一样,走独立的 [selectedChatProvider]
+/// 导航栈,不再单独弹全屏详情页(对齐 `private_messages_page.dart` 的
+/// 做法);窄屏保持原来的 `Navigator.push` 全屏详情页。
+class DmChannelListPage extends ConsumerStatefulWidget {
+  const DmChannelListPage({super.key, this.isActive = true});
+
+  final bool isActive;
+
+  @override
+  ConsumerState<DmChannelListPage> createState() => _DmChannelListPageState();
+}
+
+class _DmChannelListPageState extends ConsumerState<DmChannelListPage> {
+  Key _keyForChat(int channelId) => ValueKey('chat_$channelId');
+
+  /// 平行视界压栈时:左侧显示栈里"上一层"内容,右侧显示新顶替的内容。
+  Widget _buildMasterPane(SelectedTopicState selectedChat, Widget list) {
+    if (!selectedChat.isStacked) return list;
+    final previous = selectedChat.stack[selectedChat.stack.length - 2];
+    return Stack(
+      children: [
+        Offstage(offstage: true, child: list),
+        PaneContentWidget(
+          key: previous.kind == PaneKind.chat
+              ? _keyForChat(previous.chatChannelId!)
+              : ValueKey('master_${previous.kind}_${previous.username}'),
+          entry: previous,
+          stackProvider: selectedChatProvider,
+          truncateOnPush: true,
+          parentActive: widget.isActive,
+        ),
+      ],
+    );
+  }
+
+  /// 新建聊天:目前只能从某个用户的资料卡"聊天"按钮发起,对方没在可见
+  /// 处发过言就完全没有路径。对齐私信列表页 FAB 的入口设计。
+  Future<void> _composeNewChat() async {
+    final recipients = await showDialog<List<String>>(
+      context: context,
+      builder: (ctx) => const _NewChatDialog(),
+    );
+    if (recipients == null || recipients.isEmpty || !mounted) return;
+    try {
+      final service = ref.read(discourseServiceProvider);
+      final channel = await service.createOrGetDirectMessageChannel(recipients);
+      if (!mounted) return;
+      ref.read(chatChannelListProvider.notifier).refresh();
+      final currentUsername = ref.read(currentUserProvider).value?.username;
+      final other = currentUsername != null
+          ? channel.otherParticipant(currentUsername)
+          : channel.participants.firstOrNull;
+      final title = channel.isGroup
+          ? (channel.title ?? '群聊')
+          : (other?.name ?? other?.username);
+      _openChannel(channel.id, title);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('创建聊天失败: $e')),
+      );
+    }
+  }
+
+  /// 全局搜索聊天消息(官方 `GET /chat/api/search`,含公共频道和私聊),
+  /// 点结果直接进对应频道。
+  Future<void> _searchChats() async {
+    final picked = await showChatSearchDialog(context);
+    if (picked == null || !mounted) return;
+    _openChannel(picked.channelId, picked.channelTitle);
+  }
+
+  /// 浏览可加入的公共频道:关键词搜索 + 一键加入,加入后整表刷新。
+  Future<void> _browsePublicChannels() async {
+    final joined = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => const _BrowseChannelsDialog(),
+    );
+    if (joined == true && mounted) {
+      unawaited(ref.read(chatChannelListProvider.notifier).refresh());
+    }
+  }
+
+  /// 点列表里的一项(切换到另一个频道):跟私信列表页 `_onItemTap` 同一套
+  /// 语义——**替换**当前显示的内容,不是压栈。压栈是"从正文内容里跳转"
+  /// 才该有的行为(比如聊天气泡里点头像跳资料);在列表本身点另一项,
+  /// 用户心智是"看列表里的另一条",每点一次都多叠一层平行视界的话,
+  /// 栈会无限增长,`_buildMasterPane` 只处理得了一层"上一层"缓存,
+  /// 栈深超过 2 之后右栏该显示哪层就会错乱。
+  void _openChannel(int channelId, String? title) {
+    final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
+    if (canShowDetailPane) {
+      ref.read(selectedChatProvider.notifier).selectChat(channelId, title: title);
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DmChannelDetailPage(channelId: channelId, title: title),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 激活全局未读追踪订阅(离开此页仍由导航徽标那侧的 watch 保活)
+    ref.watch(chatTrackingChannelProvider);
+    final channelsAsync = ref.watch(chatChannelListProvider);
+    final currentUsername = ref.watch(
+      currentUserProvider.select((s) => s.value?.username),
+    );
+
+    final listScaffold = DefaultTabController(
+      length: 2,
+      // 有私聊在聊、公共频道多数人没加入:默认落在"直接消息"标签
+      initialIndex: 1,
+      child: Scaffold(
+      appBar: AppBar(
+        title: const Text('聊天'),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            tooltip: '搜索聊天',
+            icon: const Icon(Icons.search_rounded),
+            onPressed: _searchChats,
+          ),
+          IconButton(
+            tooltip: '浏览公共频道',
+            icon: const Icon(Icons.explore_outlined),
+            onPressed: _browsePublicChannels,
+          ),
+        ],
+        // 顶栏 Tab 切换公共频道 / 直接消息(对齐官方网页端的两个分组)
+        bottom: const TabBar(
+          tabs: [
+            Tab(text: '频道'),
+            Tab(text: '直接消息'),
+          ],
+        ),
+      ),
+      body: channelsAsync.when(
+        data: (channels) {
+          // 各组内收藏的置顶,组内保持原有(最近消息时间倒序)顺序不变——
+          // List.sort 不保证稳定,手动分组拼接才能保住组内原序。
+          List<ChatChannel> starredFirst(Iterable<ChatChannel> group) => [
+                ...group.where((c) => c.membership.starred),
+                ...group.where((c) => !c.membership.starred),
+              ];
+          final publicChannels =
+              starredFirst(channels.where((c) => !c.isDirectMessage));
+          final dmChannels =
+              starredFirst(channels.where((c) => c.isDirectMessage));
+
+          Widget channelList(List<ChatChannel> group, String emptyHint) {
+            if (group.isEmpty) {
+              return Center(
+                child: Text(emptyHint, style: const TextStyle(color: Colors.grey)),
+              );
+            }
+            return DesktopRefreshIndicator(
+              onRefresh: () =>
+                  ref.read(chatChannelListProvider.notifier).refresh(),
+              child: ListView.builder(
+                padding: const EdgeInsets.fromLTRB(12, 8, 12, 88),
+                itemCount: group.length,
+                itemBuilder: (context, index) => Padding(
+                  padding: const EdgeInsets.only(bottom: 3),
+                  child: SegmentedCardItem(
+                    index: index,
+                    count: group.length,
+                    child: _DmChannelTile(
+                      channel: group[index],
+                      currentUsername: currentUsername,
+                      onTap: _openChannel,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return TabBarView(
+            children: [
+              channelList(publicChannels, '还没加入任何公共频道\n点右上角的指南针浏览并加入'),
+              channelList(dmChannels, '暂无私聊消息'),
+            ],
+          );
+        },
+        loading: () => const Center(child: LoadingSpinner()),
+        error: (error, stack) => ErrorView(
+          error: error,
+          stackTrace: stack,
+          onRetry: () => ref.read(chatChannelListProvider.notifier).refresh(),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'composeChat',
+        onPressed: _composeNewChat,
+        tooltip: '新建聊天',
+        child: const Icon(Icons.edit_rounded),
+      ),
+      ),
+    );
+
+    final canShowDetailPane = MasterDetailLayout.canShowBothPanesFor(context);
+    final selectedChat = ref.watch(selectedChatProvider);
+    if (!canShowDetailPane) return listScaffold;
+
+    // 单层(左列表右聊天)时列表窄一点好看;一旦压栈(左边变成话题等
+    // 正文内容)就回到 1:1——不然从私聊里点话题、再点新话题后,左栏的
+    // 话题被挤成私聊列表那么窄。
+    final masterRatio = selectedChat.isStacked ? 0.5 : 0.32;
+
+    return EmbeddedStackScope(
+      stackProvider: selectedChatProvider,
+      child: MasterDetailLayout(
+        preferredMasterRatio: masterRatio,
+        master: _buildMasterPane(selectedChat, listScaffold),
+        detail: selectedChat.hasSelection
+            ? PaneContentWidget(
+                key: selectedChat.kind == PaneKind.chat
+                    ? _keyForChat(selectedChat.topEntry!.chatChannelId!)
+                    : ValueKey('${selectedChat.kind}_${selectedChat.username}'),
+                entry: selectedChat.topEntry!,
+                stackProvider: selectedChatProvider,
+                parentActive: widget.isActive,
+                // onBack 也是 Esc 的落点,单层时给 null 等于第一层按 Esc
+                // 没反应——单层就关掉右栏(同 private_messages_page.dart)。
+                onBack: () {
+                  final notifier = ref.read(selectedChatProvider.notifier);
+                  selectedChat.isStacked ? notifier.pop() : notifier.clear();
+                },
+              )
+            : null,
+        emptyDetail: const PaneEmptyState(
+          icon: Icons.chat_bubble_outline_rounded,
+          hint: '选择一个聊天查看消息',
+        ),
+      ),
+    );
+  }
+}
+
+class _DmChannelTile extends StatelessWidget {
+  const _DmChannelTile({
+    required this.channel,
+    this.currentUsername,
+    required this.onTap,
+  });
+
+  final ChatChannel channel;
+  final String? currentUsername;
+  final void Function(int channelId, String? title) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    // 公共频道没有"对方"概念:标题用频道名,头像画个 # 图标
+    if (!channel.isDirectMessage) {
+      final name = channel.title ?? channel.slug ?? '频道';
+      final unread = channel.membership.unreadCount;
+      return ListTile(
+        leading: CircleAvatar(
+          radius: 22,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+          child: Icon(Icons.tag_rounded,
+              color: Theme.of(context).colorScheme.onSurfaceVariant),
+        ),
+        title: Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            fontWeight: unread > 0 ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+        subtitle: Text(
+          channel.lastMessage?.message ?? channel.description ?? '',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              TimeUtils.formatCompactTime(channel.lastMessage?.createdAt),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (unread > 0) ...[
+              const SizedBox(height: 4),
+              Badge(label: Text(unread > 99 ? '99+' : '$unread')),
+            ],
+          ],
+        ),
+        onTap: () => onTap(channel.id, name),
+      );
+    }
+
+    final other = currentUsername != null
+        ? channel.otherParticipant(currentUsername!)
+        : channel.participants.firstOrNull;
+    final displayName = channel.isGroup
+        ? (channel.title ?? '群聊')
+        : (other?.name ?? other?.username ?? channel.title ?? '未知用户');
+    final unread = channel.membership.unreadCount;
+
+    return ListTile(
+      leading: SmartAvatar(
+        imageUrl: other?.getAvatarUrl(AppConstants.baseUrl, size: 48),
+        radius: 22,
+        fallbackText: displayName.isNotEmpty ? displayName[0] : '?',
+      ),
+      title: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              displayName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontWeight: unread > 0 ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+          ),
+          if (other?.status != null) ...[
+            const SizedBox(width: 5),
+            // 列表行的状态只展示不可点(手机上点到状态会点不进私聊)
+            UserStatusIcon(status: other!.status, size: 14),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        channel.lastMessage?.message ?? '',
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            TimeUtils.formatCompactTime(channel.lastMessage?.createdAt),
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          if (unread > 0) ...[
+            const SizedBox(height: 4),
+            Badge(label: Text(unread > 99 ? '99+' : '$unread')),
+          ],
+        ],
+      ),
+      onTap: () => onTap(channel.id, displayName),
+    );
+  }
+}
+
+/// 浏览公共频道弹窗:关键词搜索 + 加入。已加入(following)的显示"已加入"。
+/// 关闭时若加入过任意频道,pop(true) 让列表页整表刷新。
+class _BrowseChannelsDialog extends ConsumerStatefulWidget {
+  const _BrowseChannelsDialog();
+
+  @override
+  ConsumerState<_BrowseChannelsDialog> createState() => _BrowseChannelsDialogState();
+}
+
+class _BrowseChannelsDialogState extends ConsumerState<_BrowseChannelsDialog> {
+  final TextEditingController _searchController = TextEditingController();
+  Timer? _debounce;
+  Future<List<ChatChannel>>? _future;
+  final Set<int> _joined = {};
+  bool _joinedAny = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = _load();
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<List<ChatChannel>> _load() {
+    final service = ref.read(discourseServiceProvider);
+    return service.browsePublicChatChannels(filter: _searchController.text.trim());
+  }
+
+  void _onSearchChanged(String _) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), () {
+      if (mounted) setState(() => _future = _load());
+    });
+  }
+
+  Future<void> _join(ChatChannel channel) async {
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.joinChatChannel(channel.id);
+      if (!mounted) return;
+      setState(() {
+        _joined.add(channel.id);
+        _joinedAny = true;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('加入频道失败: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('浏览公共频道'),
+      content: SizedBox(
+        width: 420,
+        height: 420,
+        child: Column(
+          children: [
+            TextField(
+              controller: _searchController,
+              autofocus: true,
+              onChanged: _onSearchChanged,
+              decoration: const InputDecoration(
+                hintText: '搜索频道…',
+                prefixIcon: Icon(Icons.search_rounded),
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: FutureBuilder<List<ChatChannel>>(
+                future: _future,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const Center(child: LoadingSpinner());
+                  }
+                  if (snapshot.hasError) {
+                    return Center(child: Text('加载失败: ${snapshot.error}'));
+                  }
+                  final channels = snapshot.data ?? const [];
+                  if (channels.isEmpty) {
+                    return const Center(
+                      child: Text('没有找到频道', style: TextStyle(color: Colors.grey)),
+                    );
+                  }
+                  return ListView.builder(
+                    itemCount: channels.length,
+                    itemBuilder: (context, index) {
+                      final channel = channels[index];
+                      final following =
+                          channel.membership.following || _joined.contains(channel.id);
+                      return ListTile(
+                        leading: const Icon(Icons.tag_rounded),
+                        title: Text(
+                          channel.title ?? channel.slug ?? '',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        subtitle: (channel.description ?? '').isEmpty
+                            ? null
+                            : Text(
+                                channel.description!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                        trailing: following
+                            ? const Text('已加入', style: TextStyle(color: Colors.grey))
+                            : FilledButton.tonal(
+                                onPressed: () => _join(channel),
+                                child: const Text('加入'),
+                              ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(_joinedAny),
+          child: const Text('关闭'),
+        ),
+      ],
+    );
+  }
+}
+
+/// 新建聊天弹窗:复用私信收件人选择器(用户名搜索 + chip)。
+class _NewChatDialog extends StatefulWidget {
+  const _NewChatDialog();
+
+  @override
+  State<_NewChatDialog> createState() => _NewChatDialogState();
+}
+
+class _NewChatDialogState extends State<_NewChatDialog> {
+  List<String> _recipients = const [];
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('新建聊天'),
+      content: SizedBox(
+        width: 360,
+        child: PmRecipientField(
+          recipients: _recipients,
+          onChanged: (value) => setState(() => _recipients = value),
+          autofocus: true,
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('取消'),
+        ),
+        FilledButton(
+          onPressed: _recipients.isEmpty
+              ? null
+              : () => Navigator.of(context).pop(_recipients),
+          child: const Text('开始聊天'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/chat/dm_thread_page.dart
+++ b/lib/pages/chat/dm_thread_page.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:m3e_ui/m3e_ui.dart';
+
+import '../../constants.dart';
+import '../../models/chat/chat_message.dart';
+import '../../providers/core_providers.dart';
+import '../../providers/message_bus/chat_providers.dart';
+import '../../utils/fluxdo_render_callbacks.dart';
+import '../../utils/time_utils.dart';
+import '../../widgets/common/error_view.dart';
+import '../../widgets/common/smart_avatar.dart';
+
+/// 消息串(thread)页:某条消息下的独立对话流 + 回复框。
+/// 结构比主频道简化:不带回应/菜单等重操作,专注"在串里聊"。
+class DmThreadPage extends ConsumerStatefulWidget {
+  const DmThreadPage({
+    super.key,
+    required this.channelId,
+    required this.threadId,
+    this.title,
+  });
+
+  final int channelId;
+  final int threadId;
+  final String? title;
+
+  @override
+  ConsumerState<DmThreadPage> createState() => _DmThreadPageState();
+}
+
+class _DmThreadPageState extends ConsumerState<DmThreadPage> {
+  final TextEditingController _inputController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final FocusNode _inputFocusNode = FocusNode();
+  bool _sending = false;
+
+  (int, int) get _arg => (widget.channelId, widget.threadId);
+
+  @override
+  void dispose() {
+    _inputController.dispose();
+    _scrollController.dispose();
+    _inputFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _send() async {
+    final text = _inputController.text.trim();
+    if (text.isEmpty || _sending) return;
+    setState(() => _sending = true);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.sendChatMessage(
+        widget.channelId,
+        text,
+        threadId: widget.threadId,
+      );
+      _inputController.clear();
+      ref.invalidate(chatThreadMessagesProvider(_arg));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('发送失败: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _sending = false);
+        _inputFocusNode.requestFocus();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final messagesAsync = ref.watch(chatThreadMessagesProvider(_arg));
+    final currentUsername = ref.watch(
+      currentUserProvider.select((s) => s.value?.username),
+    );
+    final scheme = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+        surfaceTintColor: Colors.transparent,
+        scrolledUnderElevation: 0,
+        elevation: 0,
+        title: Text(widget.title ?? '消息串'),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: messagesAsync.when(
+              data: (messages) {
+                if (messages.isEmpty) {
+                  return const Center(
+                    child: Text('还没有回复', style: TextStyle(color: Colors.grey)),
+                  );
+                }
+                return ListView.builder(
+                  controller: _scrollController,
+                  reverse: true,
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  itemCount: messages.length,
+                  itemBuilder: (context, index) {
+                    final message = messages[messages.length - 1 - index];
+                    final isOwn = currentUsername != null &&
+                        message.user?.username == currentUsername;
+                    return _ThreadMessageTile(
+                      message: message,
+                      isOwn: isOwn,
+                      scheme: scheme,
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(child: LoadingSpinner()),
+              error: (error, stack) => ErrorView(
+                error: error,
+                stackTrace: stack,
+                onRetry: () =>
+                    ref.invalidate(chatThreadMessagesProvider(_arg)),
+              ),
+            ),
+          ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _inputController,
+                      focusNode: _inputFocusNode,
+                      minLines: 1,
+                      maxLines: 5,
+                      textInputAction: TextInputAction.send,
+                      onSubmitted: (_) => _send(),
+                      decoration: InputDecoration(
+                        hintText: '回复消息串',
+                        filled: true,
+                        fillColor: scheme.surfaceContainerHigh,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(24),
+                          borderSide: BorderSide.none,
+                        ),
+                        isDense: true,
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 10),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  IconButton.filled(
+                    tooltip: '发送',
+                    onPressed: _sending ? null : _send,
+                    icon: _sending
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: LoadingSpinner(size: 18),
+                          )
+                        : const Icon(Icons.send_rounded),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 线程内的简化消息行:头像 + 名字/时间 + 正文。
+class _ThreadMessageTile extends StatelessWidget {
+  const _ThreadMessageTile({
+    required this.message,
+    required this.isOwn,
+    required this.scheme,
+  });
+
+  final ChatMessage message;
+  final bool isOwn;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final callbacks = FluxdoRenderCallbacks.generic(
+      heroTagNamespace: 'chat_thread_msg_${message.id}',
+    );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SmartAvatar(
+            imageUrl: message.user?.getAvatarUrl(AppConstants.baseUrl, size: 40),
+            radius: 16,
+            fallbackText: (message.user?.username ?? '?').isNotEmpty
+                ? message.user!.username[0]
+                : '?',
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '${message.user?.name ?? message.user?.username ?? ''} · '
+                  '${TimeUtils.formatCompactTime(message.createdAt)}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 2),
+                message.isDeleted
+                    ? const Text('(消息已删除)',
+                        style: TextStyle(color: Colors.grey))
+                    : (message.cooked?.isNotEmpty ?? false)
+                        ? callbacks.render(
+                            cookedHtml: message.cooked!, compact: true)
+                        : Text(message.message ?? ''),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/chat/dm_thread_page.dart
+++ b/lib/pages/chat/dm_thread_page.dart
@@ -1,29 +1,101 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:fluxdo_render/editor.dart'
+    show
+        observeModifierKeyEvent,
+        primaryModifierHeldForReversibleAction,
+        shiftModifierHeld;
+import 'package:fluxdo_render/fluxdo_render.dart' show LocalDateRun;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3e_ui/m3e_ui.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:super_clipboard/super_clipboard.dart';
 
 import '../../constants.dart';
 import '../../models/chat/chat_message.dart';
+import '../../models/emoji.dart';
+import '../../models/mention_user.dart';
 import '../../providers/core_providers.dart';
 import '../../providers/message_bus/chat_providers.dart';
+import '../../services/toast_service.dart';
+import '../../utils/clipboard_image_native.dart';
 import '../../utils/fluxdo_render_callbacks.dart';
 import '../../utils/time_utils.dart';
+import '../../widgets/bookmark/bookmark_edit_sheet_launcher.dart';
+import '../../widgets/chat/chat_upload_view.dart';
+import '../../widgets/chat/overlay_anchor.dart';
+import '../../widgets/chat/reaction_chip.dart';
+import '../../widgets/common/cached_image.dart';
 import '../../widgets/common/error_view.dart';
 import '../../widgets/common/smart_avatar.dart';
+import '../../widgets/common/user_status_icon.dart';
+import '../../widgets/user/user_card.dart';
+import '../../widgets/markdown_editor/emoji_sticker_panel.dart';
+import '../../widgets/markdown_editor/markdown_toolbar.dart'
+    show MarkdownToolbarState;
+import '../../widgets/markdown_editor/rich_composer/local_date_edit_dialog.dart';
+import '../../widgets/markdown_editor/template_insert_dialog.dart';
+import '../../widgets/post/post_item/widgets/post_flag_sheet.dart';
+import '../image_viewer_page.dart';
+import 'dm_channel_detail_page.dart';
 
-/// 消息串(thread)页:某条消息下的独立对话流 + 回复框。
-/// 结构比主频道简化:不带回应/菜单等重操作,专注"在串里聊"。
+/// 表情包走"伪上传":不占用真实 upload_ids,发送时直接把它的 markdown
+/// 拼进正文,沿用旧 CDN 链接,不产生新 upload 记录(见
+/// dm_channel_detail_page.dart 同名类的详细注释)。
+class _PendingUpload {
+  const _PendingUpload({
+    this.id,
+    required this.name,
+    this.localPath,
+    this.stickerMarkdown,
+    this.stickerPreviewUrl,
+  });
+  final int? id;
+  final String name;
+  final String? localPath;
+  final String? stickerMarkdown;
+  final String? stickerPreviewUrl;
+
+  bool get isSticker => stickerMarkdown != null;
+
+  bool get isImage =>
+      isSticker ||
+      const {
+        '.png',
+        '.jpg',
+        '.jpeg',
+        '.gif',
+        '.webp',
+        '.bmp',
+      }.contains(p.extension(name).toLowerCase());
+}
+
+/// 消息串(thread)页:某条消息下的独立对话流 + 回复框。图片/文件发送
+/// 跟频道主体([DmChannelDetailPage])同一套:选文件先上传拿 id 挂进
+/// 待发区,点发送时随文字一起 uploadIds 带出去。
 class DmThreadPage extends ConsumerStatefulWidget {
   const DmThreadPage({
     super.key,
     required this.channelId,
     required this.threadId,
     this.title,
+    this.embeddedMode = false,
+    this.onEmbeddedBack,
   });
 
   final int channelId;
   final int threadId;
   final String? title;
+
+  /// 嵌入平行视界右栏时为 true:不显示系统返回键,返回走 [onEmbeddedBack]。
+  final bool embeddedMode;
+  final VoidCallback? onEmbeddedBack;
 
   @override
   ConsumerState<DmThreadPage> createState() => _DmThreadPageState();
@@ -34,6 +106,10 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
   final ScrollController _scrollController = ScrollController();
   final FocusNode _inputFocusNode = FocusNode();
   bool _sending = false;
+  bool _uploading = false;
+  final List<_PendingUpload> _pendingUploads = [];
+  ChatMessage? _replyTo;
+  ChatMessage? _editing;
 
   (int, int) get _arg => (widget.channelId, widget.threadId);
 
@@ -45,25 +121,651 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
     super.dispose();
   }
 
+  void _startReply(ChatMessage message) {
+    setState(() {
+      _editing = null;
+      _replyTo = message;
+    });
+    _inputFocusNode.requestFocus();
+  }
+
+  void _startEdit(ChatMessage message) {
+    setState(() {
+      _replyTo = null;
+      _editing = message;
+      _pendingUploads.clear();
+    });
+    _inputController.text = message.message ?? '';
+    _inputController.selection =
+        TextSelection.collapsed(offset: _inputController.text.length);
+    _inputFocusNode.requestFocus();
+  }
+
+  void _cancelComposeExtras() {
+    setState(() {
+      _replyTo = null;
+      if (_editing != null) {
+        _editing = null;
+        _inputController.clear();
+      }
+    });
+  }
+
+  /// 点状态图标时弹出完整状态内容(悬浮 Tooltip 之外的触屏可达路径)。
+  void _showUserStatus(MentionUser user) {
+    final status = user.status;
+    if (status == null) return;
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(user.displayName),
+        content: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            UserStatusIcon(status: status, size: 22),
+            const SizedBox(width: 8),
+            Flexible(child: Text(status.description ?? '')),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('关闭'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _bookmarkMessage(ChatMessage message) async {
+    final notifier = ref.read(chatThreadMessagesProvider(_arg).notifier);
+    final existing = message.bookmark;
+    int bookmarkId;
+    try {
+      if (existing == null) {
+        final service = ref.read(discourseServiceProvider);
+        bookmarkId = await service.bookmarkChatMessage(message.id);
+        notifier.applyBookmark(message.id, ChatBookmark(id: bookmarkId));
+        ToastService.showSuccess('已加入书签');
+      } else {
+        bookmarkId = existing.id;
+      }
+    } on DioException catch (e) {
+      final errors = (e.response?.data is Map)
+          ? ((e.response!.data as Map)['errors'] as List?)
+          : null;
+      ToastService.showError(errors?.firstOrNull?.toString() ?? '加书签失败');
+      return;
+    } catch (e) {
+      ToastService.showError('加书签失败: $e');
+      return;
+    }
+    if (!mounted) return;
+
+    final result = await showBookmarkEditSheetWithCachedNames(
+      context,
+      ref,
+      bookmarkId: bookmarkId,
+      initialName: existing?.name,
+      initialReminderAt: existing?.reminderAt,
+      source: 'chat_message_bookmark',
+    );
+    if (result == null || !mounted) return;
+    if (result.deleted) {
+      notifier.applyBookmark(message.id, null);
+    } else {
+      notifier.applyBookmark(
+        message.id,
+        ChatBookmark(
+          id: bookmarkId,
+          name: result.name,
+          reminderAt: result.reminderAt,
+        ),
+      );
+    }
+  }
+
+  /// 举报:复用全应用同一套举报组件,和主私聊/话题同源同 UI。
+  Future<void> _showFlagDialog(ChatMessage message) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      enableDrag: false,
+      builder: (ctx) => PostFlagSheet(
+        postId: message.id,
+        postUsername: message.user?.username ?? '',
+        service: ref.read(discourseServiceProvider),
+        chatChannelId: widget.channelId,
+        chatMessageId: message.id,
+        onSuccess: () {
+          if (mounted) ToastService.showSuccess('已提交举报');
+        },
+      ),
+    );
+  }
+
+  Future<void> _uploadPathAsAttachment(String path) async {
+    final service = ref.read(discourseServiceProvider);
+    final result = await service.uploadFile(path);
+    final uploadId = result.id;
+    if (uploadId == null) throw Exception('上传成功但未返回附件 id');
+    if (!mounted) return;
+    setState(() {
+      _pendingUploads.add(
+        _PendingUpload(id: uploadId, name: p.basename(path), localPath: path),
+      );
+    });
+  }
+
+  Future<void> _uploadBytesAsAttachment(Uint8List bytes, String ext) async {
+    if (_uploading) return;
+    setState(() => _uploading = true);
+    try {
+      final tempDir = await getTemporaryDirectory();
+      final fileName = 'paste_${DateTime.now().millisecondsSinceEpoch}.$ext';
+      final tempFile = File(p.join(tempDir.path, fileName));
+      await tempFile.writeAsBytes(bytes);
+      await _uploadPathAsAttachment(tempFile.path);
+    } catch (e) {
+      if (mounted) ToastService.showError('上传图片失败: $e');
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  static const _pastedImageExtensions = {
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.webp',
+    '.bmp',
+    '.avif',
+  };
+
+  KeyEventResult _handlePasteKey(FocusNode node, KeyEvent event) {
+    observeModifierKeyEvent(event);
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+
+    final isEnter =
+        event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter;
+    if (isEnter && !HardwareKeyboard.instance.isShiftPressed) {
+      _send();
+      return KeyEventResult.handled;
+    }
+
+    final isPasteCombo =
+        event.logicalKey == LogicalKeyboardKey.keyV &&
+        !shiftModifierHeld() &&
+        !HardwareKeyboard.instance.isAltPressed &&
+        primaryModifierHeldForReversibleAction(event);
+    if (!isPasteCombo) return KeyEventResult.ignored;
+
+    unawaited(_maybePasteImage());
+    return KeyEventResult.ignored;
+  }
+
+  Future<void> _maybePasteImage() async {
+    final clipboard = SystemClipboard.instance;
+    if (clipboard == null) return;
+    final reader = await clipboard.read();
+    final img = await MarkdownToolbarState.readImageFromReader(reader);
+    if (img != null) {
+      unawaited(_uploadBytesAsAttachment(img.$1, img.$2));
+      return;
+    }
+    final native = readClipboardImageNative();
+    if (native != null) {
+      unawaited(_uploadBytesAsAttachment(native, 'png'));
+      return;
+    }
+    for (final item in reader.items) {
+      if (!item.canProvide(Formats.fileUri)) continue;
+      final uri = await item.readValue(Formats.fileUri);
+      if (uri == null) continue;
+      final path = uri.toFilePath(windows: Platform.isWindows);
+      if (_pastedImageExtensions.contains(p.extension(path).toLowerCase())) {
+        await _uploadPathAsAttachment(path);
+      }
+    }
+  }
+
+  /// 选图片/文件上传后挂进待发附件区,和文字一起随消息发出——跟频道
+  /// 主体的"附加文件"同一个入口,不区分图片和其它文件类型。
+  Future<void> _pickAndAttachFile() async {
+    if (_uploading) return;
+    final picked = await FilePicker.platform.pickFiles(withData: false);
+    final path = picked?.files.single.path;
+    if (path == null || !mounted) return;
+    setState(() => _uploading = true);
+    try {
+      await _uploadPathAsAttachment(path);
+    } catch (e) {
+      if (mounted) ToastService.showError('上传文件失败: $e');
+    } finally {
+      if (mounted) setState(() => _uploading = false);
+    }
+  }
+
+  /// 光标处插入文字,替换当前选区。
+  void _insertTextAtCursor(String text) {
+    final value = _inputController.value;
+    final selection = value.selection.isValid
+        ? value.selection
+        : TextSelection.collapsed(offset: value.text.length);
+    final newText = value.text.replaceRange(
+      selection.start,
+      selection.end,
+      text,
+    );
+    _inputController.value = value.copyWith(
+      text: newText,
+      selection: TextSelection.collapsed(offset: selection.start + text.length),
+    );
+    _inputFocusNode.requestFocus();
+  }
+
+  String _serializeLocalDate(LocalDateRun n) {
+    final buf = StringBuffer('[date=${n.date}');
+    if (n.time != null) buf.write(' time=${n.time}');
+    if (n.timezone != null) buf.write(' timezone="${n.timezone}"');
+    if (n.format != null) buf.write(' format="${n.format}"');
+    if (n.timezones.isNotEmpty) {
+      buf.write(' timezones="${n.timezones.join('|')}"');
+    }
+    if (n.displayedTimezone != null) {
+      buf.write(' displayedTimezone="${n.displayedTimezone}"');
+    }
+    if (n.countdown) buf.write(' countdown="true"');
+    buf.write(']');
+    return buf.toString();
+  }
+
+  Future<void> _insertDateTime() async {
+    final run = await showLocalDateEditDialog(context);
+    if (run == null || !mounted) return;
+    _insertTextAtCursor(_serializeLocalDate(run));
+  }
+
+  Future<void> _insertTemplate() async {
+    final template = await showTemplateInsertDialog(context);
+    if (template == null || !mounted) return;
+    _insertTextAtCursor(template.content);
+  }
+
+  Future<void> _showSummarizeDialog() async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => ChatSummaryDialog(channelId: widget.channelId),
+    );
+  }
+
+  Future<void> _showComposeMenu(BuildContext anchorContext) async {
+    final btnBox = anchorContext.findRenderObject() as RenderBox?;
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (btnBox == null || overlay == null) return;
+    final btnRect =
+        btnBox.localToGlobal(Offset.zero, ancestor: overlay) & btnBox.size;
+    final scheme = Theme.of(context).colorScheme;
+
+    final selected = await showMenu<String>(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        btnRect.left,
+        btnRect.top - 8,
+        overlay.size.width - btnRect.right,
+        overlay.size.height - btnRect.top + 8,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(color: scheme.outlineVariant.withValues(alpha: 0.5)),
+      ),
+      color: scheme.surfaceContainerLow,
+      constraints: const BoxConstraints(maxWidth: 220),
+      items: [
+        PopupMenuItem(
+          value: 'file',
+          child: _row(Icons.attach_file_rounded, '附加文件'),
+        ),
+        PopupMenuItem(
+          value: 'date',
+          child: _row(Icons.event_rounded, '插入日期/时间'),
+        ),
+        PopupMenuItem(
+          value: 'template',
+          child: _row(Icons.description_outlined, '插入模板'),
+        ),
+        PopupMenuItem(
+          value: 'summarize',
+          child: _row(Icons.auto_awesome_rounded, '总结消息'),
+        ),
+      ],
+    );
+    if (selected == null || !mounted) return;
+    switch (selected) {
+      case 'file':
+        await _pickAndAttachFile();
+      case 'date':
+        await _insertDateTime();
+      case 'template':
+        await _insertTemplate();
+      case 'summarize':
+        await _showSummarizeDialog();
+    }
+  }
+
+  Widget _row(IconData icon, String label) => Row(
+    mainAxisSize: MainAxisSize.min,
+    children: [Icon(icon, size: 18), const SizedBox(width: 12), Text(label)],
+  );
+
+  void _insertEmoji(Emoji emoji) {
+    final text = _inputController.text;
+    final selection = _inputController.selection;
+    final shortcode = ':${emoji.name}:';
+    final start = selection.start >= 0 ? selection.start : text.length;
+    final end = selection.end >= 0 ? selection.end : text.length;
+    final newText = text.replaceRange(start, end, shortcode);
+    _inputController.text = newText;
+    _inputController.selection = TextSelection.collapsed(
+      offset: start + shortcode.length,
+    );
+  }
+
+  static final _stickerMarkdownPattern = RegExp(r'^!\[([^|\]]+).*?\]\((.+)\)$');
+
+  void _addStickerAsPseudoUpload(String markdown) {
+    final match = _stickerMarkdownPattern.firstMatch(markdown);
+    setState(() {
+      _pendingUploads.add(_PendingUpload(
+        name: match?.group(1) ?? markdown,
+        stickerMarkdown: markdown,
+        stickerPreviewUrl: match?.group(2),
+      ));
+    });
+  }
+
+  Future<void> _showEmojiPicker(BuildContext anchorContext) async {
+    final emoji = await showAnchoredPopup<Emoji>(
+      context: context,
+      anchorContext: anchorContext,
+      closeOnScroll: _scrollController,
+      builder: (ctx, close) => EmojiStickerPanel(
+        onEmojiSelected: (e) => close(e),
+        onStickerSelected: (markdown) {
+          close(null);
+          _addStickerAsPseudoUpload(markdown);
+        },
+      ),
+    );
+    if (emoji != null) _insertEmoji(emoji);
+  }
+
+  Future<void> _pickReaction(int messageId) async {
+    final emoji = await showDialog<Emoji>(
+      context: context,
+      builder: (ctx) => Dialog(
+        clipBehavior: Clip.antiAlias,
+        child: SizedBox(
+          width: 420,
+          height: 480,
+          child: EmojiStickerPanel(
+            showStickerTab: false,
+            onEmojiSelected: (e) => Navigator.of(ctx).pop(e),
+            // 回应场景不露出表情包页签,onStickerSelected 走不到。
+            onStickerSelected: (_) {},
+          ),
+        ),
+      ),
+    );
+    if (emoji == null || !mounted) return;
+    unawaited(
+      ref
+          .read(chatThreadMessagesProvider(_arg).notifier)
+          .toggleReaction(messageId, emoji.name),
+    );
+  }
+
+  /// 悬浮条上"更多表情"点了之后,面板贴在点击位置附近弹出——对齐官方
+  /// 网页端悬浮工具条的表现,而不是屏幕正中的对话框。
+  Future<void> _pickReactionNear(BuildContext anchorContext, int messageId) {
+    return showAnchoredPopup<Emoji>(
+      context: context,
+      anchorContext: anchorContext,
+      closeOnScroll: _scrollController,
+      builder: (ctx, close) => EmojiStickerPanel(
+        compact: true,
+        inlineSearch: true,
+        showStickerTab: false,
+        onEmojiSelected: (e) => close(e),
+        onStickerSelected: (_) {},
+      ),
+    ).then((emoji) {
+      if (emoji == null || !mounted) return;
+      unawaited(
+        ref
+            .read(chatThreadMessagesProvider(_arg).notifier)
+            .toggleReaction(messageId, emoji.name),
+      );
+    });
+  }
+
+  static const _quickReactionEmojis = [
+    '+1',
+    'heart',
+    'joy',
+    'open_mouth',
+    'cry',
+    'tada',
+  ];
+
+  Future<void> _showThreadMessageMenu(ChatMessage message, bool isOwn) async {
+    final notifier = ref.read(chatThreadMessagesProvider(_arg).notifier);
+    final canManagePins = ref
+            .read(chatChannelListProvider)
+            .value
+            ?.where((c) => c.id == widget.channelId)
+            .firstOrNull
+            ?.canManagePins ??
+        false;
+    final action = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (!message.isDeleted)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Wrap(
+                  alignment: WrapAlignment.center,
+                  spacing: 4,
+                  children: [
+                    for (final name in _quickReactionEmojis)
+                      IconButton(
+                        onPressed: () => Navigator.of(ctx).pop('react:$name'),
+                        icon: ReactionEmoji(name: name, size: 26),
+                      ),
+                    IconButton(
+                      tooltip: '更多表情',
+                      onPressed: () => Navigator.of(ctx).pop('react_more'),
+                      icon: const Icon(Icons.add_reaction_outlined),
+                    ),
+                  ],
+                ),
+              ),
+            if (!message.isDeleted) const Divider(height: 1),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.reply_rounded),
+                title: const Text('回复'),
+                onTap: () => Navigator.of(ctx).pop('reply'),
+              ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.copy_rounded),
+                title: const Text('复制文本'),
+                onTap: () => Navigator.of(ctx).pop('copy'),
+              ),
+            ListTile(
+              leading: const Icon(Icons.link_rounded),
+              title: const Text('复制链接'),
+              onTap: () => Navigator.of(ctx).pop('copy_link'),
+            ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: Icon(message.bookmark != null
+                    ? Icons.bookmark_rounded
+                    : Icons.bookmark_border_rounded),
+                title: Text(message.bookmark != null ? '修改书签' : '书签'),
+                onTap: () => Navigator.of(ctx).pop('bookmark'),
+              ),
+            if (!message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.select_all_rounded),
+                title: const Text('选择文本'),
+                onTap: () => Navigator.of(ctx).pop('select'),
+              ),
+            if (!message.isDeleted && canManagePins)
+              ListTile(
+                leading: Icon(message.pinned
+                    ? Icons.push_pin_rounded
+                    : Icons.push_pin_outlined),
+                title: Text(message.pinned ? '取消置顶' : '置顶'),
+                onTap: () => Navigator.of(ctx).pop('pin'),
+              ),
+            if (isOwn && !message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.edit_rounded),
+                title: const Text('编辑'),
+                onTap: () => Navigator.of(ctx).pop('edit'),
+              ),
+            if (isOwn && !message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.delete_outline_rounded),
+                title: const Text('删除'),
+                onTap: () => Navigator.of(ctx).pop('delete'),
+              ),
+            if (isOwn && message.isDeleted)
+              ListTile(
+                leading: const Icon(Icons.restore_rounded),
+                title: const Text('恢复'),
+                onTap: () => Navigator.of(ctx).pop('restore'),
+              ),
+            if (!isOwn && !message.isDeleted)
+              ListTile(
+                leading: Icon(Icons.flag_outlined,
+                    color: Theme.of(ctx).colorScheme.error),
+                title: Text('举报',
+                    style: TextStyle(color: Theme.of(ctx).colorScheme.error)),
+                onTap: () => Navigator.of(ctx).pop('flag'),
+              ),
+          ],
+        ),
+      ),
+    );
+    if (action == null || !mounted) return;
+
+    if (action.startsWith('react:')) {
+      unawaited(notifier.toggleReaction(message.id, action.substring(6)));
+      return;
+    }
+    switch (action) {
+      case 'react_more':
+        await _pickReaction(message.id);
+      case 'reply':
+        _startReply(message);
+      case 'copy':
+        await Clipboard.setData(ClipboardData(text: message.message ?? ''));
+        if (mounted) ToastService.showSuccess('已复制文本');
+      case 'copy_link':
+        await Clipboard.setData(ClipboardData(
+          text:
+              '${AppConstants.baseUrl}/chat/c/-/${widget.channelId}/${message.id}',
+        ));
+        if (mounted) ToastService.showSuccess('已复制链接');
+      case 'bookmark':
+        await _bookmarkMessage(message);
+      case 'select':
+        await showDialog<void>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('选择文本'),
+            content: SelectableText(message.message ?? ''),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('关闭'),
+              ),
+            ],
+          ),
+        );
+      case 'pin':
+        try {
+          await notifier.togglePinned(message.id);
+        } catch (e) {
+          if (mounted) ToastService.showError('置顶操作失败: $e');
+        }
+      case 'edit':
+        _startEdit(message);
+      case 'delete':
+        try {
+          await notifier.deleteMessage(message.id);
+        } catch (e) {
+          if (mounted) ToastService.showError('删除失败: $e');
+        }
+      case 'restore':
+        try {
+          await notifier.restoreMessage(message.id);
+        } catch (e) {
+          if (mounted) ToastService.showError('恢复失败: $e');
+        }
+      case 'flag':
+        await _showFlagDialog(message);
+    }
+  }
+
   Future<void> _send() async {
     final text = _inputController.text.trim();
-    if (text.isEmpty || _sending) return;
+    if ((text.isEmpty && _pendingUploads.isEmpty) || _sending) return;
     setState(() => _sending = true);
     try {
-      final service = ref.read(discourseServiceProvider);
-      await service.sendChatMessage(
-        widget.channelId,
-        text,
-        threadId: widget.threadId,
-      );
-      _inputController.clear();
-      ref.invalidate(chatThreadMessagesProvider(_arg));
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('发送失败: $e')),
+      final editing = _editing;
+      final stickerMarkdowns = _pendingUploads
+          .where((u) => u.isSticker && u.stickerMarkdown != null)
+          .map((u) => u.stickerMarkdown!);
+      final realUploadIds = _pendingUploads
+          .where((u) => !u.isSticker)
+          .map((u) => u.id!)
+          .toList();
+      final combinedText =
+          [text, ...stickerMarkdowns].where((s) => s.isNotEmpty).join('\n');
+      if (editing != null) {
+        await ref
+            .read(chatThreadMessagesProvider(_arg).notifier)
+            .editMessage(editing.id, combinedText);
+      } else {
+        final service = ref.read(discourseServiceProvider);
+        await service.sendChatMessage(
+          widget.channelId,
+          combinedText,
+          threadId: widget.threadId,
+          inReplyToId: _replyTo?.id,
+          uploadIds: realUploadIds.isEmpty ? null : realUploadIds,
         );
       }
+      _inputController.clear();
+      setState(() {
+        _pendingUploads.clear();
+        _replyTo = null;
+        _editing = null;
+      });
+      ref.invalidate(chatThreadMessagesProvider(_arg));
+    } catch (e) {
+      if (mounted) ToastService.showError('发送失败: $e');
     } finally {
       if (mounted) {
         setState(() => _sending = false);
@@ -86,6 +788,10 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
         surfaceTintColor: Colors.transparent,
         scrolledUnderElevation: 0,
         elevation: 0,
+        automaticallyImplyLeading: !widget.embeddedMode,
+        leading: widget.embeddedMode && widget.onEmbeddedBack != null
+            ? BackButton(onPressed: widget.onEmbeddedBack)
+            : null,
         title: Text(widget.title ?? '消息串'),
       ),
       body: Column(
@@ -101,16 +807,41 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
                 return ListView.builder(
                   controller: _scrollController,
                   reverse: true,
+                  cacheExtent: 1200,
                   padding: const EdgeInsets.symmetric(vertical: 8),
+                  // 同 dm_channel_detail_page.dart:findChildIndexCallback +
+                  // addAutomaticKeepAlives:false 这套滚动调优上线后出现了新的
+                  // 原生层空指针崩溃,已回退,只保留 ValueKey 本身的正确性修复。
                   itemCount: messages.length,
                   itemBuilder: (context, index) {
-                    final message = messages[messages.length - 1 - index];
-                    final isOwn = currentUsername != null &&
+                    final chronoIndex = messages.length - 1 - index;
+                    final message = messages[chronoIndex];
+                    final previous =
+                        chronoIndex > 0 ? messages[chronoIndex - 1] : null;
+                    final isOwn =
+                        currentUsername != null &&
                         message.user?.username == currentUsername;
+                    final showHeader = previous == null ||
+                        previous.user?.username != message.user?.username;
                     return _ThreadMessageTile(
+                      key: ValueKey('thread_msg_${message.id}'),
                       message: message,
                       isOwn: isOwn,
+                      showHeader: showHeader,
                       scheme: scheme,
+                      onToggleReaction: (emoji) => unawaited(
+                        ref
+                            .read(chatThreadMessagesProvider(_arg).notifier)
+                            .toggleReaction(message.id, emoji),
+                      ),
+                      onAddReaction: (anchorCtx) =>
+                          _pickReactionNear(anchorCtx, message.id),
+                      onOpenMenu: () => _showThreadMessageMenu(message, isOwn),
+                      onReply: () => _startReply(message),
+                      onBookmark: () => _bookmarkMessage(message),
+                      onShowStatus: message.user != null
+                          ? () => _showUserStatus(message.user!)
+                          : null,
                     );
                   },
                 );
@@ -119,11 +850,164 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
               error: (error, stack) => ErrorView(
                 error: error,
                 stackTrace: stack,
-                onRetry: () =>
-                    ref.invalidate(chatThreadMessagesProvider(_arg)),
+                onRetry: () => ref.invalidate(chatThreadMessagesProvider(_arg)),
               ),
             ),
           ),
+          if (_uploading) const LinearProgressIndicator(minHeight: 2),
+          if (_replyTo != null || _editing != null)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              color: scheme.surfaceContainerLow,
+              child: Row(
+                children: [
+                  Icon(
+                    _editing != null ? Icons.edit_rounded : Icons.reply_rounded,
+                    size: 16,
+                    color: scheme.primary,
+                  ),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      _editing != null
+                          ? '编辑消息'
+                          : '回复 ${_replyTo!.user?.displayName ?? ''}: '
+                              '${_replyTo!.excerpt ?? _replyTo!.message ?? ''}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(fontSize: 12, color: scheme.onSurfaceVariant),
+                    ),
+                  ),
+                  InkWell(
+                    onTap: _cancelComposeExtras,
+                    child: const Padding(
+                      padding: EdgeInsets.all(4),
+                      child: Icon(Icons.close_rounded, size: 16),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          if (_pendingUploads.isNotEmpty)
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              color: scheme.surfaceContainerLow,
+              child: Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  for (final upload in _pendingUploads)
+                    if (upload.isImage && upload.localPath != null)
+                      Stack(
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: GestureDetector(
+                              onTap: () {
+                                final bytes = File(
+                                  upload.localPath!,
+                                ).readAsBytesSync();
+                                Navigator.of(context).push(
+                                  PageRouteBuilder(
+                                    opaque: false,
+                                    barrierColor: Colors.transparent,
+                                    pageBuilder:
+                                        (_, animation, secondaryAnimation) =>
+                                            ImageViewerPage(imageBytes: bytes),
+                                  ),
+                                );
+                              },
+                              child: Image.file(
+                                File(upload.localPath!),
+                                width: 64,
+                                height: 64,
+                                fit: BoxFit.cover,
+                                errorBuilder: (context, e, s) => Container(
+                                  width: 64,
+                                  height: 64,
+                                  color: scheme.surfaceContainerHighest,
+                                  child: const Icon(
+                                    Icons.broken_image_outlined,
+                                    size: 20,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                          Positioned(
+                            top: 2,
+                            right: 2,
+                            child: InkWell(
+                              onTap: () => setState(
+                                () => _pendingUploads.remove(upload),
+                              ),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withValues(alpha: 0.55),
+                                  shape: BoxShape.circle,
+                                ),
+                                padding: const EdgeInsets.all(2),
+                                child: const Icon(
+                                  Icons.close_rounded,
+                                  size: 12,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      )
+                    else if (upload.isSticker && upload.stickerPreviewUrl != null)
+                      Stack(
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: CachedImage(
+                              url: upload.stickerPreviewUrl!,
+                              width: 64,
+                              height: 64,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                          Positioned(
+                            top: 2,
+                            right: 2,
+                            child: InkWell(
+                              onTap: () => setState(
+                                () => _pendingUploads.remove(upload),
+                              ),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withValues(alpha: 0.55),
+                                  shape: BoxShape.circle,
+                                ),
+                                padding: const EdgeInsets.all(2),
+                                child: const Icon(
+                                  Icons.close_rounded,
+                                  size: 12,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      )
+                    else
+                      InputChip(
+                        avatar: const Icon(Icons.attach_file_rounded, size: 16),
+                        label: Text(
+                          upload.name,
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                        visualDensity: VisualDensity.compact,
+                        onDeleted: () =>
+                            setState(() => _pendingUploads.remove(upload)),
+                      ),
+                ],
+              ),
+            ),
           SafeArea(
             top: false,
             child: Padding(
@@ -131,31 +1015,52 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
+                  Builder(
+                    builder: (btnCtx) => IconButton(
+                      tooltip: '更多',
+                      onPressed: (_uploading || _editing != null)
+                          ? null
+                          : () => _showComposeMenu(btnCtx),
+                      icon: const Icon(Icons.add_circle_outline_rounded),
+                    ),
+                  ),
+                  Builder(
+                    builder: (btnCtx) => IconButton(
+                      tooltip: '表情',
+                      onPressed: () => _showEmojiPicker(btnCtx),
+                      icon: const Icon(Icons.emoji_emotions_outlined),
+                    ),
+                  ),
                   Expanded(
-                    child: TextField(
-                      controller: _inputController,
-                      focusNode: _inputFocusNode,
-                      minLines: 1,
-                      maxLines: 5,
-                      textInputAction: TextInputAction.send,
-                      onSubmitted: (_) => _send(),
-                      decoration: InputDecoration(
-                        hintText: '回复消息串',
-                        filled: true,
-                        fillColor: scheme.surfaceContainerHigh,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(24),
-                          borderSide: BorderSide.none,
+                    child: Focus(
+                      onKeyEvent: _handlePasteKey,
+                      child: TextField(
+                        controller: _inputController,
+                        focusNode: _inputFocusNode,
+                        minLines: 1,
+                        maxLines: 5,
+                        textInputAction: TextInputAction.send,
+                        onSubmitted: (_) => _send(),
+                        decoration: InputDecoration(
+                          hintText: _editing != null ? '编辑消息…' : '回复消息串',
+                          filled: true,
+                          fillColor: scheme.surfaceContainerHigh,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(24),
+                            borderSide: BorderSide.none,
+                          ),
+                          isDense: true,
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 10,
+                          ),
                         ),
-                        isDense: true,
-                        contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 10),
                       ),
                     ),
                   ),
                   const SizedBox(width: 8),
                   IconButton.filled(
-                    tooltip: '发送',
+                    tooltip: _editing != null ? '保存编辑' : '发送',
                     onPressed: _sending ? null : _send,
                     icon: _sending
                         ? const SizedBox(
@@ -163,7 +1068,9 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
                             height: 18,
                             child: LoadingSpinner(size: 18),
                           )
-                        : const Icon(Icons.send_rounded),
+                        : Icon(_editing != null
+                            ? Icons.check_rounded
+                            : Icons.send_rounded),
                   ),
                 ],
               ),
@@ -175,58 +1082,254 @@ class _DmThreadPageState extends ConsumerState<DmThreadPage> {
   }
 }
 
-/// 线程内的简化消息行:头像 + 名字/时间 + 正文。
-class _ThreadMessageTile extends StatelessWidget {
+/// 线程内的简化消息行:头像 + 名字/时间 + 正文 + 回应。桌面悬浮出操作条,
+/// 头像可点开资料卡,姓名旁带自定义状态——对齐主私聊 `_ChatMessageBubble`。
+class _ThreadMessageTile extends ConsumerStatefulWidget {
   const _ThreadMessageTile({
+    super.key,
     required this.message,
     required this.isOwn,
+    required this.showHeader,
     required this.scheme,
+    required this.onToggleReaction,
+    required this.onAddReaction,
+    required this.onOpenMenu,
+    required this.onReply,
+    required this.onBookmark,
+    this.onShowStatus,
   });
 
   final ChatMessage message;
   final bool isOwn;
+  final bool showHeader;
   final ColorScheme scheme;
+  final ValueChanged<String> onToggleReaction;
+  final ValueChanged<BuildContext> onAddReaction;
+  final VoidCallback onOpenMenu;
+  final VoidCallback onReply;
+  final VoidCallback onBookmark;
+  final VoidCallback? onShowStatus;
+
+  @override
+  ConsumerState<_ThreadMessageTile> createState() => _ThreadMessageTileState();
+}
+
+class _ThreadMessageTileState extends ConsumerState<_ThreadMessageTile> {
+  ChatMessage get message => widget.message;
 
   @override
   Widget build(BuildContext context) {
     final callbacks = FluxdoRenderCallbacks.generic(
       heroTagNamespace: 'chat_thread_msg_${message.id}',
     );
-    return Padding(
+    final scheme = widget.scheme;
+    final status = message.user?.status;
+
+    final row = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          SmartAvatar(
-            imageUrl: message.user?.getAvatarUrl(AppConstants.baseUrl, size: 40),
-            radius: 16,
-            fallbackText: (message.user?.username ?? '?').isNotEmpty
-                ? message.user!.username[0]
-                : '?',
-          ),
+          widget.showHeader
+              ? Builder(
+                  builder: (avatarCtx) => GestureDetector(
+                    onTap: message.user == null
+                        ? null
+                        : () {
+                            final box =
+                                avatarCtx.findRenderObject() as RenderBox?;
+                            if (box == null || !box.hasSize) return;
+                            showUserCard(
+                              context: avatarCtx,
+                              anchorRect:
+                                  box.localToGlobal(Offset.zero) & box.size,
+                              username: message.user!.username,
+                              nameFallback: message.user!.name,
+                              avatarFallbackUrl: message.user!
+                                  .getAvatarUrl(AppConstants.baseUrl, size: 144),
+                            );
+                          },
+                    child: SmartAvatar(
+                      imageUrl: message.user?.getAvatarUrl(
+                        AppConstants.baseUrl,
+                        size: 40,
+                      ),
+                      radius: 16,
+                      fallbackText: (message.user?.username ?? '?').isNotEmpty
+                          ? message.user!.username[0]
+                          : '?',
+                      isOnline: message.user?.id != null &&
+                          (ref.watch(chatOnlinePresenceProvider).value ??
+                                  const {})
+                              .contains(message.user!.id),
+                    ),
+                  ),
+                )
+              : const SizedBox(width: 32),
           const SizedBox(width: 8),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  '${message.user?.name ?? message.user?.username ?? ''} · '
-                  '${TimeUtils.formatCompactTime(message.createdAt)}',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-                const SizedBox(height: 2),
+                if (widget.showHeader)
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          '${message.user?.displayName ?? ''} · '
+                          '${TimeUtils.formatCompactTime(message.createdAt)}',
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (status != null) ...[
+                        const SizedBox(width: 4),
+                        UserStatusIcon(
+                          status: status,
+                          size: 14,
+                          onTap: widget.onShowStatus,
+                        ),
+                      ],
+                    ],
+                  ),
+                if (widget.showHeader) const SizedBox(height: 2),
                 message.isDeleted
-                    ? const Text('(消息已删除)',
-                        style: TextStyle(color: Colors.grey))
+                    ? const Text(
+                        '(消息已删除)',
+                        style: TextStyle(color: Colors.grey),
+                      )
                     : (message.cooked?.isNotEmpty ?? false)
-                        ? callbacks.render(
-                            cookedHtml: message.cooked!, compact: true)
-                        : Text(message.message ?? ''),
+                    ? callbacks.render(
+                        cookedHtml: message.cooked!,
+                        compact: true,
+                      )
+                    : Text(message.message ?? ''),
+                // 图片/附件不在 cooked 里,得单独渲染(见 chat_upload_view.dart)
+                if (!message.isDeleted)
+                  for (final upload in message.uploads)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: ChatUploadView(upload: upload),
+                    ),
+                if (!message.isDeleted && message.reactions.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Wrap(
+                    spacing: 4,
+                    runSpacing: 4,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      for (final reaction in message.reactions)
+                        ReactionChip(
+                          reaction: reaction,
+                          onTap: () => widget.onToggleReaction(reaction.emoji),
+                        ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ),
         ],
       ),
     );
+
+    final tappableRow = GestureDetector(
+      onLongPress: widget.onOpenMenu,
+      onSecondaryTap: widget.onOpenMenu,
+      child: row,
+    );
+
+    if (message.isDeleted) return tappableRow;
+
+    return HoverPopupAnchor(
+      alignRight: true,
+      gap: -10,
+      popupBuilder: (overlayCtx, closePopup) => _buildHoverPanel(
+          Theme.of(overlayCtx).colorScheme, closePopup),
+      child: tappableRow,
+    );
+  }
+
+  Widget _buildHoverPanel(ColorScheme scheme, VoidCallback closePopup) {
+    final recentReactions = ref.watch(recentChatReactionsProvider);
+    return Material(
+      elevation: 2,
+      borderRadius: BorderRadius.circular(20),
+      color: scheme.surfaceContainerLowest,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final name in recentReactions)
+              IconButton(
+                tooltip: ':$name:',
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                onPressed: () {
+                  closePopup();
+                  widget.onToggleReaction(name);
+                },
+                icon: ReactionEmoji(name: name, size: 18),
+              ),
+            Builder(
+              builder: (btnCtx) => IconButton(
+                tooltip: '更多表情',
+                iconSize: 18,
+                visualDensity: VisualDensity.compact,
+                onPressed: () {
+                  // 先同步用 btnCtx 发起(算锚点位置),再收起悬浮条。
+                  widget.onAddReaction(btnCtx);
+                  closePopup();
+                },
+                icon: Icon(Icons.add_reaction_outlined,
+                    color: scheme.onSurfaceVariant),
+              ),
+            ),
+            IconButton(
+              tooltip: message.bookmark != null ? '修改书签' : '书签',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: () {
+                closePopup();
+                widget.onBookmark();
+              },
+              icon: Icon(
+                message.bookmark != null
+                    ? Icons.bookmark_rounded
+                    : Icons.bookmark_border_rounded,
+                color: message.bookmark != null
+                    ? scheme.primary
+                    : scheme.onSurfaceVariant,
+              ),
+            ),
+            IconButton(
+              tooltip: '回复',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: () {
+                closePopup();
+                widget.onReply();
+              },
+              icon: Icon(Icons.reply_rounded, color: scheme.onSurfaceVariant),
+            ),
+            IconButton(
+              tooltip: '更多',
+              iconSize: 18,
+              visualDensity: VisualDensity.compact,
+              onPressed: () {
+                closePopup();
+                widget.onOpenMenu();
+              },
+              icon: Icon(Icons.more_vert_rounded,
+                  color: scheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
+

--- a/lib/pages/search_page.dart
+++ b/lib/pages/search_page.dart
@@ -987,6 +987,12 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             parentActive: widget.parentActive,
           ),
         );
+      case PaneKind.chat:
+      case PaneKind.chatThread:
+        // 搜索页自己的栈(_stackProvider)不会被压入 DM 频道/消息串——
+        // 私聊走的是独立的 selectedChatProvider,两套栈完全不共用。
+        // 兜底分支不该真的走到,走到了也不炸,给空态而不是崩溃。
+        return const SizedBox.shrink();
     }
   }
 

--- a/lib/pages/topics_screen.dart
+++ b/lib/pages/topics_screen.dart
@@ -27,6 +27,12 @@ import 'topic_detail_page/topic_detail_page.dart';
 import 'user_profile_page.dart';
 import 'create_topic_page.dart';
 import 'drafts_page.dart';
+import 'trust_level_requirements_page.dart';
+import 'metaverse_page.dart';
+import 'invite_links_page.dart';
+import 'category_topics_page.dart';
+import 'chat/dm_channel_detail_page.dart';
+import 'tag_topics_page.dart';
 
 /// 话题屏幕
 /// 在手机上显示单栏列表，平板上显示 Master-Detail 双栏
@@ -1084,6 +1090,18 @@ class PaneContentWidget extends StatelessWidget {
             embeddedMode: true,
             onEmbeddedBack: onBack,
             parentActive: parentActive,
+          ),
+        );
+      case PaneKind.chat:
+        return EmbeddedStackScope(
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: DmChannelDetailPage(
+            key: ValueKey('pane_chat_${entry.chatChannelId}'),
+            channelId: entry.chatChannelId!,
+            title: entry.chatTitle,
+            embeddedMode: true,
+            onEmbeddedBack: onBack,
           ),
         );
     }

--- a/lib/pages/topics_screen.dart
+++ b/lib/pages/topics_screen.dart
@@ -32,6 +32,7 @@ import 'metaverse_page.dart';
 import 'invite_links_page.dart';
 import 'category_topics_page.dart';
 import 'chat/dm_channel_detail_page.dart';
+import 'chat/dm_thread_page.dart';
 import 'tag_topics_page.dart';
 
 /// 话题屏幕
@@ -1100,6 +1101,21 @@ class PaneContentWidget extends StatelessWidget {
             key: ValueKey('pane_chat_${entry.chatChannelId}'),
             channelId: entry.chatChannelId!,
             title: entry.chatTitle,
+            embeddedMode: true,
+            onEmbeddedBack: onBack,
+          ),
+        );
+      case PaneKind.chatThread:
+        return EmbeddedStackScope(
+          stackProvider: stackProvider,
+          truncateOnPush: truncateOnPush,
+          child: DmThreadPage(
+            key: ValueKey(
+              'pane_chat_thread_${entry.chatChannelId}_${entry.chatThreadId}',
+            ),
+            channelId: entry.chatChannelId!,
+            threadId: entry.chatThreadId!,
+            title: entry.chatThreadTitle,
             embeddedMode: true,
             onEmbeddedBack: onBack,
           ),

--- a/lib/providers/message_bus/chat_providers.dart
+++ b/lib/providers/message_bus/chat_providers.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../models/chat/chat_channel.dart';
@@ -13,6 +14,14 @@ import '../core_providers.dart';
 import '../preferences_provider.dart';
 import 'message_bus_service_provider.dart';
 import 'topic_tracking_providers.dart';
+
+/// 当前正打开的聊天详情页频道 id(没打开则为 null)。用于解决"频道详情页
+/// 收到新消息本地清零未读"和"频道列表订阅收到同一条消息本地未读+1"这
+/// 两条独立订阅之间的竞态——谁的回调后跑到,未读数就以谁为准,顺序不
+/// 确定时会出现"消息明明读了,左侧红点却还在"。详情页 initState/dispose
+/// 里维护这个值,[ChatChannelListNotifier.applyIncomingMessage] 据此跳过
+/// 正在被查看的频道的未读自增。
+final activeChatChannelIdProvider = StateProvider<int?>((ref) => null);
 
 /// DM 频道列表(仅 Chat 插件的 Direct Message 频道,不含公开频道)。
 /// autoDispose:未读徽标常驻监听,页面/徽标都不在时自动释放。
@@ -29,7 +38,10 @@ class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
   }
 
   /// 对某个频道就地替换(找不到就不动),所有本地增量更新的公共骨架。
-  void _updateChannel(int channelId, ChatChannel Function(ChatChannel old) transform) {
+  void _updateChannel(
+    int channelId,
+    ChatChannel Function(ChatChannel old) transform,
+  ) {
     state.whenData((channels) {
       final index = channels.indexWhere((c) => c.id == channelId);
       if (index == -1) return;
@@ -41,13 +53,20 @@ class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
 
   /// 本地增量更新某频道未读数(来自 user-tracking-state 推送),
   /// 避免每条消息都整表重拉。
-  void applyUnreadUpdate(int channelId, {int? unreadCount, int? unreadMentions}) {
-    _updateChannel(channelId, (old) => old.copyWith(
-          membership: old.membership.copyWith(
-            unreadCount: unreadCount,
-            unreadMentions: unreadMentions,
-          ),
-        ));
+  void applyUnreadUpdate(
+    int channelId, {
+    int? unreadCount,
+    int? unreadMentions,
+  }) {
+    _updateChannel(
+      channelId,
+      (old) => old.copyWith(
+        membership: old.membership.copyWith(
+          unreadCount: unreadCount,
+          unreadMentions: unreadMentions,
+        ),
+      ),
+    );
   }
 
   /// 本地清零某频道未读数(打开详情页读到最新消息后调用,
@@ -58,22 +77,29 @@ class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
 
   /// 本地切换某频道收藏状态(服务端调用已在别处完成,这里只同步 UI)。
   void applyStarred(int channelId, bool starred) {
-    _updateChannel(channelId,
-        (old) => old.copyWith(membership: old.membership.copyWith(starred: starred)));
+    _updateChannel(
+      channelId,
+      (old) =>
+          old.copyWith(membership: old.membership.copyWith(starred: starred)),
+    );
   }
 
   /// 本地切换某频道静音状态(服务端调用已在别处完成,这里只同步 UI)。
   void applyMuted(int channelId, bool muted) {
-    _updateChannel(channelId,
-        (old) => old.copyWith(membership: old.membership.copyWith(muted: muted)));
+    _updateChannel(
+      channelId,
+      (old) => old.copyWith(membership: old.membership.copyWith(muted: muted)),
+    );
   }
 
   /// 本地更新某频道通知级别(服务端调用已在别处完成,这里只同步 UI)。
   void applyNotificationLevel(int channelId, int level) {
     _updateChannel(
-        channelId,
-        (old) => old.copyWith(
-            membership: old.membership.copyWith(notificationLevel: level)));
+      channelId,
+      (old) => old.copyWith(
+        membership: old.membership.copyWith(notificationLevel: level),
+      ),
+    );
   }
 
   /// 本地更新某频道消息串开关(服务端调用已在别处完成)。
@@ -81,11 +107,20 @@ class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
     _updateChannel(channelId, (old) => old.copyWith(threadingEnabled: enabled));
   }
 
+  /// 本地更新群聊名称/缩略名/emoji 图标(服务端调用已在别处完成)。
+  void applyChannelInfo(int channelId, {String? title, String? slug, String? emoji}) {
+    _updateChannel(
+      channelId,
+      (old) => old.copyWith(title: title, slug: slug, emoji: emoji),
+    );
+  }
+
   /// 离开频道后从本地列表移除(服务端调用已在别处完成)。
   void removeChannel(int channelId) {
     state.whenData((channels) {
       state = AsyncValue.data(
-          channels.where((c) => c.id != channelId).toList());
+        channels.where((c) => c.id != channelId).toList(),
+      );
     });
   }
 
@@ -93,26 +128,59 @@ class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
   /// 每个已加载频道的 new-messages 订阅):更新最后一条消息预览,自己发的
   /// 不计未读,别人发的本地未读 +1(列表页本身没有数字角标,但每行的
   /// 加粗/小圆点状态还是要跟着变,不然看着像没收到消息)。
-  void applyIncomingMessage(int channelId, ChatMessage message, {required bool isOwnMessage}) {
-    _updateChannel(channelId, (old) => old.copyWith(
-          lastMessage: ChatLastMessage(
-            id: message.id,
-            message: message.message,
-            createdAt: message.createdAt,
-          ),
-          membership: old.membership.copyWith(
-            unreadCount: isOwnMessage
-                ? old.membership.unreadCount
-                : old.membership.unreadCount + 1,
-          ),
-        ));
+  void applyIncomingMessage(
+    int channelId,
+    ChatMessage message, {
+    required bool isOwnMessage,
+  }) {
+    state.whenData((channels) {
+      final index = channels.indexWhere((c) => c.id == channelId);
+      if (index == -1) return;
+      // 详情页正开着这个频道时,消息会被详情页自己的订阅立刻标记已读,
+      // 这里不再自增,避免跟那边的清零动作产生竞态导致红点消不掉。
+      final isActivelyViewed = ref.read(activeChatChannelIdProvider) == channelId;
+      final updated = channels[index].copyWith(
+        lastMessage: ChatLastMessage(
+          id: message.id,
+          message: message.message,
+          createdAt: message.createdAt,
+        ),
+        membership: channels[index].membership.copyWith(
+          unreadCount: (isOwnMessage || isActivelyViewed)
+              ? (isActivelyViewed ? 0 : channels[index].membership.unreadCount)
+              : channels[index].membership.unreadCount + 1,
+        ),
+      );
+      // 有新消息就把这个频道挪到列表最前——之前只在原位置替换,列表顺序
+      // 一直停在首次拉取时的样子,看着像没刷新。
+      final next = List<ChatChannel>.from(channels)..removeAt(index);
+      next.insert(0, updated);
+      state = AsyncValue.data(next);
+    });
+  }
+
+  /// 本地更新某频道最后一条消息的预览文字(来自根频道的 processed/edit/
+  /// delete 事件)——之前只订阅了 new-messages,编辑/撤回/图片处理完成
+  /// 这几种事件完全没接,预览文字会一直停在旧内容上。
+  void applyLastMessagePreview(int channelId, int messageId, String? text) {
+    _updateChannel(channelId, (old) {
+      if (old.lastMessage?.id != messageId) return old;
+      return old.copyWith(
+        lastMessage: ChatLastMessage(
+          id: messageId,
+          message: text,
+          createdAt: old.lastMessage?.createdAt,
+        ),
+      );
+    });
   }
 }
 
 final chatChannelListProvider =
-    AsyncNotifierProvider.autoDispose<ChatChannelListNotifier, List<ChatChannel>>(
-  ChatChannelListNotifier.new,
-);
+    AsyncNotifierProvider.autoDispose<
+      ChatChannelListNotifier,
+      List<ChatChannel>
+    >(ChatChannelListNotifier.new);
 
 /// DM 频道列表页的追踪监听器:
 /// - `/chat/new-channel`:感知到新DM频道到达,整表重拉一次;
@@ -130,6 +198,7 @@ final chatChannelListProvider =
 class ChatTrackingChannelNotifier extends Notifier<void> {
   final List<(String, MessageBusCallback)> _globalSubscriptions = [];
   final Map<int, MessageBusCallback> _channelSubscriptions = {};
+  final Map<int, MessageBusCallback> _rootSubscriptions = {};
 
   @override
   void build() {
@@ -148,6 +217,10 @@ class ChatTrackingChannelNotifier extends Notifier<void> {
         messageBus.unsubscribe('/chat/${entry.key}/new-messages', entry.value);
       }
       _channelSubscriptions.clear();
+      for (final entry in _rootSubscriptions.entries) {
+        messageBus.unsubscribe('/chat/${entry.key}', entry.value);
+      }
+      _rootSubscriptions.clear();
       return;
     }
 
@@ -165,7 +238,9 @@ class ChatTrackingChannelNotifier extends Notifier<void> {
       if (channelId == null) return;
       debugPrint('[ChatTracking] 频道 $channelId 已读状态同步');
       if (ref.exists(chatChannelListProvider)) {
-        ref.read(chatChannelListProvider.notifier).applyUnreadUpdate(
+        ref
+            .read(chatChannelListProvider.notifier)
+            .applyUnreadUpdate(
               channelId,
               unreadCount: data['unread_count'] as int?,
               unreadMentions: data['mention_count'] as int?,
@@ -183,14 +258,54 @@ class ChatTrackingChannelNotifier extends Notifier<void> {
 
     // 按当前频道列表动态增减 per-channel 订阅
     final currentIds = channels.map((c) => c.id).toSet();
-    final removedIds = _channelSubscriptions.keys.where((id) => !currentIds.contains(id)).toList();
+    final removedIds = _channelSubscriptions.keys
+        .where((id) => !currentIds.contains(id))
+        .toList();
     for (final id in removedIds) {
-      messageBus.unsubscribe('/chat/$id/new-messages', _channelSubscriptions.remove(id));
+      messageBus.unsubscribe(
+        '/chat/$id/new-messages',
+        _channelSubscriptions.remove(id),
+      );
+      final rootCallback = _rootSubscriptions.remove(id);
+      if (rootCallback != null)
+        messageBus.unsubscribe('/chat/$id', rootCallback);
     }
 
     for (final chatChannel in channels) {
-      if (_channelSubscriptions.containsKey(chatChannel.id)) continue;
       final channelId = chatChannel.id;
+
+      if (!_rootSubscriptions.containsKey(channelId)) {
+        void onRootMessage(MessageBusMessage message) {
+          final data = message.data;
+          if (data is! Map<String, dynamic>) return;
+          if (!ref.exists(chatChannelListProvider)) return;
+          final notifier = ref.read(chatChannelListProvider.notifier);
+
+          if (data['type'] == 'processed' || data['type'] == 'edit') {
+            final raw = data['chat_message'] as Map<String, dynamic>?;
+            if (raw == null) return;
+            final id = raw['id'] as int?;
+            if (id == null) return;
+            notifier.applyLastMessagePreview(
+              channelId,
+              id,
+              raw['message'] as String?,
+            );
+            return;
+          }
+
+          if (data['type'] == 'delete') {
+            final deletedId = data['deleted_id'] as int?;
+            if (deletedId == null) return;
+            notifier.applyLastMessagePreview(channelId, deletedId, null);
+          }
+        }
+
+        messageBus.subscribe('/chat/$channelId', onRootMessage);
+        _rootSubscriptions[channelId] = onRootMessage;
+      }
+
+      if (_channelSubscriptions.containsKey(channelId)) continue;
       void onChannelMessage(MessageBusMessage message) {
         final data = message.data;
         if (data is! Map<String, dynamic> || data['type'] == 'thread') return;
@@ -200,11 +315,9 @@ class ChatTrackingChannelNotifier extends Notifier<void> {
           final incoming = ChatMessage.fromJson(raw);
           final isOwn = incoming.user?.username == currentUser.username;
           if (ref.exists(chatChannelListProvider)) {
-            ref.read(chatChannelListProvider.notifier).applyIncomingMessage(
-                  channelId,
-                  incoming,
-                  isOwnMessage: isOwn,
-                );
+            ref
+                .read(chatChannelListProvider.notifier)
+                .applyIncomingMessage(channelId, incoming, isOwnMessage: isOwn);
           }
         } catch (e) {
           debugPrint('[ChatTracking] 解析频道 $channelId 新消息失败: $e');
@@ -230,8 +343,8 @@ class ChatTrackingChannelNotifier extends Notifier<void> {
 
 final chatTrackingChannelProvider =
     NotifierProvider.autoDispose<ChatTrackingChannelNotifier, void>(
-  ChatTrackingChannelNotifier.new,
-);
+      ChatTrackingChannelNotifier.new,
+    );
 
 /// DM 系统通知:订阅 `/chat/notification-alert/{userId}`(Discourse Chat
 /// 插件 `Jobs::Chat::NotifyWatching` 在对方"watching"这个频道时推送,payload
@@ -265,8 +378,11 @@ class ChatNotificationAlertChannelNotifier extends Notifier<void> {
       debugPrint('[ChatNotificationAlert] 收到提醒: $data');
 
       final username = data['username'] as String? ?? '';
-      final blockedUsernames = ref.read(preferencesProvider).normalizedBlockedUsernames;
-      if (BlockedUserFilter.isBlockedUsername(username, blockedUsernames)) return;
+      final blockedUsernames = ref
+          .read(preferencesProvider)
+          .normalizedBlockedUsernames;
+      if (BlockedUserFilter.isBlockedUsername(username, blockedUsernames))
+        return;
 
       final channelId = data['channel_id'] as int?;
       final title = data['translated_title'] as String? ?? username;
@@ -293,8 +409,8 @@ class ChatNotificationAlertChannelNotifier extends Notifier<void> {
 
 final chatNotificationAlertChannelProvider =
     NotifierProvider<ChatNotificationAlertChannelNotifier, void>(
-  ChatNotificationAlertChannelNotifier.new,
-);
+      ChatNotificationAlertChannelNotifier.new,
+    );
 
 /// 单个 DM 频道的消息流:进入详情页加载历史消息 + 订阅频道内新消息,
 /// 离开页面(不再被引用)自动退订。
@@ -309,6 +425,13 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
   MessageBusCallback? _callback;
   String? _subscribedRootChannel;
   MessageBusCallback? _rootCallback;
+  // autoDispose 场景下,MessageBus 分发某个 chunk 时先给回调列表拍了张快照
+  // 再逐个调用(见 message_bus_service.dart 的 ConcurrentModificationError
+  // 修复),快照里的回调即便随后被 unsubscribe 也还是会跑完——如果这时
+  // provider 已经 dispose(比如快速切换私聊频道),回调里的 `state = ...`
+  // 会打在已死的 Element 上炸 `_lifecycleState != defunct` 断言。
+  // 所有回调开头都要先检查这个标志。
+  bool _disposed = false;
 
   @override
   Future<List<ChatMessage>> build() async {
@@ -333,7 +456,10 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
     );
     // 接口返回按时间倒序或正序取决于 fetch_from_last_read,统一按创建时间升序排列
     final sorted = [...messages]
-      ..sort((a, b) => (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+      ..sort(
+        (a, b) =>
+            (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)),
+      );
 
     if (sorted.isNotEmpty) {
       _markRead(sorted.last.id);
@@ -341,6 +467,7 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
 
     final channel = '/chat/$channelId/new-messages';
     void onMessage(MessageBusMessage message) {
+      if (_disposed) return;
       final data = message.data;
       if (data is! Map<String, dynamic>) return;
       // 核对过 Discourse 源码 Chat::Publisher#publish_new!:payload 是
@@ -370,6 +497,7 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
     // publish_to_targets!→calculate_publish_targets,非线程消息只发根频道。
     final rootChannel = '/chat/$channelId';
     void onRootMessage(MessageBusMessage message) {
+      if (_disposed) return;
       final data = message.data;
       if (data is! Map<String, dynamic>) return;
 
@@ -468,6 +596,7 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
     messageBus.subscribe(rootChannel, onRootMessage);
 
     ref.onDispose(() {
+      _disposed = true;
       if (_subscribedChannel != null && _callback != null) {
         messageBus.unsubscribe(_subscribedChannel!, _callback);
       }
@@ -495,15 +624,21 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
       if (old.count <= 1) {
         optimistic.removeAt(reactionIndex);
       } else {
-        optimistic[reactionIndex] =
-            ChatReaction(emoji: emoji, count: old.count - 1, reacted: false);
+        optimistic[reactionIndex] = ChatReaction(
+          emoji: emoji,
+          count: old.count - 1,
+          reacted: false,
+        );
       }
     } else if (reactionIndex == -1) {
       optimistic.add(ChatReaction(emoji: emoji, count: 1, reacted: true));
     } else {
       final old = optimistic[reactionIndex];
-      optimistic[reactionIndex] =
-          ChatReaction(emoji: emoji, count: old.count + 1, reacted: true);
+      optimistic[reactionIndex] = ChatReaction(
+        emoji: emoji,
+        count: old.count + 1,
+        reacted: true,
+      );
     }
 
     final next = [...current];
@@ -516,7 +651,12 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
 
     try {
       final service = ref.read(discourseServiceProvider);
-      await service.toggleChatReaction(channelId, messageId, emoji, add: !wasReacted);
+      await service.toggleChatReaction(
+        channelId,
+        messageId,
+        emoji,
+        add: !wasReacted,
+      );
     } catch (e) {
       debugPrint('[ChatMessages] 表情回应失败: $e');
       final rollback = <ChatMessage>[...(state.value ?? const [])];
@@ -565,8 +705,11 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
       }
       final existingIds = current.map((m) => m.id).toSet();
       final fresh = older.where((m) => !existingIds.contains(m.id)).toList()
-        ..sort((a, b) =>
-            (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+        ..sort(
+          (a, b) => (a.createdAt ?? DateTime(0)).compareTo(
+            b.createdAt ?? DateTime(0),
+          ),
+        );
       if (fresh.isEmpty) {
         _hasMoreOlder = false;
         return;
@@ -599,7 +742,9 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
     next[index] = original.copyWith(deletedAt: DateTime.now());
     state = AsyncValue.data(next);
     try {
-      await ref.read(discourseServiceProvider).deleteChatMessage(channelId, messageId);
+      await ref
+          .read(discourseServiceProvider)
+          .deleteChatMessage(channelId, messageId);
     } catch (e) {
       final rollback = <ChatMessage>[...(state.value ?? const [])];
       final i = rollback.indexWhere((m) => m.id == messageId);
@@ -613,7 +758,9 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
 
   /// 恢复被删除的消息(restore 事件会推回完整消息,这里只发请求)。
   Future<void> restoreMessage(int messageId) async {
-    await ref.read(discourseServiceProvider).restoreChatMessage(channelId, messageId);
+    await ref
+        .read(discourseServiceProvider)
+        .restoreChatMessage(channelId, messageId);
   }
 
   /// 置顶/取消置顶:乐观更新 pinned 标记,失败回滚。
@@ -646,9 +793,11 @@ class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
   /// 影响消息流本身的展示。
   void _markRead(int messageId) {
     final service = ref.read(discourseServiceProvider);
-    unawaited(service.markChatChannelRead(channelId, messageId).catchError((e) {
-      debugPrint('[ChatMessages] 标记已读失败: $e');
-    }));
+    unawaited(
+      service.markChatChannelRead(channelId, messageId).catchError((e) {
+        debugPrint('[ChatMessages] 标记已读失败: $e');
+      }),
+    );
     if (ref.exists(chatChannelListProvider)) {
       ref.read(chatChannelListProvider.notifier).markRead(channelId);
     }
@@ -672,9 +821,10 @@ class RecentChatReactionsNotifier extends Notifier<List<String>> {
     final prefs = await SharedPreferences.getInstance();
     final stored = prefs.getStringList(_prefsKey);
     if (stored != null && stored.isNotEmpty) {
-      state = [...stored, ..._defaults.where((e) => !stored.contains(e))]
-          .take(3)
-          .toList();
+      state = [
+        ...stored,
+        ..._defaults.where((e) => !stored.contains(e)),
+      ].take(3).toList();
     }
   }
 
@@ -688,8 +838,8 @@ class RecentChatReactionsNotifier extends Notifier<List<String>> {
 
 final recentChatReactionsProvider =
     NotifierProvider<RecentChatReactionsNotifier, List<String>>(
-  RecentChatReactionsNotifier.new,
-);
+      RecentChatReactionsNotifier.new,
+    );
 
 /// 单个消息串的消息流:加载历史 + 订阅本频道 new-messages 里
 /// type == "thread" 且 thread_id 匹配的推送。参数是 (channelId, threadId)。
@@ -702,6 +852,11 @@ class ChatThreadMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
 
   String? _subscribedChannel;
   MessageBusCallback? _callback;
+  String? _subscribedRootChannel;
+  MessageBusCallback? _rootCallback;
+  // 同 ChatMessagesNotifier 的 _disposed 说明:防止已 dispose 后回调快照
+  // 仍触发 `state = ...` 炸 defunct Element 断言。
+  bool _disposed = false;
 
   @override
   Future<List<ChatMessage>> build() async {
@@ -714,16 +869,26 @@ class ChatThreadMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
       _subscribedChannel = null;
       _callback = null;
     }
+    if (_subscribedRootChannel != null && _rootCallback != null) {
+      messageBus.unsubscribe(_subscribedRootChannel!, _rootCallback);
+      _subscribedRootChannel = null;
+      _rootCallback = null;
+    }
 
     final messages = await service.fetchChatThreadMessages(channelId, threadId);
     final sorted = [...messages]
-      ..sort((a, b) =>
-          (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+      ..sort(
+        (a, b) =>
+            (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)),
+      );
 
-    unawaited(service.markChatThreadRead(channelId, threadId).catchError((_) {}));
+    unawaited(
+      service.markChatThreadRead(channelId, threadId).catchError((_) {}),
+    );
 
     final channel = '/chat/$channelId/new-messages';
     void onMessage(MessageBusMessage message) {
+      if (_disposed) return;
       final data = message.data;
       if (data is! Map<String, dynamic>) return;
       if (data['type'] != 'thread' || data['thread_id'] != threadId) return;
@@ -743,20 +908,243 @@ class ChatThreadMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
     _callback = onMessage;
     messageBus.subscribe(channel, onMessage);
 
+    // 主频道那份(ChatMessagesNotifier.build)接了根频道 `/chat/{id}` 的
+    // processed/edit/restore/delete/reaction,串这边之前只接了
+    // new-messages,图片处理完成/编辑/撤回/回应这些事件全收不到——
+    // 表现就是串里内容不会自动更新,得手动刷新。这里补齐同一套处理,
+    // 按 messageId 是否存在于当前串状态里过滤,不用额外核对 thread_id。
+    final rootChannel = '/chat/$channelId';
+    void onRootMessage(MessageBusMessage message) {
+      if (_disposed) return;
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+
+      if (data['type'] == 'processed' ||
+          data['type'] == 'edit' ||
+          data['type'] == 'restore') {
+        final raw = data['chat_message'] as Map<String, dynamic>?;
+        if (raw == null) return;
+        try {
+          final updated = ChatMessage.fromJson(raw);
+          final current = state.value ?? const [];
+          final index = current.indexWhere((m) => m.id == updated.id);
+          if (index == -1) return;
+          final next = [...current];
+          next[index] = updated;
+          state = AsyncValue.data(next);
+        } catch (e) {
+          debugPrint('[ChatThread] 解析更新消息失败: $e');
+        }
+        return;
+      }
+
+      if (data['type'] == 'delete') {
+        final deletedId = data['deleted_id'] as int?;
+        if (deletedId == null) return;
+        final current = state.value ?? const [];
+        final index = current.indexWhere((m) => m.id == deletedId);
+        if (index == -1) return;
+        final next = [...current];
+        next[index] = next[index].copyWith(deletedAt: DateTime.now());
+        state = AsyncValue.data(next);
+        return;
+      }
+
+      if (data['type'] != 'reaction') return;
+      final messageId = data['chat_message_id'] as int?;
+      final emoji = data['emoji'] as String?;
+      final action = data['action'] as String?;
+      final reactUser = data['user'] as Map<String, dynamic>?;
+      if (messageId == null || emoji == null || action == null) return;
+      final currentUsername = ref.read(currentUserProvider).value?.username;
+      final isSelf = reactUser?['username'] == currentUsername;
+      if (isSelf) return;
+      final current = state.value ?? const [];
+      final index = current.indexWhere((m) => m.id == messageId);
+      if (index == -1) return;
+      final target = current[index];
+      final reactions = [...target.reactions];
+      final reactionIndex = reactions.indexWhere((r) => r.emoji == emoji);
+      if (action == 'add') {
+        if (reactionIndex == -1) {
+          reactions.add(ChatReaction(emoji: emoji, count: 1, reacted: isSelf));
+        } else {
+          final old = reactions[reactionIndex];
+          reactions[reactionIndex] = ChatReaction(
+            emoji: emoji,
+            count: old.count + 1,
+            reacted: old.reacted || isSelf,
+          );
+        }
+      } else if (reactionIndex != -1) {
+        final old = reactions[reactionIndex];
+        final nextCount = old.count - 1;
+        if (nextCount <= 0) {
+          reactions.removeAt(reactionIndex);
+        } else {
+          reactions[reactionIndex] = ChatReaction(
+            emoji: emoji,
+            count: nextCount,
+            reacted: isSelf ? false : old.reacted,
+          );
+        }
+      }
+      final next = [...current];
+      next[index] = target.copyWithReactions(reactions);
+      state = AsyncValue.data(next);
+    }
+
+    _subscribedRootChannel = rootChannel;
+    _rootCallback = onRootMessage;
+    messageBus.subscribe(rootChannel, onRootMessage);
+
     ref.onDispose(() {
+      _disposed = true;
       if (_subscribedChannel != null && _callback != null) {
         messageBus.unsubscribe(_subscribedChannel!, _callback);
+      }
+      if (_subscribedRootChannel != null && _rootCallback != null) {
+        messageBus.unsubscribe(_subscribedRootChannel!, _rootCallback);
       }
     });
 
     return sorted;
   }
+
+  Future<void> toggleReaction(int messageId, String emoji) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final target = current[index];
+    final reactions = [...target.reactions];
+    final reactionIndex = reactions.indexWhere((r) => r.emoji == emoji);
+    final wasReacted = reactionIndex != -1 && reactions[reactionIndex].reacted;
+
+    final optimistic = [...reactions];
+    if (wasReacted) {
+      final old = optimistic[reactionIndex];
+      if (old.count <= 1) {
+        optimistic.removeAt(reactionIndex);
+      } else {
+        optimistic[reactionIndex] = ChatReaction(
+          emoji: emoji,
+          count: old.count - 1,
+          reacted: false,
+        );
+      }
+    } else if (reactionIndex == -1) {
+      optimistic.add(ChatReaction(emoji: emoji, count: 1, reacted: true));
+    } else {
+      final old = optimistic[reactionIndex];
+      optimistic[reactionIndex] = ChatReaction(
+        emoji: emoji,
+        count: old.count + 1,
+        reacted: true,
+      );
+    }
+
+    final next = [...current];
+    next[index] = target.copyWithReactions(optimistic);
+    state = AsyncValue.data(next);
+
+    if (!wasReacted) {
+      unawaited(ref.read(recentChatReactionsProvider.notifier).track(emoji));
+    }
+
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.toggleChatReaction(
+        channelId,
+        messageId,
+        emoji,
+        add: !wasReacted,
+      );
+    } catch (e) {
+      debugPrint('[ChatThread] 切换回应失败,回退: $e');
+      final rollback = state.value ?? const [];
+      final rollbackIndex = rollback.indexWhere((m) => m.id == messageId);
+      if (rollbackIndex == -1) return;
+      final rolledBack = [...rollback];
+      rolledBack[rollbackIndex] = rolledBack[rollbackIndex].copyWithReactions(
+        reactions,
+      );
+      state = AsyncValue.data(rolledBack);
+    }
+  }
+
+  Future<void> editMessage(int messageId, String text) async {
+    final service = ref.read(discourseServiceProvider);
+    await service.updateChatMessage(channelId, messageId, text);
+  }
+
+  /// 删除自己的消息:乐观标记为已删除,失败回滚。
+  Future<void> deleteMessage(int messageId) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final original = current[index];
+    final next = [...current];
+    next[index] = original.copyWith(deletedAt: DateTime.now());
+    state = AsyncValue.data(next);
+    try {
+      await ref.read(discourseServiceProvider).deleteChatMessage(channelId, messageId);
+    } catch (e) {
+      final rollback = <ChatMessage>[...(state.value ?? const [])];
+      final i = rollback.indexWhere((m) => m.id == messageId);
+      if (i != -1) {
+        rollback[i] = original;
+        state = AsyncValue.data(rollback);
+      }
+      rethrow;
+    }
+  }
+
+  Future<void> restoreMessage(int messageId) async {
+    await ref.read(discourseServiceProvider).restoreChatMessage(channelId, messageId);
+  }
+
+  Future<void> togglePinned(int messageId) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final original = current[index];
+    final nextPinned = !original.pinned;
+    final next = [...current];
+    next[index] = original.copyWith(pinned: nextPinned);
+    state = AsyncValue.data(next);
+    try {
+      await ref
+          .read(discourseServiceProvider)
+          .setChatMessagePinned(channelId, messageId, pinned: nextPinned);
+    } catch (e) {
+      final rollback = <ChatMessage>[...(state.value ?? const [])];
+      final i = rollback.indexWhere((m) => m.id == messageId);
+      if (i != -1) {
+        rollback[i] = original;
+        state = AsyncValue.data(rollback);
+      }
+      rethrow;
+    }
+  }
+
+  void applyBookmark(int messageId, ChatBookmark? bookmark) {
+    final current = state.value;
+    if (current == null) return;
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final next = List<ChatMessage>.from(current);
+    next[index] = current[index].copyWith(
+      bookmark: bookmark,
+      clearBookmark: bookmark == null,
+    );
+    state = AsyncValue.data(next);
+  }
 }
 
 final chatThreadMessagesProvider = AsyncNotifierProvider.autoDispose
     .family<ChatThreadMessagesNotifier, List<ChatMessage>, (int, int)>(
-  (arg) => ChatThreadMessagesNotifier(arg),
-);
+      (arg) => ChatThreadMessagesNotifier(arg),
+    );
 
 /// 某频道"正在向上加载更早消息"的 UI 状态,详情页顶部转圈用。
 class ChatLoadingOlderNotifier extends Notifier<bool> {
@@ -768,10 +1156,66 @@ class ChatLoadingOlderNotifier extends Notifier<bool> {
 
 final chatLoadingOlderProvider = NotifierProvider.autoDispose
     .family<ChatLoadingOlderNotifier, bool, int>(
-  (channelId) => ChatLoadingOlderNotifier(),
-);
+      (channelId) => ChatLoadingOlderNotifier(),
+    );
 
 final chatMessagesProvider = AsyncNotifierProvider.autoDispose
     .family<ChatMessagesNotifier, List<ChatMessage>, int>(
-  (channelId) => ChatMessagesNotifier(channelId),
+      (channelId) => ChatMessagesNotifier(channelId),
+    );
+
+/// 聊天在线用户 id 集合,对齐官方 `/chat/online` presence 频道:
+/// 初始 `/presence/get` 快照 + MessageBus `/presence/chat/online` 增量
+/// (`entering_users`/`leaving_user_ids`)。autoDispose:没有聊天页面/头像
+/// 使用时自动释放订阅。
+class ChatOnlinePresenceNotifier extends AsyncNotifier<Set<int>> {
+  String? _subscribedChannel;
+  MessageBusCallback? _callback;
+  // 同 ChatMessagesNotifier 的 _disposed 说明:防止已 dispose 后回调快照
+  // 仍触发 `state = ...` 炸 defunct Element 断言。
+  bool _disposed = false;
+
+  @override
+  Future<Set<int>> build() async {
+    final messageBus = ref.watch(messageBusServiceProvider);
+    final service = ref.read(discourseServiceProvider);
+
+    ref.onDispose(() {
+      _disposed = true;
+      if (_subscribedChannel != null && _callback != null) {
+        messageBus.unsubscribe(_subscribedChannel!, _callback!);
+      }
+    });
+
+    final channel = '/presence/chat/online';
+    _callback = (message) {
+      if (_disposed) return;
+      final data = message.data as Map<String, dynamic>?;
+      if (data == null) return;
+      final current = Set<int>.from(state.value ?? const {});
+      final entering = data['entering_users'] as List<dynamic>?;
+      if (entering != null) {
+        for (final u in entering) {
+          final id = (u as Map<String, dynamic>)['id'] as int?;
+          if (id != null) current.add(id);
+        }
+      }
+      final leaving = data['leaving_user_ids'] as List<dynamic>?;
+      if (leaving != null) {
+        for (final id in leaving) {
+          current.remove(id as int);
+        }
+      }
+      state = AsyncValue.data(current);
+    };
+    messageBus.subscribe(channel, _callback!);
+    _subscribedChannel = channel;
+
+    return service.getChatOnlinePresence();
+  }
+}
+
+final chatOnlinePresenceProvider =
+    AsyncNotifierProvider.autoDispose<ChatOnlinePresenceNotifier, Set<int>>(
+  ChatOnlinePresenceNotifier.new,
 );

--- a/lib/providers/message_bus/chat_providers.dart
+++ b/lib/providers/message_bus/chat_providers.dart
@@ -1,0 +1,777 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../models/chat/chat_channel.dart';
+import '../../models/chat/chat_message.dart';
+import '../../services/local_notification_service.dart';
+import '../../services/message_bus_service.dart';
+import '../../utils/blocked_user_filter.dart';
+import '../core_providers.dart';
+import '../preferences_provider.dart';
+import 'message_bus_service_provider.dart';
+import 'topic_tracking_providers.dart';
+
+/// DM 频道列表(仅 Chat 插件的 Direct Message 频道,不含公开频道)。
+/// autoDispose:未读徽标常驻监听,页面/徽标都不在时自动释放。
+class ChatChannelListNotifier extends AsyncNotifier<List<ChatChannel>> {
+  @override
+  Future<List<ChatChannel>> build() async {
+    final service = ref.read(discourseServiceProvider);
+    return service.fetchChatChannels();
+  }
+
+  Future<void> refresh() async {
+    final service = ref.read(discourseServiceProvider);
+    state = await AsyncValue.guard(() => service.fetchChatChannels());
+  }
+
+  /// 对某个频道就地替换(找不到就不动),所有本地增量更新的公共骨架。
+  void _updateChannel(int channelId, ChatChannel Function(ChatChannel old) transform) {
+    state.whenData((channels) {
+      final index = channels.indexWhere((c) => c.id == channelId);
+      if (index == -1) return;
+      final next = List<ChatChannel>.from(channels);
+      next[index] = transform(channels[index]);
+      state = AsyncValue.data(next);
+    });
+  }
+
+  /// 本地增量更新某频道未读数(来自 user-tracking-state 推送),
+  /// 避免每条消息都整表重拉。
+  void applyUnreadUpdate(int channelId, {int? unreadCount, int? unreadMentions}) {
+    _updateChannel(channelId, (old) => old.copyWith(
+          membership: old.membership.copyWith(
+            unreadCount: unreadCount,
+            unreadMentions: unreadMentions,
+          ),
+        ));
+  }
+
+  /// 本地清零某频道未读数(打开详情页读到最新消息后调用,
+  /// 避免等下一次整表刷新才把徽标降下去)。
+  void markRead(int channelId) {
+    applyUnreadUpdate(channelId, unreadCount: 0, unreadMentions: 0);
+  }
+
+  /// 本地切换某频道收藏状态(服务端调用已在别处完成,这里只同步 UI)。
+  void applyStarred(int channelId, bool starred) {
+    _updateChannel(channelId,
+        (old) => old.copyWith(membership: old.membership.copyWith(starred: starred)));
+  }
+
+  /// 本地切换某频道静音状态(服务端调用已在别处完成,这里只同步 UI)。
+  void applyMuted(int channelId, bool muted) {
+    _updateChannel(channelId,
+        (old) => old.copyWith(membership: old.membership.copyWith(muted: muted)));
+  }
+
+  /// 本地更新某频道通知级别(服务端调用已在别处完成,这里只同步 UI)。
+  void applyNotificationLevel(int channelId, int level) {
+    _updateChannel(
+        channelId,
+        (old) => old.copyWith(
+            membership: old.membership.copyWith(notificationLevel: level)));
+  }
+
+  /// 本地更新某频道消息串开关(服务端调用已在别处完成)。
+  void applyThreadingEnabled(int channelId, bool enabled) {
+    _updateChannel(channelId, (old) => old.copyWith(threadingEnabled: enabled));
+  }
+
+  /// 离开频道后从本地列表移除(服务端调用已在别处完成)。
+  void removeChannel(int channelId) {
+    state.whenData((channels) {
+      state = AsyncValue.data(
+          channels.where((c) => c.id != channelId).toList());
+    });
+  }
+
+  /// 列表页开着时收到某频道的新消息(来自 [ChatTrackingChannelNotifier] 对
+  /// 每个已加载频道的 new-messages 订阅):更新最后一条消息预览,自己发的
+  /// 不计未读,别人发的本地未读 +1(列表页本身没有数字角标,但每行的
+  /// 加粗/小圆点状态还是要跟着变,不然看着像没收到消息)。
+  void applyIncomingMessage(int channelId, ChatMessage message, {required bool isOwnMessage}) {
+    _updateChannel(channelId, (old) => old.copyWith(
+          lastMessage: ChatLastMessage(
+            id: message.id,
+            message: message.message,
+            createdAt: message.createdAt,
+          ),
+          membership: old.membership.copyWith(
+            unreadCount: isOwnMessage
+                ? old.membership.unreadCount
+                : old.membership.unreadCount + 1,
+          ),
+        ));
+  }
+}
+
+final chatChannelListProvider =
+    AsyncNotifierProvider.autoDispose<ChatChannelListNotifier, List<ChatChannel>>(
+  ChatChannelListNotifier.new,
+);
+
+/// DM 频道列表页的追踪监听器:
+/// - `/chat/new-channel`:感知到新DM频道到达,整表重拉一次;
+/// - `/chat/user-tracking-state/{userId}`:自己在别的设备/标签页把某频道
+///   标成已读时同步清零(**不会**在别人给你发消息时推给你——核对过源码
+///   Chat::Publisher#publish_user_tracking_state!,只在"当前用户自己标记
+///   已读"的调用链里触发,纯粹是多端已读状态同步,不是新消息通知);
+/// - 对列表里**每一个**频道各自订阅 `/chat/{id}/new-messages`,让列表页
+///   开着时收到消息也能实时刷新预览/加粗状态(官方网页端 chat-channels-
+///   manager 就是这么订的)。这层随频道列表增删动态增减订阅,列表页关掉
+///   (autoDispose)时随之整体退订。
+///
+/// 由频道列表页 `ref.watch` 激活;不接未读徽标——本 app 通知 tab 本身
+/// 在底栏就没有角标,DM 保持一致,不单独做。
+class ChatTrackingChannelNotifier extends Notifier<void> {
+  final List<(String, MessageBusCallback)> _globalSubscriptions = [];
+  final Map<int, MessageBusCallback> _channelSubscriptions = {};
+
+  @override
+  void build() {
+    ref.watch(messageBusInitProvider);
+    final messageBus = ref.watch(messageBusServiceProvider);
+    final currentUser = ref.watch(currentUserProvider).value;
+    final channels = ref.watch(chatChannelListProvider).value ?? const [];
+
+    for (final (channel, callback) in _globalSubscriptions) {
+      messageBus.unsubscribe(channel, callback);
+    }
+    _globalSubscriptions.clear();
+
+    if (currentUser == null) {
+      for (final entry in _channelSubscriptions.entries) {
+        messageBus.unsubscribe('/chat/${entry.key}/new-messages', entry.value);
+      }
+      _channelSubscriptions.clear();
+      return;
+    }
+
+    void onNewChannel(MessageBusMessage message) {
+      debugPrint('[ChatTracking] 收到新 DM 频道推送');
+      if (ref.exists(chatChannelListProvider)) {
+        unawaited(ref.read(chatChannelListProvider.notifier).refresh());
+      }
+    }
+
+    void onTrackingState(MessageBusMessage message) {
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+      final channelId = data['channel_id'] as int?;
+      if (channelId == null) return;
+      debugPrint('[ChatTracking] 频道 $channelId 已读状态同步');
+      if (ref.exists(chatChannelListProvider)) {
+        ref.read(chatChannelListProvider.notifier).applyUnreadUpdate(
+              channelId,
+              unreadCount: data['unread_count'] as int?,
+              unreadMentions: data['mention_count'] as int?,
+            );
+      }
+    }
+
+    const newChannelChannel = '/chat/new-channel';
+    final trackingChannel = '/chat/user-tracking-state/${currentUser.id}';
+
+    messageBus.subscribe(newChannelChannel, onNewChannel);
+    messageBus.subscribe(trackingChannel, onTrackingState);
+    _globalSubscriptions.add((newChannelChannel, onNewChannel));
+    _globalSubscriptions.add((trackingChannel, onTrackingState));
+
+    // 按当前频道列表动态增减 per-channel 订阅
+    final currentIds = channels.map((c) => c.id).toSet();
+    final removedIds = _channelSubscriptions.keys.where((id) => !currentIds.contains(id)).toList();
+    for (final id in removedIds) {
+      messageBus.unsubscribe('/chat/$id/new-messages', _channelSubscriptions.remove(id));
+    }
+
+    for (final chatChannel in channels) {
+      if (_channelSubscriptions.containsKey(chatChannel.id)) continue;
+      final channelId = chatChannel.id;
+      void onChannelMessage(MessageBusMessage message) {
+        final data = message.data;
+        if (data is! Map<String, dynamic> || data['type'] == 'thread') return;
+        final raw = data['message'] as Map<String, dynamic>?;
+        if (raw == null) return;
+        try {
+          final incoming = ChatMessage.fromJson(raw);
+          final isOwn = incoming.user?.username == currentUser.username;
+          if (ref.exists(chatChannelListProvider)) {
+            ref.read(chatChannelListProvider.notifier).applyIncomingMessage(
+                  channelId,
+                  incoming,
+                  isOwnMessage: isOwn,
+                );
+          }
+        } catch (e) {
+          debugPrint('[ChatTracking] 解析频道 $channelId 新消息失败: $e');
+        }
+      }
+
+      messageBus.subscribe('/chat/$channelId/new-messages', onChannelMessage);
+      _channelSubscriptions[channelId] = onChannelMessage;
+    }
+
+    ref.onDispose(() {
+      for (final (channel, callback) in _globalSubscriptions) {
+        messageBus.unsubscribe(channel, callback);
+      }
+      _globalSubscriptions.clear();
+      for (final entry in _channelSubscriptions.entries) {
+        messageBus.unsubscribe('/chat/${entry.key}/new-messages', entry.value);
+      }
+      _channelSubscriptions.clear();
+    });
+  }
+}
+
+final chatTrackingChannelProvider =
+    NotifierProvider.autoDispose<ChatTrackingChannelNotifier, void>(
+  ChatTrackingChannelNotifier.new,
+);
+
+/// DM 系统通知:订阅 `/chat/notification-alert/{userId}`(Discourse Chat
+/// 插件 `Jobs::Chat::NotifyWatching` 在对方"watching"这个频道时推送,payload
+/// 里已经有服务端拼好的标题/摘要,不用自己再拼)。本 app 通知列表/角标都
+/// 走的是普通 `/notification-alert/{userId}`,chat 是完全独立的一条推送
+/// 通道,必须单独订阅,不会自动出现在通知列表里。
+/// 常驻(非 autoDispose),由 main.dart 在用户登录后统一激活。
+class ChatNotificationAlertChannelNotifier extends Notifier<void> {
+  String? _subscribedChannel;
+  MessageBusCallback? _callback;
+
+  @override
+  void build() {
+    ref.watch(messageBusInitProvider);
+    final messageBus = ref.watch(messageBusServiceProvider);
+    final currentUser = ref.watch(currentUserProvider).value;
+
+    if (_subscribedChannel != null && _callback != null) {
+      messageBus.unsubscribe(_subscribedChannel!, _callback);
+      _subscribedChannel = null;
+      _callback = null;
+    }
+
+    if (currentUser == null) return;
+
+    final channel = '/chat/notification-alert/${currentUser.id}';
+
+    void onAlert(MessageBusMessage message) {
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+      debugPrint('[ChatNotificationAlert] 收到提醒: $data');
+
+      final username = data['username'] as String? ?? '';
+      final blockedUsernames = ref.read(preferencesProvider).normalizedBlockedUsernames;
+      if (BlockedUserFilter.isBlockedUsername(username, blockedUsernames)) return;
+
+      final channelId = data['channel_id'] as int?;
+      final title = data['translated_title'] as String? ?? username;
+      final body = data['excerpt'] as String? ?? '';
+
+      LocalNotificationService().show(
+        title: title,
+        body: body,
+        chatChannelId: channelId,
+      );
+    }
+
+    _subscribedChannel = channel;
+    _callback = onAlert;
+    messageBus.subscribe(channel, onAlert);
+
+    ref.onDispose(() {
+      if (_subscribedChannel != null && _callback != null) {
+        messageBus.unsubscribe(_subscribedChannel!, _callback);
+      }
+    });
+  }
+}
+
+final chatNotificationAlertChannelProvider =
+    NotifierProvider<ChatNotificationAlertChannelNotifier, void>(
+  ChatNotificationAlertChannelNotifier.new,
+);
+
+/// 单个 DM 频道的消息流:进入详情页加载历史消息 + 订阅频道内新消息,
+/// 离开页面(不再被引用)自动退订。
+/// 非 codegen 的 family AsyncNotifier 写法:参数通过构造函数传入并存成
+/// 字段,`build()` 不接收参数(对齐 riverpod 3 手写 API,而非 @riverpod 生成版)。
+class ChatMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
+  ChatMessagesNotifier(this.channelId);
+
+  final int channelId;
+
+  String? _subscribedChannel;
+  MessageBusCallback? _callback;
+  String? _subscribedRootChannel;
+  MessageBusCallback? _rootCallback;
+
+  @override
+  Future<List<ChatMessage>> build() async {
+    ref.watch(messageBusInitProvider);
+    final messageBus = ref.watch(messageBusServiceProvider);
+    final service = ref.read(discourseServiceProvider);
+
+    if (_subscribedChannel != null && _callback != null) {
+      messageBus.unsubscribe(_subscribedChannel!, _callback);
+      _subscribedChannel = null;
+      _callback = null;
+    }
+    if (_subscribedRootChannel != null && _rootCallback != null) {
+      messageBus.unsubscribe(_subscribedRootChannel!, _rootCallback);
+      _subscribedRootChannel = null;
+      _rootCallback = null;
+    }
+
+    final messages = await service.fetchChatMessages(
+      channelId,
+      fetchFromLastRead: true,
+    );
+    // 接口返回按时间倒序或正序取决于 fetch_from_last_read,统一按创建时间升序排列
+    final sorted = [...messages]
+      ..sort((a, b) => (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+
+    if (sorted.isNotEmpty) {
+      _markRead(sorted.last.id);
+    }
+
+    final channel = '/chat/$channelId/new-messages';
+    void onMessage(MessageBusMessage message) {
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+      // 核对过 Discourse 源码 Chat::Publisher#publish_new!:payload 是
+      // `{type: "channel"|"thread", channel_id, thread_id, message: <序列化后的消息>}`,
+      // 键名是 `message` 不是 `chat_message`;`type == "thread"` 时是子串消息,
+      // DM 场景不开线程,这里跳过以免误当主时间线消息插入。
+      if (data['type'] == 'thread') return;
+      final raw = data['message'] as Map<String, dynamic>?;
+      if (raw == null) return;
+      try {
+        final incoming = ChatMessage.fromJson(raw);
+        final current = state.value ?? const [];
+        if (current.any((m) => m.id == incoming.id)) return;
+        state = AsyncValue.data([...current, incoming]);
+        _markRead(incoming.id);
+      } catch (e) {
+        debugPrint('[ChatMessages] 解析新消息失败: $e');
+      }
+    }
+
+    _subscribedChannel = channel;
+    _callback = onMessage;
+    messageBus.subscribe(channel, onMessage);
+
+    // 表情回应走的是频道**根**频道(`/chat/{id}`),不是 new-messages 子
+    // 频道——核对过源码 Chat::Publisher#publish_reaction!→
+    // publish_to_targets!→calculate_publish_targets,非线程消息只发根频道。
+    final rootChannel = '/chat/$channelId';
+    void onRootMessage(MessageBusMessage message) {
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+
+      // 图片/附件消息发出时服务端异步"cook"(生成最终 HTML),首次广播
+      // 常常 cooked 还没算完;算完后走 `processed` 事件补发完整消息
+      // (核对过源码 Chat::Publisher#publish_processed!/publish_edit!/
+      // publish_restore!,统一走 `serialize_message_with_type`,payload
+      // 形状是 `{chat_message: {...完整字段...}, type: "processed"}`——
+      // 注意键名是 `chat_message` 不是 `message`,跟 new-messages 频道
+      // 那条不是一回事)。不接这个事件的话,图片/附件消息会一直停在
+      // "没有 cooked"的状态,表现为"收不到图片"。
+      if (data['type'] == 'processed' ||
+          data['type'] == 'edit' ||
+          data['type'] == 'restore') {
+        final raw = data['chat_message'] as Map<String, dynamic>?;
+        if (raw == null) return;
+        try {
+          final updated = ChatMessage.fromJson(raw);
+          final current = state.value ?? const [];
+          final index = current.indexWhere((m) => m.id == updated.id);
+          if (index == -1) return;
+          final next = [...current];
+          next[index] = updated;
+          state = AsyncValue.data(next);
+        } catch (e) {
+          debugPrint('[ChatMessages] 解析更新消息失败: $e');
+        }
+        return;
+      }
+
+      // 删除是软删除:标记 deletedAt 让气泡显示"(消息已删除)",不从列表移除
+      // (payload 核对过 publish_delete!:`{type:"delete", deleted_id, deleted_at, ...}`)。
+      if (data['type'] == 'delete') {
+        final deletedId = data['deleted_id'] as int?;
+        if (deletedId == null) return;
+        final current = state.value ?? const [];
+        final index = current.indexWhere((m) => m.id == deletedId);
+        if (index == -1) return;
+        final next = [...current];
+        next[index] = next[index].copyWith(deletedAt: DateTime.now());
+        state = AsyncValue.data(next);
+        return;
+      }
+
+      if (data['type'] != 'reaction') return;
+      final messageId = data['chat_message_id'] as int?;
+      final emoji = data['emoji'] as String?;
+      final action = data['action'] as String?;
+      final reactUser = data['user'] as Map<String, dynamic>?;
+      if (messageId == null || emoji == null || action == null) return;
+      final currentUsername = ref.read(currentUserProvider).value?.username;
+      final isSelf = reactUser?['username'] == currentUsername;
+      // 自己点的回应服务端也会广播回本频道(root channel 的推送是发给
+      // 全体成员的,不区分"是不是操作者本人")。[toggleReaction] 已经
+      // 乐观更新过一次了,这里再原样应用一次 add/remove 会把自己那份
+      // 计数重复叠加——两个人各点一次同一个表情,本该显示 2,结果显示 3
+      // 就是这么来的:一次自己的乐观 +1,一次自己动作的回声又 +1。
+      if (isSelf) return;
+      final current = state.value ?? const [];
+      final index = current.indexWhere((m) => m.id == messageId);
+      if (index == -1) return;
+      final target = current[index];
+      final reactions = [...target.reactions];
+      final reactionIndex = reactions.indexWhere((r) => r.emoji == emoji);
+      if (action == 'add') {
+        if (reactionIndex == -1) {
+          reactions.add(ChatReaction(emoji: emoji, count: 1, reacted: isSelf));
+        } else {
+          final old = reactions[reactionIndex];
+          reactions[reactionIndex] = ChatReaction(
+            emoji: emoji,
+            count: old.count + 1,
+            reacted: old.reacted || isSelf,
+          );
+        }
+      } else if (reactionIndex != -1) {
+        final old = reactions[reactionIndex];
+        final nextCount = old.count - 1;
+        if (nextCount <= 0) {
+          reactions.removeAt(reactionIndex);
+        } else {
+          reactions[reactionIndex] = ChatReaction(
+            emoji: emoji,
+            count: nextCount,
+            reacted: isSelf ? false : old.reacted,
+          );
+        }
+      }
+      final next = [...current];
+      next[index] = target.copyWithReactions(reactions);
+      state = AsyncValue.data(next);
+    }
+
+    _subscribedRootChannel = rootChannel;
+    _rootCallback = onRootMessage;
+    messageBus.subscribe(rootChannel, onRootMessage);
+
+    ref.onDispose(() {
+      if (_subscribedChannel != null && _callback != null) {
+        messageBus.unsubscribe(_subscribedChannel!, _callback);
+      }
+      if (_subscribedRootChannel != null && _rootCallback != null) {
+        messageBus.unsubscribe(_subscribedRootChannel!, _rootCallback);
+      }
+    });
+
+    return sorted;
+  }
+
+  /// 切换某条消息的表情回应:乐观更新本地列表,失败再改回来。
+  Future<void> toggleReaction(int messageId, String emoji) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final target = current[index];
+    final reactions = [...target.reactions];
+    final reactionIndex = reactions.indexWhere((r) => r.emoji == emoji);
+    final wasReacted = reactionIndex != -1 && reactions[reactionIndex].reacted;
+
+    final optimistic = [...reactions];
+    if (wasReacted) {
+      final old = optimistic[reactionIndex];
+      if (old.count <= 1) {
+        optimistic.removeAt(reactionIndex);
+      } else {
+        optimistic[reactionIndex] =
+            ChatReaction(emoji: emoji, count: old.count - 1, reacted: false);
+      }
+    } else if (reactionIndex == -1) {
+      optimistic.add(ChatReaction(emoji: emoji, count: 1, reacted: true));
+    } else {
+      final old = optimistic[reactionIndex];
+      optimistic[reactionIndex] =
+          ChatReaction(emoji: emoji, count: old.count + 1, reacted: true);
+    }
+
+    final next = [...current];
+    next[index] = target.copyWithReactions(optimistic);
+    state = AsyncValue.data(next);
+
+    if (!wasReacted) {
+      unawaited(ref.read(recentChatReactionsProvider.notifier).track(emoji));
+    }
+
+    try {
+      final service = ref.read(discourseServiceProvider);
+      await service.toggleChatReaction(channelId, messageId, emoji, add: !wasReacted);
+    } catch (e) {
+      debugPrint('[ChatMessages] 表情回应失败: $e');
+      final rollback = <ChatMessage>[...(state.value ?? const [])];
+      final rollbackIndex = rollback.indexWhere((m) => m.id == messageId);
+      if (rollbackIndex != -1) {
+        rollback[rollbackIndex] = target;
+        state = AsyncValue.data(rollback);
+      }
+    }
+  }
+
+  /// 本地更新某条消息的书签状态(创建/编辑/删除书签后同步 UI)。
+  void applyBookmark(int messageId, ChatBookmark? bookmark) {
+    final current = state.value;
+    if (current == null) return;
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final next = List<ChatMessage>.from(current);
+    next[index] = current[index].copyWith(
+      bookmark: bookmark,
+      clearBookmark: bookmark == null,
+    );
+    state = AsyncValue.data(next);
+  }
+
+  bool _loadingOlder = false;
+  bool _hasMoreOlder = true;
+
+  /// 往上翻加载更早的消息(以当前最早一条为锚点,direction=past)。
+  Future<void> loadOlder() async {
+    if (_loadingOlder || !_hasMoreOlder) return;
+    final current = state.value;
+    if (current == null || current.isEmpty) return;
+    _loadingOlder = true;
+    ref.read(chatLoadingOlderProvider(channelId).notifier).set(true);
+    try {
+      final service = ref.read(discourseServiceProvider);
+      final older = await service.fetchChatMessages(
+        channelId,
+        targetMessageId: current.first.id,
+        direction: 'past',
+      );
+      if (older.isEmpty) {
+        _hasMoreOlder = false;
+        return;
+      }
+      final existingIds = current.map((m) => m.id).toSet();
+      final fresh = older.where((m) => !existingIds.contains(m.id)).toList()
+        ..sort((a, b) =>
+            (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+      if (fresh.isEmpty) {
+        _hasMoreOlder = false;
+        return;
+      }
+      state = AsyncValue.data([...fresh, ...(state.value ?? current)]);
+    } catch (e) {
+      debugPrint('[ChatMessages] 加载更早消息失败: $e');
+    } finally {
+      _loadingOlder = false;
+      if (ref.exists(chatLoadingOlderProvider(channelId))) {
+        ref.read(chatLoadingOlderProvider(channelId).notifier).set(false);
+      }
+    }
+  }
+
+  /// 编辑一条消息:服务端保存后会通过根频道的 `edit` 事件把完整新消息
+  /// 推回来(build 里已接),这里不做乐观更新,失败直接抛给调用方提示。
+  Future<void> editMessage(int messageId, String text) async {
+    final service = ref.read(discourseServiceProvider);
+    await service.updateChatMessage(channelId, messageId, text);
+  }
+
+  /// 删除自己的消息:乐观标记为已删除,失败回滚。
+  Future<void> deleteMessage(int messageId) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final original = current[index];
+    final next = [...current];
+    next[index] = original.copyWith(deletedAt: DateTime.now());
+    state = AsyncValue.data(next);
+    try {
+      await ref.read(discourseServiceProvider).deleteChatMessage(channelId, messageId);
+    } catch (e) {
+      final rollback = <ChatMessage>[...(state.value ?? const [])];
+      final i = rollback.indexWhere((m) => m.id == messageId);
+      if (i != -1) {
+        rollback[i] = original;
+        state = AsyncValue.data(rollback);
+      }
+      rethrow;
+    }
+  }
+
+  /// 恢复被删除的消息(restore 事件会推回完整消息,这里只发请求)。
+  Future<void> restoreMessage(int messageId) async {
+    await ref.read(discourseServiceProvider).restoreChatMessage(channelId, messageId);
+  }
+
+  /// 置顶/取消置顶:乐观更新 pinned 标记,失败回滚。
+  Future<void> togglePinned(int messageId) async {
+    final current = state.value ?? const [];
+    final index = current.indexWhere((m) => m.id == messageId);
+    if (index == -1) return;
+    final original = current[index];
+    final nextPinned = !original.pinned;
+    final next = [...current];
+    next[index] = original.copyWith(pinned: nextPinned);
+    state = AsyncValue.data(next);
+    try {
+      await ref
+          .read(discourseServiceProvider)
+          .setChatMessagePinned(channelId, messageId, pinned: nextPinned);
+    } catch (e) {
+      final rollback = <ChatMessage>[...(state.value ?? const [])];
+      final i = rollback.indexWhere((m) => m.id == messageId);
+      if (i != -1) {
+        rollback[i] = original;
+        state = AsyncValue.data(rollback);
+      }
+      rethrow;
+    }
+  }
+
+  /// 详情页开着时读到新消息,顺手标记已读:服务端 + 本地频道列表未读数
+  /// 一起清零,不等下次整表刷新才把徽标降下去。fire-and-forget,失败不
+  /// 影响消息流本身的展示。
+  void _markRead(int messageId) {
+    final service = ref.read(discourseServiceProvider);
+    unawaited(service.markChatChannelRead(channelId, messageId).catchError((e) {
+      debugPrint('[ChatMessages] 标记已读失败: $e');
+    }));
+    if (ref.exists(chatChannelListProvider)) {
+      ref.read(chatChannelListProvider.notifier).markRead(channelId);
+    }
+  }
+}
+
+/// 最近使用过的快捷回应 emoji(最多 3 个)。对齐官方实现:网页端存
+/// localStorage(`emoji-store.js` 的 KeyValueStore),服务端不存,
+/// 这里对应地存 SharedPreferences。
+class RecentChatReactionsNotifier extends Notifier<List<String>> {
+  static const _prefsKey = 'chat_recent_reactions';
+  static const _defaults = ['+1', 'heart', 'joy'];
+
+  @override
+  List<String> build() {
+    unawaited(_load());
+    return _defaults;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getStringList(_prefsKey);
+    if (stored != null && stored.isNotEmpty) {
+      state = [...stored, ..._defaults.where((e) => !stored.contains(e))]
+          .take(3)
+          .toList();
+    }
+  }
+
+  Future<void> track(String emoji) async {
+    final next = [emoji, ...state.where((e) => e != emoji)].take(3).toList();
+    state = next;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(_prefsKey, next);
+  }
+}
+
+final recentChatReactionsProvider =
+    NotifierProvider<RecentChatReactionsNotifier, List<String>>(
+  RecentChatReactionsNotifier.new,
+);
+
+/// 单个消息串的消息流:加载历史 + 订阅本频道 new-messages 里
+/// type == "thread" 且 thread_id 匹配的推送。参数是 (channelId, threadId)。
+class ChatThreadMessagesNotifier extends AsyncNotifier<List<ChatMessage>> {
+  ChatThreadMessagesNotifier(this.arg);
+
+  final (int, int) arg;
+  int get channelId => arg.$1;
+  int get threadId => arg.$2;
+
+  String? _subscribedChannel;
+  MessageBusCallback? _callback;
+
+  @override
+  Future<List<ChatMessage>> build() async {
+    ref.watch(messageBusInitProvider);
+    final messageBus = ref.watch(messageBusServiceProvider);
+    final service = ref.read(discourseServiceProvider);
+
+    if (_subscribedChannel != null && _callback != null) {
+      messageBus.unsubscribe(_subscribedChannel!, _callback);
+      _subscribedChannel = null;
+      _callback = null;
+    }
+
+    final messages = await service.fetchChatThreadMessages(channelId, threadId);
+    final sorted = [...messages]
+      ..sort((a, b) =>
+          (a.createdAt ?? DateTime(0)).compareTo(b.createdAt ?? DateTime(0)));
+
+    unawaited(service.markChatThreadRead(channelId, threadId).catchError((_) {}));
+
+    final channel = '/chat/$channelId/new-messages';
+    void onMessage(MessageBusMessage message) {
+      final data = message.data;
+      if (data is! Map<String, dynamic>) return;
+      if (data['type'] != 'thread' || data['thread_id'] != threadId) return;
+      final raw = data['message'] as Map<String, dynamic>?;
+      if (raw == null) return;
+      try {
+        final incoming = ChatMessage.fromJson(raw);
+        final current = state.value ?? const [];
+        if (current.any((m) => m.id == incoming.id)) return;
+        state = AsyncValue.data([...current, incoming]);
+      } catch (e) {
+        debugPrint('[ChatThread] 解析线程新消息失败: $e');
+      }
+    }
+
+    _subscribedChannel = channel;
+    _callback = onMessage;
+    messageBus.subscribe(channel, onMessage);
+
+    ref.onDispose(() {
+      if (_subscribedChannel != null && _callback != null) {
+        messageBus.unsubscribe(_subscribedChannel!, _callback);
+      }
+    });
+
+    return sorted;
+  }
+}
+
+final chatThreadMessagesProvider = AsyncNotifierProvider.autoDispose
+    .family<ChatThreadMessagesNotifier, List<ChatMessage>, (int, int)>(
+  (arg) => ChatThreadMessagesNotifier(arg),
+);
+
+/// 某频道"正在向上加载更早消息"的 UI 状态,详情页顶部转圈用。
+class ChatLoadingOlderNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void set(bool value) => state = value;
+}
+
+final chatLoadingOlderProvider = NotifierProvider.autoDispose
+    .family<ChatLoadingOlderNotifier, bool, int>(
+  (channelId) => ChatLoadingOlderNotifier(),
+);
+
+final chatMessagesProvider = AsyncNotifierProvider.autoDispose
+    .family<ChatMessagesNotifier, List<ChatMessage>, int>(
+  (channelId) => ChatMessagesNotifier(channelId),
+);

--- a/lib/providers/message_bus_providers.dart
+++ b/lib/providers/message_bus_providers.dart
@@ -18,3 +18,6 @@ export 'message_bus/topic_tracking_providers.dart';
 
 // 导出话题频道 provider
 export 'message_bus/topic_channel_provider.dart';
+
+// 导出 Chat 插件 DM 相关 providers
+export 'message_bus/chat_providers.dart';

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -4,13 +4,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:uuid/uuid.dart';
+import '../models/category.dart';
+import '../pages/category_topics_page.dart';
+import '../pages/chat/dm_channel_detail_page.dart';
+import '../pages/tag_topics_page.dart';
+import '../pages/drafts_page.dart';
 import '../pages/settings_page.dart';
 import '../pages/user_profile_page.dart';
 import '../widgets/layout/auto_restore_master_detail_route.dart';
+import '../widgets/layout/home_workspace_scope.dart';
 
 /// 平行视界导航栈里一层的内容种类。栈里可以混插话题层和个人资料层
 /// （比如：话题 -> 点头像 -> 资料 -> 点资料里的链接 -> 另一个话题）。
-enum PaneKind { topic, profile, settings }
+enum PaneKind {
+  topic,
+  profile,
+  settings,
+  drafts,
+  trustLevelRequirements,
+  metaverse,
+  inviteLinks,
+  category,
+  tag,
+  chat,
+}
 
 /// 平行视界导航栈里的一层。
 class PaneEntry {
@@ -25,7 +42,12 @@ class PaneEntry {
     this.autoOpenReply = false,
     this.autoReplyToPostNumber,
   }) : kind = PaneKind.topic,
-       username = null;
+       username = null,
+       tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
 
   const PaneEntry.profile({required this.username})
     : kind = PaneKind.profile,
@@ -37,10 +59,144 @@ class PaneEntry {
       initialRevisionPostNumber = null,
       initialRevisionNumber = null,
       autoOpenReply = false,
-      autoReplyToPostNumber = null;
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  const PaneEntry.drafts()
+    : kind = PaneKind.drafts,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
 
   const PaneEntry.settings()
     : kind = PaneKind.settings,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  const PaneEntry.trustLevelRequirements()
+    : kind = PaneKind.trustLevelRequirements,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  const PaneEntry.metaverse()
+    : kind = PaneKind.metaverse,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  const PaneEntry.inviteLinks()
+    : kind = PaneKind.inviteLinks,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  /// 标签层。[tagName] 是**带 id 段的原串**(`1534-tag/1534`),请求路径
+  /// 直接用它,显示时经 `DiscourseUrlParser.tagDisplayName` 去掉 id。
+  const PaneEntry.tag({required String this.tagName, this.tagDisplayName})
+    : kind = PaneKind.tag,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      categoryId = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  const PaneEntry.category({required int this.categoryId})
+    : kind = PaneKind.category,
+      tagName = null,
+      tagDisplayName = null,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      chatChannelId = null,
+      chatTitle = null;
+
+  /// Chat 插件 DM 频道层。
+  const PaneEntry.chat({required int this.chatChannelId, this.chatTitle})
+    : kind = PaneKind.chat,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
       topicId = null,
       username = null,
       initialTitle = null,
@@ -54,6 +210,22 @@ class PaneEntry {
 
   final PaneKind kind;
   final int? topicId;
+
+  /// kind == category 时的分类 id(面板栈承载分类话题列表)
+  final int? categoryId;
+
+  /// kind == tag 时的标签(带 id 段的原串,请求路径用它)
+  final String? tagName;
+
+  /// 标签的显示名。中文标签的 URL 段是 Discourse 生成的 `<id>-tag`
+  /// slug,推不回真名 —— 从药丸锚文本带过来,只用于标题。
+  final String? tagDisplayName;
+
+  /// kind == chat 时的 DM 频道 id。
+  final int? chatChannelId;
+
+  /// DM 频道的显示名(对方昵称/用户名,或群聊标题)。
+  final String? chatTitle;
   final String? username;
   final String? initialTitle;
   final int? scrollToPostNumber;
@@ -309,10 +481,139 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     state = SelectedTopicState(stack: [PaneEntry.profile(username: username)]);
   }
 
+  /// 在 DM 频道列表里点开(切换)一个频道:清空栈重新开始,不是压栈。
+  /// 用户心智是"看列表里的另一项",跟 [select] 对话题列表的语义一致——
+  /// 每点一次列表项就多叠一层的话,栈会无限增长,`_buildMasterPane` 只
+  /// 处理得了"上一层"这一档,栈深超过 2 层后右栏该显示哪层就会错乱
+  /// (表现为标题跟高亮的列表项对不上、甚至右栏加载不出来)。
+  void selectChat(int channelId, {String? title}) {
+    state = SelectedTopicState(
+      stack: [PaneEntry.chat(chatChannelId: channelId, chatTitle: title)],
+    );
+  }
+
+  /// 打开分类话题列表——**兜底路径**,只在信息流展示不出来时用(多层平行
+  /// 视界、非首页宿主)。首选永远是把分类接到左栏信息流,见
+  /// [EmbeddedStackScope.openCategory]。
+  void pushCategory(int categoryId) {
+    state = SelectedTopicState(
+      stack: [...state.stack, PaneEntry.category(categoryId: categoryId)],
+    );
+  }
+
+  /// 打开标签话题列表——同 [pushCategory],兜底路径。
+  void pushTag(String tagName, {String? displayName}) {
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack,
+        PaneEntry.tag(tagName: tagName, tagDisplayName: displayName),
+      ],
+    );
+  }
+
+  /// 打开 DM 频道详情:压栈显示在右栏。
+  void pushChat(int channelId, {String? title}) {
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack,
+        PaneEntry.chat(chatChannelId: channelId, chatTitle: title),
+      ],
+    );
+  }
+
+  /// master 预览位里打开 DM 频道:截断栈顶后压入(顶替右栏)。
+  void pushChatTruncating(int channelId, {String? title}) {
+    if (state.stack.length < 2) {
+      pushChat(channelId, title: title);
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.chat(chatChannelId: channelId, chatTitle: title),
+      ],
+    );
+  }
+
+  void pushTagTruncating(String tagName, {String? displayName}) {
+    if (state.stack.length < 2) {
+      pushTag(tagName, displayName: displayName);
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.tag(tagName: tagName, tagDisplayName: displayName),
+      ],
+    );
+  }
+
+  /// master 预览位里打开分类:截断栈顶后压入(顶替右栏)。
+  void pushCategoryTruncating(int categoryId) {
+    if (state.stack.length < 2) {
+      pushCategory(categoryId);
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.category(categoryId: categoryId),
+      ],
+    );
+  }
+
+  /// 打开草稿列表：压栈显示在右栏。语义同 pushSettings ——
+  /// 草稿页是平行视界的一层内容，不是自成一套分栏。
+  void pushDrafts() {
+    // 草稿**占据**右栏，不是叠在别人上面：右边已经有话题时顶替掉它，
+    // 左边保持信息流/私信列表。所以整栈重置成单层草稿，而不是 append
+    // —— append 会让"栈里两个草稿"和"草稿压在话题上"两种烂状态都成立。
+    if (state.stack.length == 1 && state.stack.single.kind == PaneKind.drafts) {
+      return; // 已经就是它，别白重建一次状态
+    }
+    state = const SelectedTopicState(stack: [PaneEntry.drafts()]);
+  }
+
+  /// master 面板"上一层预览"里打开草稿：截断栈顶后压入。
+  void pushDraftsTruncating() {
+    if (state.stack.length < 2) {
+      pushDrafts();
+      return;
+    }
+    // 同 [pushDrafts]：草稿层唯一，截断后若下面还压着一个草稿就别再加
+    final kept = state.stack
+        .take(state.stack.length - 1)
+        .where((e) => e.kind != PaneKind.drafts);
+    state = SelectedTopicState(
+      stack: [...kept, const PaneEntry.drafts()],
+    );
+  }
+
   /// 打开设置：压栈，保留之前的层。
   void pushSettings() {
     state = SelectedTopicState(
       stack: [...state.stack, const PaneEntry.settings()],
+    );
+  }
+
+  /// 打开信任等级要求：压栈，保留之前的层。
+  void pushTrustLevelRequirements() {
+    state = SelectedTopicState(
+      stack: [...state.stack, const PaneEntry.trustLevelRequirements()],
+    );
+  }
+
+  /// 打开元宇宙：压栈，保留之前的层。
+  void pushMetaverse() {
+    state = SelectedTopicState(
+      stack: [...state.stack, const PaneEntry.metaverse()],
+    );
+  }
+
+  /// 打开邀请链接：压栈，保留之前的层。
+  void pushInviteLinks() {
+    state = SelectedTopicState(
+      stack: [...state.stack, const PaneEntry.inviteLinks()],
     );
   }
 
@@ -391,6 +692,18 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     );
   }
 
+  /// 抽掉栈中某一类层，其余层保持相对顺序。
+  ///
+  /// 草稿栏用:草稿全部处理完之后，草稿这一层要从栈里消失，但**右边的
+  /// 话题/私信必须留着** —— 所以不能用 pop(那会关掉栈顶的话题)。
+  /// 抽掉后 `[草稿, 话题]` 变成 `[话题]`，左栏自然退回信息流/私信列表。
+  void removeEntriesOfKind(PaneKind kind) {
+    if (!state.stack.any((e) => e.kind == kind)) return;
+    state = SelectedTopicState(
+      stack: state.stack.where((e) => e.kind != kind).toList(),
+    );
+  }
+
   void clear() {
     state = const SelectedTopicState();
   }
@@ -404,11 +717,39 @@ final selectedTopicProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
+/// DM 聊天列表的导航栈——跟私信各自独立(两套完全不同的后端体系),
+/// 语义同 [selectedMessageProvider]。
+final selectedChatProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
+
 /// 私信列表的导航栈——跟首页话题列表各自独立一份状态，切 tab 互不干扰，
 /// 但复用同一套 push/pop/select/clear 语义。
 final selectedMessageProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
+
+/// 把草稿和某条话题/私信一起放进栈：`[草稿, 内容]`。
+///
+/// 这是"处理草稿"的标准形态 —— 左栏草稿处理栏、右栏正在处理的那条。
+/// 处理完最后一条时 [SelectedTopicNotifier.removeEntriesOfKind] 抽掉草稿
+/// 层，栈剩 `[内容]`，左栏自然退回该内容对应的列表（信息流 / 私信列表）。
+extension DraftHandoff on SelectedTopicNotifier {
+  void openDraftTarget({
+    required int topicId,
+    int? scrollToPostNumber,
+    bool autoOpenReply = true,
+    int? autoReplyToPostNumber,
+  }) {
+    pushDrafts(); // 栈重置成 [草稿]
+    push(
+      topicId: topicId,
+      scrollToPostNumber: scrollToPostNumber,
+      autoOpenReply: autoOpenReply,
+      autoReplyToPostNumber: autoReplyToPostNumber,
+    ); // → [草稿, 内容]
+  }
+}
 
 /// 「我的」页右栏的平行视界栈。
 ///
@@ -597,6 +938,47 @@ class EmbeddedStackScope extends InheritedWidget {
     );
   }
 
+  /// 打开草稿列表的统一入口：嵌入面板里压栈（右栏显示草稿列表），
+  /// 不在就全屏 push。
+  static void openDrafts(BuildContext context) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushDraftsTruncating();
+      } else {
+        notifier.pushDrafts();
+      }
+      return;
+    }
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (_) => const DraftsPage()));
+  }
+
+  /// 打开 DM 频道详情的统一入口:嵌入面板里压栈显示平行视界(不在就全屏
+  /// push)。DM 详情不是信息流,没有 [openCategory]/[openTag] 那套"切换
+  /// 左栏"的窗口恢复复杂度,语义同 [openDrafts]/[openSettings]。
+  static void openChat(BuildContext context, int channelId, {String? title}) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushChatTruncating(channelId, title: title);
+      } else {
+        notifier.pushChat(channelId, title: title);
+      }
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DmChannelDetailPage(channelId: channelId, title: title),
+      ),
+    );
+  }
+
   /// 打开设置的统一入口：嵌入面板里压栈显示平行视界，不在就全屏 push。
   static void openSettings(BuildContext context) {
     final scope = _maybeScopeOf(context);
@@ -614,6 +996,79 @@ class EmbeddedStackScope extends InheritedWidget {
       context,
     ).push(MaterialPageRoute(builder: (_) => const SettingsPage()));
   }
+
+  /// 打开分类的统一入口。分类是**信息流**语义(跟标签同一档),优先级:
+  ///
+  /// 1. 能拿到首页左栏控制器、且当前不是多层平行视界 → 直接把左栏信息流
+  ///    切成该分类(右栏正在看的话题原样保留)。这是绝大多数情况。
+  /// 2. 多层平行视界 / 非首页宿主(私信、搜索栈…)展示不了信息流 →
+  ///    退化成右栏面板层。
+  /// 3. 完全不在平行视界里 → 全屏 push。
+  static void openCategory(BuildContext context, Category category) {
+    final scope = _maybeScopeOf(context);
+    final workspace = HomeWorkspaceScope.maybeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final stacked = container.read(scope.stackProvider).isStacked;
+      if (workspace != null && !stacked) {
+        workspace.onShowCategory(category);
+        return;
+      }
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushCategoryTruncating(category.id);
+      } else {
+        notifier.pushCategory(category.id);
+      }
+      return;
+    }
+    if (workspace != null) {
+      workspace.onShowCategory(category);
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => CategoryTopicsPage(category: category)),
+    );
+  }
+
+  /// 打开标签的统一入口,与 [openCategory] 同一档语义(标签也是信息流):
+  ///
+  /// 1. 拿得到首页左栏控制器、且不是多层平行视界 → 左栏信息流切成该标签。
+  /// 2. 多层平行视界 / 非首页宿主 → 退化成右栏面板层(同分类)。
+  /// 3. 完全不在平行视界里 → 全屏 push。
+  static void openTag(
+    BuildContext context,
+    String tag, {
+    String? displayName,
+  }) {
+    if (tag.isEmpty) return;
+    final scope = _maybeScopeOf(context);
+    final workspace = HomeWorkspaceScope.maybeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final stacked = container.read(scope.stackProvider).isStacked;
+      if (workspace != null && !stacked) {
+        workspace.onShowTag(tag);
+        return;
+      }
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushTagTruncating(tag, displayName: displayName);
+      } else {
+        notifier.pushTag(tag, displayName: displayName);
+      }
+      return;
+    }
+    if (workspace != null) {
+      workspace.onShowTag(tag);
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => TagTopicsPage(tagName: tag, displayName: displayName),
+      ),
+    );
+  }
 }
 
 typedef DetailScrollPositionKey = ({int topicId, String instanceId});
@@ -624,3 +1079,10 @@ typedef DetailScrollPositionKey = ({int topicId, String instanceId});
 /// topicId 会让同一话题的不同平行视界层互相覆盖位置。
 final detailScrollPositionProvider =
     StateProvider.family<int?, DetailScrollPositionKey>((ref, key) => null);
+
+// 注:试过再记一个"楼内像素偏移",定位完成后补上,想把位置还原得更准。
+// 探针实测补偿量算对、也执行了(delta=-187.5 → target=+187.5),但**画面
+// 照样跳** —— 残余跳动来自面板在 master/detail 槽位间搬动时**宽度变化**
+// 导致的正文重排(楼高全变,"楼内 187.5px"在新宽度下已指向别的内容)。
+// 补偿只是给结果再加一个偏移,治不了重排,反而让落点更飘。已撤除。
+// 真要修得从「宽度变化时按内容比例重定位」入手,不是加偏移量能解决的。

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -4,32 +4,15 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:uuid/uuid.dart';
-import '../models/category.dart';
-import '../pages/category_topics_page.dart';
 import '../pages/chat/dm_channel_detail_page.dart';
 import '../pages/chat/dm_thread_page.dart';
-import '../pages/tag_topics_page.dart';
-import '../pages/drafts_page.dart';
 import '../pages/settings_page.dart';
 import '../pages/user_profile_page.dart';
 import '../widgets/layout/auto_restore_master_detail_route.dart';
-import '../widgets/layout/home_workspace_scope.dart';
 
 /// 平行视界导航栈里一层的内容种类。栈里可以混插话题层和个人资料层
 /// （比如：话题 -> 点头像 -> 资料 -> 点资料里的链接 -> 另一个话题）。
-enum PaneKind {
-  topic,
-  profile,
-  settings,
-  drafts,
-  trustLevelRequirements,
-  metaverse,
-  inviteLinks,
-  category,
-  tag,
-  chat,
-  chatThread,
-}
+enum PaneKind { topic, profile, settings, chat, chatThread }
 
 /// 平行视界导航栈里的一层。
 class PaneEntry {
@@ -45,13 +28,10 @@ class PaneEntry {
     this.autoReplyToPostNumber,
   }) : kind = PaneKind.topic,
        username = null,
-       tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
+       chatChannelId = null,
+       chatTitle = null,
+       chatThreadId = null,
+       chatThreadTitle = null;
 
   const PaneEntry.profile({required this.username})
     : kind = PaneKind.profile,
@@ -64,29 +44,6 @@ class PaneEntry {
       initialRevisionNumber = null,
       autoOpenReply = false,
       autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  const PaneEntry.drafts()
-    : kind = PaneKind.drafts,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
       chatChannelId = null,
       chatTitle = null,
       chatThreadId = null,
@@ -94,108 +51,6 @@ class PaneEntry {
 
   const PaneEntry.settings()
     : kind = PaneKind.settings,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  const PaneEntry.trustLevelRequirements()
-    : kind = PaneKind.trustLevelRequirements,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  const PaneEntry.metaverse()
-    : kind = PaneKind.metaverse,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  const PaneEntry.inviteLinks()
-    : kind = PaneKind.inviteLinks,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  /// 标签层。[tagName] 是**带 id 段的原串**(`1534-tag/1534`),请求路径
-  /// 直接用它,显示时经 `DiscourseUrlParser.tagDisplayName` 去掉 id。
-  const PaneEntry.tag({required String this.tagName, this.tagDisplayName})
-    : kind = PaneKind.tag,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null,
-      categoryId = null,
-      chatChannelId = null,
-      chatTitle = null,
-      chatThreadId = null,
-      chatThreadTitle = null;
-
-  const PaneEntry.category({required int this.categoryId})
-    : kind = PaneKind.category,
-      tagName = null,
-      tagDisplayName = null,
       topicId = null,
       username = null,
       initialTitle = null,
@@ -214,9 +69,6 @@ class PaneEntry {
   /// Chat 插件 DM 频道层。
   const PaneEntry.chat({required int this.chatChannelId, this.chatTitle})
     : kind = PaneKind.chat,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
       topicId = null,
       username = null,
       initialTitle = null,
@@ -237,33 +89,20 @@ class PaneEntry {
     required int this.chatThreadId,
     this.chatThreadTitle,
   }) : kind = PaneKind.chatThread,
-      chatTitle = null,
-      tagName = null,
-      tagDisplayName = null,
-      categoryId = null,
-      topicId = null,
-      username = null,
-      initialTitle = null,
-      scrollToPostNumber = null,
-      instanceId = null,
-      highlightBoostUsername = null,
-      initialRevisionPostNumber = null,
-      initialRevisionNumber = null,
-      autoOpenReply = false,
-      autoReplyToPostNumber = null;
+       chatTitle = null,
+       topicId = null,
+       username = null,
+       initialTitle = null,
+       scrollToPostNumber = null,
+       instanceId = null,
+       highlightBoostUsername = null,
+       initialRevisionPostNumber = null,
+       initialRevisionNumber = null,
+       autoOpenReply = false,
+       autoReplyToPostNumber = null;
 
   final PaneKind kind;
   final int? topicId;
-
-  /// kind == category 时的分类 id(面板栈承载分类话题列表)
-  final int? categoryId;
-
-  /// kind == tag 时的标签(带 id 段的原串,请求路径用它)
-  final String? tagName;
-
-  /// 标签的显示名。中文标签的 URL 段是 Discourse 生成的 `<id>-tag`
-  /// slug,推不回真名 —— 从药丸锚文本带过来,只用于标题。
-  final String? tagDisplayName;
 
   /// kind == chat 时的 DM 频道 id。
   final int? chatChannelId;
@@ -542,25 +381,6 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     );
   }
 
-  /// 打开分类话题列表——**兜底路径**,只在信息流展示不出来时用(多层平行
-  /// 视界、非首页宿主)。首选永远是把分类接到左栏信息流,见
-  /// [EmbeddedStackScope.openCategory]。
-  void pushCategory(int categoryId) {
-    state = SelectedTopicState(
-      stack: [...state.stack, PaneEntry.category(categoryId: categoryId)],
-    );
-  }
-
-  /// 打开标签话题列表——同 [pushCategory],兜底路径。
-  void pushTag(String tagName, {String? displayName}) {
-    state = SelectedTopicState(
-      stack: [
-        ...state.stack,
-        PaneEntry.tag(tagName: tagName, tagDisplayName: displayName),
-      ],
-    );
-  }
-
   /// 打开 DM 频道详情:压栈显示在右栏。
   void pushChat(int channelId, {String? title}) {
     state = SelectedTopicState(
@@ -618,85 +438,10 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     );
   }
 
-  void pushTagTruncating(String tagName, {String? displayName}) {
-    if (state.stack.length < 2) {
-      pushTag(tagName, displayName: displayName);
-      return;
-    }
-    state = SelectedTopicState(
-      stack: [
-        ...state.stack.take(state.stack.length - 1),
-        PaneEntry.tag(tagName: tagName, tagDisplayName: displayName),
-      ],
-    );
-  }
-
-  /// master 预览位里打开分类:截断栈顶后压入(顶替右栏)。
-  void pushCategoryTruncating(int categoryId) {
-    if (state.stack.length < 2) {
-      pushCategory(categoryId);
-      return;
-    }
-    state = SelectedTopicState(
-      stack: [
-        ...state.stack.take(state.stack.length - 1),
-        PaneEntry.category(categoryId: categoryId),
-      ],
-    );
-  }
-
-  /// 打开草稿列表：压栈显示在右栏。语义同 pushSettings ——
-  /// 草稿页是平行视界的一层内容，不是自成一套分栏。
-  void pushDrafts() {
-    // 草稿**占据**右栏，不是叠在别人上面：右边已经有话题时顶替掉它，
-    // 左边保持信息流/私信列表。所以整栈重置成单层草稿，而不是 append
-    // —— append 会让"栈里两个草稿"和"草稿压在话题上"两种烂状态都成立。
-    if (state.stack.length == 1 && state.stack.single.kind == PaneKind.drafts) {
-      return; // 已经就是它，别白重建一次状态
-    }
-    state = const SelectedTopicState(stack: [PaneEntry.drafts()]);
-  }
-
-  /// master 面板"上一层预览"里打开草稿：截断栈顶后压入。
-  void pushDraftsTruncating() {
-    if (state.stack.length < 2) {
-      pushDrafts();
-      return;
-    }
-    // 同 [pushDrafts]：草稿层唯一，截断后若下面还压着一个草稿就别再加
-    final kept = state.stack
-        .take(state.stack.length - 1)
-        .where((e) => e.kind != PaneKind.drafts);
-    state = SelectedTopicState(
-      stack: [...kept, const PaneEntry.drafts()],
-    );
-  }
-
   /// 打开设置：压栈，保留之前的层。
   void pushSettings() {
     state = SelectedTopicState(
       stack: [...state.stack, const PaneEntry.settings()],
-    );
-  }
-
-  /// 打开信任等级要求：压栈，保留之前的层。
-  void pushTrustLevelRequirements() {
-    state = SelectedTopicState(
-      stack: [...state.stack, const PaneEntry.trustLevelRequirements()],
-    );
-  }
-
-  /// 打开元宇宙：压栈，保留之前的层。
-  void pushMetaverse() {
-    state = SelectedTopicState(
-      stack: [...state.stack, const PaneEntry.metaverse()],
-    );
-  }
-
-  /// 打开邀请链接：压栈，保留之前的层。
-  void pushInviteLinks() {
-    state = SelectedTopicState(
-      stack: [...state.stack, const PaneEntry.inviteLinks()],
     );
   }
 
@@ -775,18 +520,6 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
     );
   }
 
-  /// 抽掉栈中某一类层，其余层保持相对顺序。
-  ///
-  /// 草稿栏用:草稿全部处理完之后，草稿这一层要从栈里消失，但**右边的
-  /// 话题/私信必须留着** —— 所以不能用 pop(那会关掉栈顶的话题)。
-  /// 抽掉后 `[草稿, 话题]` 变成 `[话题]`，左栏自然退回信息流/私信列表。
-  void removeEntriesOfKind(PaneKind kind) {
-    if (!state.stack.any((e) => e.kind == kind)) return;
-    state = SelectedTopicState(
-      stack: state.stack.where((e) => e.kind != kind).toList(),
-    );
-  }
-
   void clear() {
     state = const SelectedTopicState();
   }
@@ -800,39 +533,17 @@ final selectedTopicProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
-/// DM 聊天列表的导航栈——跟私信各自独立(两套完全不同的后端体系),
-/// 语义同 [selectedMessageProvider]。
-final selectedChatProvider = SelectedTopicProvider((ref) {
-  return SelectedTopicNotifier();
-});
-
 /// 私信列表的导航栈——跟首页话题列表各自独立一份状态，切 tab 互不干扰，
 /// 但复用同一套 push/pop/select/clear 语义。
 final selectedMessageProvider = SelectedTopicProvider((ref) {
   return SelectedTopicNotifier();
 });
 
-/// 把草稿和某条话题/私信一起放进栈：`[草稿, 内容]`。
-///
-/// 这是"处理草稿"的标准形态 —— 左栏草稿处理栏、右栏正在处理的那条。
-/// 处理完最后一条时 [SelectedTopicNotifier.removeEntriesOfKind] 抽掉草稿
-/// 层，栈剩 `[内容]`，左栏自然退回该内容对应的列表（信息流 / 私信列表）。
-extension DraftHandoff on SelectedTopicNotifier {
-  void openDraftTarget({
-    required int topicId,
-    int? scrollToPostNumber,
-    bool autoOpenReply = true,
-    int? autoReplyToPostNumber,
-  }) {
-    pushDrafts(); // 栈重置成 [草稿]
-    push(
-      topicId: topicId,
-      scrollToPostNumber: scrollToPostNumber,
-      autoOpenReply: autoOpenReply,
-      autoReplyToPostNumber: autoReplyToPostNumber,
-    ); // → [草稿, 内容]
-  }
-}
+/// DM 聊天列表的导航栈——跟私信各自独立(两套完全不同的后端体系),
+/// 语义同 [selectedMessageProvider]。
+final selectedChatProvider = SelectedTopicProvider((ref) {
+  return SelectedTopicNotifier();
+});
 
 /// 「我的」页右栏的平行视界栈。
 ///
@@ -1021,28 +732,27 @@ class EmbeddedStackScope extends InheritedWidget {
     );
   }
 
-  /// 打开草稿列表的统一入口：嵌入面板里压栈（右栏显示草稿列表），
-  /// 不在就全屏 push。
-  static void openDrafts(BuildContext context) {
+  /// 打开设置的统一入口：嵌入面板里压栈显示平行视界，不在就全屏 push。
+  static void openSettings(BuildContext context) {
     final scope = _maybeScopeOf(context);
     if (scope != null) {
       final container = ProviderScope.containerOf(context, listen: false);
       final notifier = container.read(scope.stackProvider.notifier);
       if (scope.truncateOnPush) {
-        notifier.pushDraftsTruncating();
+        notifier.pushSettingsTruncating();
       } else {
-        notifier.pushDrafts();
+        notifier.pushSettings();
       }
       return;
     }
     Navigator.of(
       context,
-    ).push(MaterialPageRoute(builder: (_) => const DraftsPage()));
+    ).push(MaterialPageRoute(builder: (_) => const SettingsPage()));
   }
 
   /// 打开 DM 频道详情的统一入口:嵌入面板里压栈显示平行视界(不在就全屏
-  /// push)。DM 详情不是信息流,没有 [openCategory]/[openTag] 那套"切换
-  /// 左栏"的窗口恢复复杂度,语义同 [openDrafts]/[openSettings]。
+  /// push)。DM 详情不是信息流,没有 [openProfile] 那套"窄屏临时路由恢复"
+  /// 的复杂度,语义同 [openSettings]。
   static void openChat(BuildContext context, int channelId, {String? title}) {
     final scope = _maybeScopeOf(context);
     if (scope != null) {
@@ -1095,97 +805,6 @@ class EmbeddedStackScope extends InheritedWidget {
       ),
     );
   }
-
-  /// 打开设置的统一入口：嵌入面板里压栈显示平行视界，不在就全屏 push。
-  static void openSettings(BuildContext context) {
-    final scope = _maybeScopeOf(context);
-    if (scope != null) {
-      final container = ProviderScope.containerOf(context, listen: false);
-      final notifier = container.read(scope.stackProvider.notifier);
-      if (scope.truncateOnPush) {
-        notifier.pushSettingsTruncating();
-      } else {
-        notifier.pushSettings();
-      }
-      return;
-    }
-    Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (_) => const SettingsPage()));
-  }
-
-  /// 打开分类的统一入口。分类是**信息流**语义(跟标签同一档),优先级:
-  ///
-  /// 1. 能拿到首页左栏控制器、且当前不是多层平行视界 → 直接把左栏信息流
-  ///    切成该分类(右栏正在看的话题原样保留)。这是绝大多数情况。
-  /// 2. 多层平行视界 / 非首页宿主(私信、搜索栈…)展示不了信息流 →
-  ///    退化成右栏面板层。
-  /// 3. 完全不在平行视界里 → 全屏 push。
-  static void openCategory(BuildContext context, Category category) {
-    final scope = _maybeScopeOf(context);
-    final workspace = HomeWorkspaceScope.maybeOf(context);
-    if (scope != null) {
-      final container = ProviderScope.containerOf(context, listen: false);
-      final stacked = container.read(scope.stackProvider).isStacked;
-      if (workspace != null && !stacked) {
-        workspace.onShowCategory(category);
-        return;
-      }
-      final notifier = container.read(scope.stackProvider.notifier);
-      if (scope.truncateOnPush) {
-        notifier.pushCategoryTruncating(category.id);
-      } else {
-        notifier.pushCategory(category.id);
-      }
-      return;
-    }
-    if (workspace != null) {
-      workspace.onShowCategory(category);
-      return;
-    }
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => CategoryTopicsPage(category: category)),
-    );
-  }
-
-  /// 打开标签的统一入口,与 [openCategory] 同一档语义(标签也是信息流):
-  ///
-  /// 1. 拿得到首页左栏控制器、且不是多层平行视界 → 左栏信息流切成该标签。
-  /// 2. 多层平行视界 / 非首页宿主 → 退化成右栏面板层(同分类)。
-  /// 3. 完全不在平行视界里 → 全屏 push。
-  static void openTag(
-    BuildContext context,
-    String tag, {
-    String? displayName,
-  }) {
-    if (tag.isEmpty) return;
-    final scope = _maybeScopeOf(context);
-    final workspace = HomeWorkspaceScope.maybeOf(context);
-    if (scope != null) {
-      final container = ProviderScope.containerOf(context, listen: false);
-      final stacked = container.read(scope.stackProvider).isStacked;
-      if (workspace != null && !stacked) {
-        workspace.onShowTag(tag);
-        return;
-      }
-      final notifier = container.read(scope.stackProvider.notifier);
-      if (scope.truncateOnPush) {
-        notifier.pushTagTruncating(tag, displayName: displayName);
-      } else {
-        notifier.pushTag(tag, displayName: displayName);
-      }
-      return;
-    }
-    if (workspace != null) {
-      workspace.onShowTag(tag);
-      return;
-    }
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (_) => TagTopicsPage(tagName: tag, displayName: displayName),
-      ),
-    );
-  }
 }
 
 typedef DetailScrollPositionKey = ({int topicId, String instanceId});
@@ -1196,10 +815,3 @@ typedef DetailScrollPositionKey = ({int topicId, String instanceId});
 /// topicId 会让同一话题的不同平行视界层互相覆盖位置。
 final detailScrollPositionProvider =
     StateProvider.family<int?, DetailScrollPositionKey>((ref, key) => null);
-
-// 注:试过再记一个"楼内像素偏移",定位完成后补上,想把位置还原得更准。
-// 探针实测补偿量算对、也执行了(delta=-187.5 → target=+187.5),但**画面
-// 照样跳** —— 残余跳动来自面板在 master/detail 槽位间搬动时**宽度变化**
-// 导致的正文重排(楼高全变,"楼内 187.5px"在新宽度下已指向别的内容)。
-// 补偿只是给结果再加一个偏移,治不了重排,反而让落点更飘。已撤除。
-// 真要修得从「宽度变化时按内容比例重定位」入手,不是加偏移量能解决的。

--- a/lib/providers/selected_topic_provider.dart
+++ b/lib/providers/selected_topic_provider.dart
@@ -7,6 +7,7 @@ import 'package:uuid/uuid.dart';
 import '../models/category.dart';
 import '../pages/category_topics_page.dart';
 import '../pages/chat/dm_channel_detail_page.dart';
+import '../pages/chat/dm_thread_page.dart';
 import '../pages/tag_topics_page.dart';
 import '../pages/drafts_page.dart';
 import '../pages/settings_page.dart';
@@ -27,6 +28,7 @@ enum PaneKind {
   category,
   tag,
   chat,
+  chatThread,
 }
 
 /// 平行视界导航栈里的一层。
@@ -47,7 +49,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.profile({required this.username})
     : kind = PaneKind.profile,
@@ -64,7 +68,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.drafts()
     : kind = PaneKind.drafts,
@@ -82,7 +88,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.settings()
     : kind = PaneKind.settings,
@@ -100,7 +108,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.trustLevelRequirements()
     : kind = PaneKind.trustLevelRequirements,
@@ -118,7 +128,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.metaverse()
     : kind = PaneKind.metaverse,
@@ -136,7 +148,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.inviteLinks()
     : kind = PaneKind.inviteLinks,
@@ -154,7 +168,9 @@ class PaneEntry {
       tagDisplayName = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   /// 标签层。[tagName] 是**带 id 段的原串**(`1534-tag/1534`),请求路径
   /// 直接用它,显示时经 `DiscourseUrlParser.tagDisplayName` 去掉 id。
@@ -172,7 +188,9 @@ class PaneEntry {
       autoReplyToPostNumber = null,
       categoryId = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   const PaneEntry.category({required int this.categoryId})
     : kind = PaneKind.category,
@@ -189,11 +207,37 @@ class PaneEntry {
       autoOpenReply = false,
       autoReplyToPostNumber = null,
       chatChannelId = null,
-      chatTitle = null;
+      chatTitle = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
 
   /// Chat 插件 DM 频道层。
   const PaneEntry.chat({required int this.chatChannelId, this.chatTitle})
     : kind = PaneKind.chat,
+      tagName = null,
+      tagDisplayName = null,
+      categoryId = null,
+      topicId = null,
+      username = null,
+      initialTitle = null,
+      scrollToPostNumber = null,
+      instanceId = null,
+      highlightBoostUsername = null,
+      initialRevisionPostNumber = null,
+      initialRevisionNumber = null,
+      autoOpenReply = false,
+      autoReplyToPostNumber = null,
+      chatThreadId = null,
+      chatThreadTitle = null;
+
+  /// Chat 插件消息串(thread)层——挂在某个频道下的子对话流。
+  /// [chatChannelId] 是串所属的频道,不是可选项(串脱离频道没意义)。
+  const PaneEntry.chatThread({
+    required int this.chatChannelId,
+    required int this.chatThreadId,
+    this.chatThreadTitle,
+  }) : kind = PaneKind.chatThread,
+      chatTitle = null,
       tagName = null,
       tagDisplayName = null,
       categoryId = null,
@@ -226,6 +270,12 @@ class PaneEntry {
 
   /// DM 频道的显示名(对方昵称/用户名,或群聊标题)。
   final String? chatTitle;
+
+  /// kind == chatThread 时的消息串 id。
+  final int? chatThreadId;
+
+  /// 消息串的显示名。
+  final String? chatThreadTitle;
   final String? username;
   final String? initialTitle;
   final int? scrollToPostNumber;
@@ -531,6 +581,39 @@ class SelectedTopicNotifier extends StateNotifier<SelectedTopicState> {
       stack: [
         ...state.stack.take(state.stack.length - 1),
         PaneEntry.chat(chatChannelId: channelId, chatTitle: title),
+      ],
+    );
+  }
+
+  /// 打开消息串(thread):压栈显示在右栏。栈顶原有内容(频道本身,或
+  /// 频道里点开的话题/资料等)退到 master 预览位,不丢——退串就能回去。
+  void pushThread(int channelId, int threadId, {String? title}) {
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack,
+        PaneEntry.chatThread(
+          chatChannelId: channelId,
+          chatThreadId: threadId,
+          chatThreadTitle: title,
+        ),
+      ],
+    );
+  }
+
+  /// master 预览位里打开消息串:截断栈顶后压入(顶替右栏)。
+  void pushThreadTruncating(int channelId, int threadId, {String? title}) {
+    if (state.stack.length < 2) {
+      pushThread(channelId, threadId, title: title);
+      return;
+    }
+    state = SelectedTopicState(
+      stack: [
+        ...state.stack.take(state.stack.length - 1),
+        PaneEntry.chatThread(
+          chatChannelId: channelId,
+          chatThreadId: threadId,
+          chatThreadTitle: title,
+        ),
       ],
     );
   }
@@ -975,6 +1058,40 @@ class EmbeddedStackScope extends InheritedWidget {
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => DmChannelDetailPage(channelId: channelId, title: title),
+      ),
+    );
+  }
+
+  /// 打开消息串(thread)的统一入口。嵌入面板里(不管当前右栏是频道本身
+  /// 还是频道里点开的话题/资料等)一律压栈顶替显示,退出去再退回上一层
+  /// ——用户要的"右边没东西就顶到右栏,右边已经有东西就在当前平行视界
+  /// 里再压一层"两种情形,压栈语义本身就覆盖了(depth 1→2 时串顶替频道
+  /// 显示且频道退到 master 预览位;depth ≥2 时串再往上叠一层)。不在
+  /// 嵌入上下文里(窄屏/独立入口)就全屏 push。
+  static void openThread(
+    BuildContext context,
+    int channelId,
+    int threadId, {
+    String? title,
+  }) {
+    final scope = _maybeScopeOf(context);
+    if (scope != null) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final notifier = container.read(scope.stackProvider.notifier);
+      if (scope.truncateOnPush) {
+        notifier.pushThreadTruncating(channelId, threadId, title: title);
+      } else {
+        notifier.pushThread(channelId, threadId, title: title);
+      }
+      return;
+    }
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => DmThreadPage(
+          channelId: channelId,
+          threadId: threadId,
+          title: title,
+        ),
       ),
     );
   }

--- a/lib/services/discourse/_chat.dart
+++ b/lib/services/discourse/_chat.dart
@@ -1,0 +1,360 @@
+part of 'discourse_service.dart';
+
+/// Chat 插件直接消息(DM)相关
+mixin _ChatMixin on _DiscourseServiceBase {
+  /// 获取当前用户的 DM 频道列表
+  ///
+  /// 未读数不在每个频道对象的 `current_user_membership` 里(该 serializer
+  /// 只有 following/muted/last_read_message_id 等字段,没有 unread 相关
+  /// 字段——核对过 Discourse 源码 `BaseChannelMembershipSerializer`)。
+  /// 未读数是响应顶层独立的 `tracking` 表,按频道 id 映射
+  /// `{unread_count, mention_count}`(核对过 `Chat::ChannelFetcher.structured`
+  /// / `StructuredChannelSerializer`),这里手动合并进 membership 字段,
+  /// 让 [ChatChannel.fromJson] 不用感知这个分裂的响应结构。
+  Future<List<ChatChannel>> fetchChatChannels() async {
+    final response = await _dio.get('/chat/api/me/channels');
+    final data = response.data as Map<String, dynamic>;
+    // 已加入的公共频道 + DM 频道一起返回,UI 侧按 isDirectMessage 分组
+    final channels = [
+      ...(data['public_channels'] as List<dynamic>? ?? []),
+      ...(data['direct_message_channels'] as List<dynamic>? ?? []),
+    ];
+    final tracking = data['tracking'] as Map<String, dynamic>? ?? {};
+
+    return channels.map((e) {
+      final json = Map<String, dynamic>.from(e as Map<String, dynamic>);
+      final trackingInfo = tracking[json['id'].toString()] as Map<String, dynamic>?;
+      if (trackingInfo != null) {
+        final membership = Map<String, dynamic>.from(
+          json['current_user_membership'] as Map<String, dynamic>? ?? {},
+        );
+        membership['unread_count'] = trackingInfo['unread_count'];
+        membership['unread_mentions'] = trackingInfo['mention_count'];
+        json['current_user_membership'] = membership;
+      }
+      return ChatChannel.fromJson(json);
+    }).toList();
+  }
+
+  /// 浏览可加入的公共频道(`Chat::Api::ChannelsController#index`,
+  /// 支持 filter 关键词搜索,status 传 "open" 只看开放频道)。
+  Future<List<ChatChannel>> browsePublicChatChannels({
+    String? filter,
+    int limit = 25,
+    int offset = 0,
+  }) async {
+    final response = await _dio.get('/chat/api/channels', queryParameters: {
+      if (filter != null && filter.isNotEmpty) 'filter': filter,
+      'limit': limit,
+      'offset': offset,
+      'status': 'open',
+    });
+    final channels = response.data['channels'] as List<dynamic>? ?? [];
+    return channels
+        .map((e) => ChatChannel.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 加入(关注)一个公共频道
+  Future<void> joinChatChannel(int channelId) async {
+    await _dio.post('/chat/api/channels/$channelId/memberships/me');
+  }
+
+  /// 离开频道(`Chat::LeaveChannel`,DM 和公共频道都适用)
+  Future<void> leaveChatChannel(int channelId) async {
+    await _dio.delete('/chat/api/channels/$channelId/memberships/me');
+  }
+
+  /// 频道置顶消息列表(`Chat::Api::ChannelPinsController#index`,响应
+  /// `{pinned_messages: [{id, chat_message_id, pinned_at, pinned_by, message}]}`)。
+  Future<List<ChatMessage>> fetchChatChannelPins(int channelId) async {
+    final response = await _dio.get('/chat/api/channels/$channelId/pins');
+    final pins = response.data['pinned_messages'] as List<dynamic>? ?? [];
+    return pins
+        .map((e) => ChatMessage.fromJson(
+            (e as Map<String, dynamic>)['message'] as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 标记频道置顶列表已读(清掉"有新置顶"的小红点)
+  Future<void> markChatChannelPinsRead(int channelId) async {
+    await _dio.put('/chat/api/channels/$channelId/pins/read');
+  }
+
+  /// 消息串内的消息列表
+  Future<List<ChatMessage>> fetchChatThreadMessages(
+    int channelId,
+    int threadId, {
+    int pageSize = 50,
+    bool fetchFromLastRead = true,
+  }) async {
+    final response = await _dio.get(
+      '/chat/api/channels/$channelId/threads/$threadId/messages',
+      queryParameters: {
+        'page_size': pageSize,
+        if (fetchFromLastRead) 'fetch_from_last_read': true,
+      },
+    );
+    final messages = response.data['messages'] as List<dynamic>? ?? [];
+    return messages
+        .map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 标记消息串已读
+  Future<void> markChatThreadRead(int channelId, int threadId) async {
+    await _dio.put('/chat/api/channels/$channelId/threads/$threadId/read');
+  }
+
+  /// 频道成员列表(服务端分页 + 用户名搜索,常规频道几万人也不用全量拉,
+  /// `Chat::Api::ChannelsMembershipsController#index`,limit 上限 50)。
+  Future<List<MentionUser>> fetchChatChannelMembers(
+    int channelId, {
+    String? username,
+    int offset = 0,
+    int limit = 50,
+  }) async {
+    final response = await _dio.get(
+      '/chat/api/channels/$channelId/memberships',
+      queryParameters: {
+        if (username != null && username.isNotEmpty) 'username': username,
+        'offset': offset,
+        'limit': limit,
+      },
+    );
+    final memberships = response.data['memberships'] as List<dynamic>? ?? [];
+    return memberships
+        .map((e) => MentionUser.fromJson(
+            (e as Map<String, dynamic>)['user'] as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 全局/单频道搜索聊天消息(`Chat::SearchMessage`,响应里每条消息带
+  /// `channel` 字段)。
+  Future<List<ChatMessage>> searchChatMessages(
+    String query, {
+    int? channelId,
+    int limit = 20,
+    int offset = 0,
+    String sort = 'relevance', // relevance | latest
+  }) async {
+    final response = await _dio.get('/chat/api/search', queryParameters: {
+      'query': query,
+      'channel_id': ?channelId,
+      'limit': limit,
+      'offset': offset,
+      'sort': sort,
+    });
+    final messages = response.data['messages'] as List<dynamic>? ?? [];
+    return messages
+        .map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 给聊天消息加书签(走站点通用书签接口,类型 Chat::Message)
+  Future<int> bookmarkChatMessage(int messageId) async {
+    final response = await _dio.post('/bookmarks.json', data: {
+      'bookmarkable_id': messageId,
+      'bookmarkable_type': 'Chat::Message',
+    });
+    return response.data['id'] as int;
+  }
+
+  /// 发起或获取与某些用户的 DM 频道（已存在则复用，upsert 语义）
+  Future<ChatChannel> createOrGetDirectMessageChannel(List<String> usernames) async {
+    final response = await _dio.post('/chat/api/direct-message-channels', data: {
+      'target_usernames': usernames,
+      'upsert': true,
+    });
+    return ChatChannel.fromJson(response.data['channel'] as Map<String, dynamic>);
+  }
+
+  /// 获取某个频道的消息列表
+  Future<List<ChatMessage>> fetchChatMessages(
+    int channelId, {
+    int pageSize = 50,
+    int? targetMessageId,
+    String direction = 'past',
+    bool fetchFromLastRead = false,
+  }) async {
+    final queryParams = <String, dynamic>{'page_size': pageSize};
+    if (targetMessageId != null) {
+      queryParams['target_message_id'] = targetMessageId;
+      queryParams['direction'] = direction;
+    } else if (fetchFromLastRead) {
+      queryParams['fetch_from_last_read'] = true;
+    }
+    final response = await _dio.get(
+      '/chat/api/channels/$channelId/messages',
+      queryParameters: queryParams,
+    );
+    final messages = response.data['messages'] as List<dynamic>? ?? [];
+    return messages
+        .map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// 在频道内发送一条消息([threadId] 非空时发到指定消息串里)
+  Future<int> sendChatMessage(
+    int channelId,
+    String message, {
+    int? inReplyToId,
+    List<int>? uploadIds,
+    int? threadId,
+  }) async {
+    final data = <String, dynamic>{
+      'message': message,
+      'staged_id': DateTime.now().microsecondsSinceEpoch.toString(),
+    };
+    if (inReplyToId != null) data['in_reply_to_id'] = inReplyToId;
+    if (threadId != null) data['thread_id'] = threadId;
+    if (uploadIds != null && uploadIds.isNotEmpty) data['upload_ids'] = uploadIds;
+    // 路由表里这条是 Chat::Engine 的"顶层路由"`POST /:chat_channel_id`,
+    // 但引擎本身是 `mount ::Chat::Engine, at: "/chat"`(plugin.rb),所以
+    // 相对站点根其实是 `/chat/:channel_id`——之前当成裸的 `/:channelId`
+    // 发,404 了(找不到请求的 URL)。
+    final response = await _dio.post('/chat/$channelId', data: data);
+    return response.data['message_id'] as int;
+  }
+
+  /// 给消息加/取消一个表情回应。核对过 Discourse 源码
+  /// `Chat::ChatController#react` + `Chat::MessageReactor`:路由跟发消息
+  /// 那条一样是 Chat::Engine 的顶层路由(挂载在 `/chat` 下),
+  /// `emoji` 是不带冒号的裸名(如 `heart`),`react_action` 只认
+  /// `"add"`/`"remove"` 字符串。
+  Future<void> toggleChatReaction(
+    int channelId,
+    int messageId,
+    String emoji, {
+    required bool add,
+  }) async {
+    await _dio.put(
+      '/chat/$channelId/react/$messageId',
+      data: {
+        'message_id': messageId,
+        'emoji': emoji,
+        'react_action': add ? 'add' : 'remove',
+      },
+    );
+  }
+
+  /// 切换频道收藏状态。核对过 Discourse 源码
+  /// `Chat::UpdateUserChannelMembership`:任意频道(含 DM)都能收藏。
+  Future<void> setChatChannelStarred(int channelId, bool starred) async {
+    await _dio.put(
+      '/chat/api/channels/$channelId/memberships/me',
+      data: {'starred': starred},
+    );
+  }
+
+  /// 编辑一条消息。核对过源码 `Chat::UpdateMessage`:
+  /// `PUT /chat/api/channels/:channel_id/messages/:message_id`,
+  /// `message` 在 `upload_ids` 为空时必填。
+  Future<void> updateChatMessage(
+    int channelId,
+    int messageId,
+    String message, {
+    List<int>? uploadIds,
+  }) async {
+    final data = <String, dynamic>{'message': message};
+    if (uploadIds != null && uploadIds.isNotEmpty) data['upload_ids'] = uploadIds;
+    await _dio.put('/chat/api/channels/$channelId/messages/$messageId', data: data);
+  }
+
+  /// 删除自己的消息(软删除,可恢复)
+  Future<void> deleteChatMessage(int channelId, int messageId) async {
+    await _dio.delete('/chat/api/channels/$channelId/messages/$messageId');
+  }
+
+  /// 恢复被删除的消息
+  Future<void> restoreChatMessage(int channelId, int messageId) async {
+    await _dio.put('/chat/api/channels/$channelId/messages/$messageId/restore');
+  }
+
+  /// 举报一条消息。核对过源码 `Chat::FlagMessage`:
+  /// `flag_type_id` 取 `ReviewableScore.types` 的值
+  /// (off_topic=3, inappropriate=4, spam=8, notify_moderators=7),
+  /// `message` 仅 notify_moderators/notify_user 时用来附言。
+  Future<void> flagChatMessage(
+    int channelId,
+    int messageId,
+    int flagTypeId, {
+    String? message,
+  }) async {
+    final data = <String, dynamic>{'flag_type_id': flagTypeId};
+    if (message != null && message.isNotEmpty) data['message'] = message;
+    await _dio.post(
+      '/chat/api/channels/$channelId/messages/$messageId/flags',
+      data: data,
+    );
+  }
+
+  /// 置顶/取消置顶一条消息(站点需开 chat_pinned_messages)
+  Future<void> setChatMessagePinned(
+    int channelId,
+    int messageId, {
+    required bool pinned,
+  }) async {
+    final path = '/chat/api/channels/$channelId/messages/$messageId/pin';
+    if (pinned) {
+      await _dio.post(path);
+    } else {
+      await _dio.delete(path);
+    }
+  }
+
+  /// 静音/取消静音频道。核对过源码
+  /// `ChannelsCurrentUserNotificationsSettingsController`:参数必须包在
+  /// `notifications_settings` 里(`params.require(:notifications_settings)`)。
+  Future<void> setChatChannelMuted(int channelId, bool muted) async {
+    await _dio.put(
+      '/chat/api/channels/$channelId/notifications-settings/me',
+      data: {
+        'notifications_settings': {'muted': muted},
+      },
+    );
+  }
+
+  /// 设置频道通知级别(never=0 / mention=1 / always=2,对应
+  /// `Chat::UserChatChannelMembership::NOTIFICATION_LEVELS`)。
+  Future<void> setChatChannelNotificationLevel(int channelId, int level) async {
+    const names = {0: 'never', 1: 'mention', 2: 'always'};
+    await _dio.put(
+      '/chat/api/channels/$channelId/notifications-settings/me',
+      data: {
+        'notifications_settings': {'notification_level': names[level] ?? 'always'},
+      },
+    );
+  }
+
+  /// 开关频道"消息串"(threading)。核对过源码 `Chat::UpdateChannel`:
+  /// `PUT /chat/api/channels/:id`,参数是顶层 `threading_enabled`。
+  Future<void> setChatChannelThreadingEnabled(int channelId, bool enabled) async {
+    await _dio.put(
+      '/chat/api/channels/$channelId',
+      data: {'threading_enabled': enabled},
+    );
+  }
+
+  /// 标记单个频道已读到某条消息
+  Future<void> markChatChannelRead(int channelId, int messageId) async {
+    await _dio.put('/chat/api/channels/$channelId/read', data: {'message_id': messageId});
+  }
+
+  /// 标记所有 DM 频道已读
+  Future<void> markAllChatChannelsRead() async {
+    await _dio.put('/chat/api/channels/read');
+  }
+
+  /// AI 总结频道近期消息(discourse-ai 插件,未装插件/未开该功能时接口
+  /// 404,调用方需处理)。核对过源码 `DiscourseAi::Summarization::ChatSummaryController`:
+  /// `POST /discourse-ai/summarization/channels/:channel_id.json`,
+  /// `since` 只能是 [1,3,6,12,24,72,168](小时),返回 `{summary: String}`。
+  Future<String> summarizeChatChannel(int channelId, int sinceHours) async {
+    final response = await _dio.post(
+      '/discourse-ai/summarization/channels/$channelId.json',
+      data: {'since': sinceHours},
+    );
+    return (response.data as Map<String, dynamic>)['summary'] as String? ?? '';
+  }
+}

--- a/lib/services/discourse/_chat.dart
+++ b/lib/services/discourse/_chat.dart
@@ -327,13 +327,33 @@ mixin _ChatMixin on _DiscourseServiceBase {
     );
   }
 
-  /// 开关频道"消息串"(threading)。核对过源码 `Chat::UpdateChannel`:
-  /// `PUT /chat/api/channels/:id`,参数是顶层 `threading_enabled`。
+  /// 开关频道"消息串"(threading)。核对过源码 `Chat::Api::ChannelsController#update`:
+  /// `PUT /chat/api/channels/:id`,`params.require(:channel).permit(...)`——
+  /// 参数必须包在顶层 `channel` 键下面,不能拍平发。
   Future<void> setChatChannelThreadingEnabled(int channelId, bool enabled) async {
     await _dio.put(
       '/chat/api/channels/$channelId',
-      data: {'threading_enabled': enabled},
+      data: {
+        'channel': {'threading_enabled': enabled},
+      },
     );
+  }
+
+  /// 改群聊名称/缩略名(slug)/emoji 图标。核对过源码
+  /// `Chat::Api::ChannelsController::CHANNEL_EDITABLE_PARAMS`:
+  /// `name`/`description`/`slug`/`threading_enabled`/`emoji`,DM 群聊(非
+  /// category channel)这几个都能改,同一个 `PUT /chat/api/channels/:id`。
+  Future<void> updateChatChannel(
+    int channelId, {
+    String? name,
+    String? slug,
+    String? emoji,
+  }) async {
+    final channel = <String, dynamic>{};
+    if (name != null) channel['name'] = name;
+    if (slug != null) channel['slug'] = slug;
+    if (emoji != null) channel['emoji'] = emoji;
+    await _dio.put('/chat/api/channels/$channelId', data: {'channel': channel});
   }
 
   /// 标记单个频道已读到某条消息

--- a/lib/services/discourse/_presence.dart
+++ b/lib/services/discourse/_presence.dart
@@ -92,6 +92,26 @@ mixin _PresenceMixin on _DiscourseServiceBase {
     }
   }
 
+  /// 聊天在线用户 id 集合(对齐官方 `/chat/online` presence 频道初始快照)
+  Future<Set<int>> getChatOnlinePresence() async {
+    try {
+      final response = await _dio.get(
+        '/presence/get',
+        queryParameters: {'channels[]': '/chat/online'},
+      );
+      final data = response.data as Map<String, dynamic>;
+      final channelData = data['/chat/online'] as Map<String, dynamic>?;
+      final usersList = channelData?['users'] as List<dynamic>? ?? [];
+      return usersList
+          .map((u) => (u as Map<String, dynamic>)['id'] as int? ?? 0)
+          .where((id) => id > 0)
+          .toSet();
+    } catch (e) {
+      debugPrint('[DiscourseService] getChatOnlinePresence failed: $e');
+      return {};
+    }
+  }
+
   /// 获取预加载的话题追踪频道元数据
   Future<Map<String, dynamic>?> getPreloadedTopicTrackingMeta() async {
     final preloaded = PreloadedDataService();

--- a/lib/services/discourse/_uploads.dart
+++ b/lib/services/discourse/_uploads.dart
@@ -36,6 +36,9 @@ class ResolvedUploadUrl {
 
 /// 上传结果
 class UploadResult {
+  /// 上传记录主键。发帖走 Markdown 短链引用不需要它;Chat 插件发消息
+  /// 走 `upload_ids` 数组关联附件,只能靠这个 id,不认短链。
+  final int? id;
   final String shortUrl;
   final String? url;
   final String originalFilename;
@@ -48,6 +51,7 @@ class UploadResult {
   final String? extension;
 
   UploadResult({
+    this.id,
     required this.shortUrl,
     this.url,
     required this.originalFilename,
@@ -292,6 +296,7 @@ mixin _UploadsMixin on _DiscourseServiceBase {
           final shortUrl = data['short_url'] as String?;
           if (shortUrl != null) {
             return UploadResult(
+              id: data['id'] as int?,
               shortUrl: shortUrl,
               url: data['url'] as String?,
               originalFilename:
@@ -309,6 +314,7 @@ mixin _UploadsMixin on _DiscourseServiceBase {
           final url = data['url'] as String?;
           if (url != null) {
             return UploadResult(
+              id: data['id'] as int?,
               shortUrl: url,
               url: url,
               originalFilename:

--- a/lib/services/discourse/discourse_service.dart
+++ b/lib/services/discourse/discourse_service.dart
@@ -12,6 +12,8 @@ import '../../models/shared_issue.dart';
 import '../../models/user.dart';
 import '../../models/user_action.dart';
 import '../../models/notification.dart';
+import '../../models/chat/chat_channel.dart';
+import '../../models/chat/chat_message.dart';
 import '../../models/category.dart';
 import '../../models/search_result.dart';
 import '../../models/emoji.dart';
@@ -59,6 +61,7 @@ part '_posts.dart';
 part '_users.dart';
 part '_search.dart';
 part '_notifications.dart';
+part '_chat.dart';
 part '_uploads.dart';
 part '_voting.dart';
 part '_presence.dart';
@@ -124,6 +127,7 @@ class DiscourseService extends _DiscourseServiceBase
         _UsersMixin,
         _SearchMixin,
         _NotificationsMixin,
+        _ChatMixin,
         _UploadsMixin,
         _VotingMixin,
         _PresenceMixin,

--- a/lib/services/local_notification_service.dart
+++ b/lib/services/local_notification_service.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import '../l10n/s.dart';
+import '../navigation/nav_action_bus.dart';
+import '../pages/chat/dm_channel_detail_page.dart';
 import '../pages/topic_detail_page/topic_detail_page.dart';
 import '../utils/notification_navigation.dart';
 
@@ -65,8 +67,21 @@ class LocalNotificationService {
     final payload = response.payload;
     if (payload == null || payload.isEmpty) return;
 
-    // payload 格式: "topic:{topicId}[:{postNumber}]" 或
-    // "message:{topicId}[:{postNumber}]"(私信,走私信平行视界栈)。
+    // payload 格式: "topic:{topicId}[:{postNumber}]" /
+    // "message:{topicId}[:{postNumber}]"(私信,走私信平行视界栈) /
+    // "chat:{channelId}"(Chat 插件 DM,跟前两者是完全不同的实体,单独处理)。
+    if (payload.startsWith('chat:')) {
+      final channelId = int.tryParse(payload.substring(5));
+      if (channelId == null) return;
+      debugPrint('[LocalNotification] 跳转到 DM 频道: $channelId');
+      navigatorKey.currentState?.push(
+        MaterialPageRoute(
+          builder: (_) => DmChannelDetailPage(channelId: channelId),
+        ),
+      );
+      return;
+    }
+
     final isMessage = payload.startsWith('message:');
     if (!isMessage && !payload.startsWith('topic:')) return;
     final parts = payload.substring(isMessage ? 8 : 6).split(':');
@@ -118,6 +133,7 @@ class LocalNotificationService {
     int? topicId,
     int? postNumber,
     bool isPrivateMessage = false,
+    int? chatChannelId,
   }) async {
     if (!_initialized) {
       await initialize();
@@ -150,7 +166,9 @@ class LocalNotificationService {
     // 构建 payload 用于点击回调:私信用 message: 前缀,走私信自己的
     // 平行视界栈,不能跟普通话题共用 topic: 前缀(否则左栏会显示信息流)。
     String? payload;
-    if (topicId != null) {
+    if (chatChannelId != null) {
+      payload = 'chat:$chatChannelId';
+    } else if (topicId != null) {
       final prefix = isPrivateMessage ? 'message' : 'topic';
       payload = postNumber != null
           ? '$prefix:$topicId:$postNumber'

--- a/lib/services/message_bus_service.dart
+++ b/lib/services/message_bus_service.dart
@@ -703,7 +703,13 @@ class MessageBusService {
   void _deliverMessage(MessageBusMessage message) {
     final sub = _subscriptions[message.channel];
     if (sub != null) {
-      for (final callback in sub.callbacks) {
+      // 拷贝一份快照再遍历——回调内部经常触发 Riverpod notifier 重建,
+      // 同步走到 subscribe/unsubscribe 改到这同一个 sub.callbacks 列表,
+      // 直接遍历原列表会在改动的同一帧内炸 ConcurrentModificationError,
+      // 且这个异常发生在 _processChunk 的 try 块里,会把整个 chunk(可能
+      // 还带着其它频道的真消息)一起吞掉——表现就是"消息发过去了但对方
+      // 收不到/不实时"。
+      for (final callback in List<MessageBusCallback>.of(sub.callbacks)) {
         try {
           callback(message);
         } catch (e) {

--- a/lib/services/preloaded_data_service.dart
+++ b/lib/services/preloaded_data_service.dart
@@ -291,6 +291,14 @@ class PreloadedDataService {
   bool get signaturesFirstPostOnly =>
       _siteSettings?['signatures_first_post_only'] == true;
 
+  /// 公共频道消息保存天数（`chat_channel_retention_days`，默认 90）。
+  int get chatChannelRetentionDays =>
+      (_siteSettings?['chat_channel_retention_days'] as num?)?.toInt() ?? 90;
+
+  /// 私聊消息保存天数（`chat_dm_retention_days`，默认 0 = 无限期保留）。
+  int get chatDmRetentionDays =>
+      (_siteSettings?['chat_dm_retention_days'] as num?)?.toInt() ?? 0;
+
   /// 限定显示签名的分类 id 列表；空列表 = 不限分类。
   List<int> get signaturesShowInCategories {
     final raw = _siteSettings?['signatures_show_in_categories'] as String?;

--- a/lib/widgets/chat/chat_upload_view.dart
+++ b/lib/widgets/chat/chat_upload_view.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../constants.dart';
+import '../../models/chat/chat_message.dart';
+import '../../pages/image_viewer_page.dart';
+import '../common/cached_image.dart';
+
+/// 消息附带的上传文件:图片直接展示(限宽等比),其它文件画成附件卡片,
+/// 点击用系统方式打开源链接。图片/附件**不在** cooked HTML 里(官方
+/// `Chat::MessageSerializer` 单独给 `uploads` 数组,网页端也是正文下方
+/// 另行渲染),任何展示聊天消息正文的地方都要单独渲染这个,不能只信 cooked。
+class ChatUploadView extends StatelessWidget {
+  const ChatUploadView({super.key, required this.upload});
+
+  final ChatUpload upload;
+
+  String get _resolvedUrl {
+    final url = upload.url;
+    if (url.startsWith('//')) return 'https:$url';
+    if (url.startsWith('/')) return '${AppConstants.baseUrl}$url';
+    return url;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (upload.isImage) {
+      final width = upload.width;
+      final height = upload.height;
+      final aspect = (width != null && height != null && height > 0)
+          ? width / height
+          : null;
+      return GestureDetector(
+        onTap: () => ImageViewerPage.open(
+          context,
+          _resolvedUrl,
+          heroTag: 'chat_upload_${upload.id ?? upload.url}',
+          filenames: [upload.originalFilename],
+          enableShare: true,
+        ),
+        child: Hero(
+          tag: 'chat_upload_${upload.id ?? upload.url}',
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 320, maxHeight: 320),
+              child: aspect != null
+                  ? AspectRatio(
+                      aspectRatio: aspect,
+                      child: CachedImage(url: _resolvedUrl, fit: BoxFit.cover),
+                    )
+                  : CachedImage(url: _resolvedUrl, fit: BoxFit.contain),
+            ),
+          ),
+        ),
+      );
+    }
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => launchUrl(Uri.parse(_resolvedUrl),
+          mode: LaunchMode.externalApplication),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerLowest,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.attach_file_rounded, size: 18),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                upload.originalFilename ?? '附件',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(fontSize: 13),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/chat/group_channel_icon.dart
+++ b/lib/widgets/chat/group_channel_icon.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'reaction_chip.dart';
+
+/// 群聊自定义图标(表情):圆形底色 + 放大的 emoji,对齐"设为群图标"后
+/// 在列表/详情页头部替代默认头像的展示位置。
+class GroupChannelIcon extends StatelessWidget {
+  const GroupChannelIcon({super.key, required this.emoji, required this.radius});
+
+  final String emoji;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: radius * 2,
+      height: radius * 2,
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: ReactionEmoji(name: emoji, size: radius * 1.1),
+    );
+  }
+}

--- a/lib/widgets/chat/overlay_anchor.dart
+++ b/lib/widgets/chat/overlay_anchor.dart
@@ -1,0 +1,243 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+/// 悬浮/长按弹出的小气泡:贴在 [child] 正上方(左边或右边对齐)。
+///
+/// 不用 OverlayPortal/CompositedTransformFollower——这俩都会在这个 App
+/// 的平行视界 GlobalKey 子树搬迁(`_buildMasterPane`:频道详情整棵子树
+/// 在"占满右栏"和"退到 master 预览位"之间用同一个 GlobalKey 来回换插
+/// 槽)时炸雷:
+/// - CompositedTransformFollower 放在 OverlayPortal.overlayChildBuilder
+///   里,只在合成阶段才建立变换矩阵,layout 阶段读不到,断言
+///   "paint transform cannot be reliably computed"。
+/// - 换成 OverlayPortal.overlayChildLayoutBuilder 后触发另一个更深的
+///   坑:OverlayPortal 自己也有一套"overlay child 逻辑上还是这里的孩子,
+///   物理上搬到 Overlay 里"的 Element 搬迁机制,跟 GlobalKey 子树搬迁撞在
+///   同一帧,'_elements.contains(element)' 断言直接崩。
+///
+/// 改用最朴素的 `Overlay.of(context).insert(OverlayEntry(...))`:纯正常
+/// 的 RenderObject 树操作,不接管任何 Element 搬迁魔法,不跟
+/// `_buildMasterPane` 打架。位置用 `RenderBox.localToGlobal` 量一次
+/// (悬浮期间气泡本身不会动,不需要每帧跟踪)。
+class HoverPopupAnchor extends StatefulWidget {
+  const HoverPopupAnchor({
+    super.key,
+    required this.child,
+    required this.popupBuilder,
+    required this.alignRight,
+    this.gap = 8,
+    this.canShow,
+    this.estimatedWidth = 220,
+  });
+
+  final Widget child;
+  final Widget Function(BuildContext context, VoidCallback closePopup) popupBuilder;
+  final bool alignRight;
+  final double gap;
+  /// 返回 false 时不弹出(比如 reaction 没有 users 数据)
+  final bool Function()? canShow;
+  /// 弹层大概宽度,用来判断左对齐会不会超出屏幕右缘(自身消息靠右贴边
+  /// 时,`alignRight: false` 硬左对齐会把弹层怼出屏幕外)。不用精确值,
+  /// 够判断超没超就行。
+  final double estimatedWidth;
+
+  @override
+  State<HoverPopupAnchor> createState() => HoverPopupAnchorState();
+}
+
+class HoverPopupAnchorState extends State<HoverPopupAnchor> {
+  /// 同一时间全 App 只允许一个悬浮弹层开着——否则手速快的话可以在关闭
+  /// 延迟(250ms)内连续划过好几条消息,叠出一堆同时开着的弹层。
+  static HoverPopupAnchorState? _currentlyOpen;
+
+  OverlayEntry? _entry;
+  Timer? _closeTimer;
+  bool _pointerOverAnchor = false;
+  bool _pointerOverPopup = false;
+
+  @override
+  void dispose() {
+    _closeTimer?.cancel();
+    if (_currentlyOpen == this) _currentlyOpen = null;
+    _removeEntry();
+    super.dispose();
+  }
+
+  void _removeEntry() {
+    _entry?.remove();
+    _entry = null;
+  }
+
+  void _cancelClose() => _closeTimer?.cancel();
+
+  void _scheduleClose() {
+    _closeTimer?.cancel();
+    _closeTimer = Timer(const Duration(milliseconds: 250), () {
+      if (!mounted) return;
+      if (!_pointerOverAnchor && !_pointerOverPopup) {
+        if (_currentlyOpen == this) _currentlyOpen = null;
+        _removeEntry();
+      }
+    });
+  }
+
+  void open() {
+    if (_entry != null) return;
+    if (widget.canShow != null && !widget.canShow!()) return;
+    if (_currentlyOpen != null && _currentlyOpen != this) {
+      _currentlyOpen!.closeNow();
+    }
+    _currentlyOpen = this;
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return;
+    final overlay = Overlay.of(context);
+    final overlayBox = overlay.context.findRenderObject() as RenderBox?;
+    final topLeft = box.localToGlobal(Offset.zero, ancestor: overlayBox);
+    final size = box.size;
+    // 左对齐会超出屏幕右缘时(自身消息贴右边),改成右对齐——两边都超
+    // (窗口特别窄)就还是保留左对齐,总要选一个,不然逻辑打架。
+    final overlayWidth = overlayBox?.size.width ?? double.infinity;
+    final wouldOverflowRight = topLeft.dx + widget.estimatedWidth > overlayWidth;
+    final effectiveAlignRight = widget.alignRight || wouldOverflowRight;
+
+    _entry = OverlayEntry(
+      builder: (overlayCtx) => Positioned(
+        left: effectiveAlignRight ? null : topLeft.dx,
+        right: effectiveAlignRight
+            ? (overlayBox?.size.width ?? 0) - (topLeft.dx + size.width)
+            : null,
+        top: topLeft.dy,
+        child: FractionalTranslation(
+          translation: const Offset(0, -1),
+          child: Transform.translate(
+            offset: Offset(0, -widget.gap),
+            child: MouseRegion(
+              onEnter: (_) {
+                _pointerOverPopup = true;
+                _cancelClose();
+              },
+              onExit: (_) {
+                _pointerOverPopup = false;
+                _scheduleClose();
+              },
+              // 点悬浮条上任意一个按钮(比如"更多"打开底部菜单)之后,
+              // 悬浮条本身也该跟着收起,不然它会悬在打开的菜单/弹窗后面。
+              child: widget.popupBuilder(overlayCtx, closeNow),
+            ),
+          ),
+        ),
+      ),
+    );
+    overlay.insert(_entry!);
+  }
+
+  void closeNow() {
+    _closeTimer?.cancel();
+    if (_currentlyOpen == this) _currentlyOpen = null;
+    _removeEntry();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: (_) {
+        _pointerOverAnchor = true;
+        _cancelClose();
+        open();
+      },
+      onExit: (_) {
+        _pointerOverAnchor = false;
+        _scheduleClose();
+      },
+      child: widget.child,
+    );
+  }
+}
+
+/// 点击触发、贴在点击位置正上方(空间不够时自动翻到下方)的锚定弹层。
+/// 用于表情选择器这类"点了才开、选完/点外面/一滚动就该关"的场景——
+/// 不用 [showMenu]:它的 PopupMenuRoute 自带半透明遮罩(挡住背景整个区域,
+/// 看起来像一大片阴影)且只会挑"哪边放得下"而不是优先贴在按钮正上方。
+/// 这里手动 [OverlayEntry] 全权控制:无遮罩、显式上下优先、滚动监听里
+/// 直接关闭。
+Future<T?> showAnchoredPopup<T>({
+  required BuildContext context,
+  required BuildContext anchorContext,
+  required Widget Function(BuildContext ctx, void Function(T? result) close)
+      builder,
+  ScrollController? closeOnScroll,
+  double gap = 8,
+  double panelWidth = 340,
+  double panelHeight = 400,
+}) {
+  final btnBox = anchorContext.findRenderObject() as RenderBox?;
+  final overlay = Overlay.of(context);
+  final overlayBox = overlay.context.findRenderObject() as RenderBox?;
+  if (btnBox == null || !btnBox.hasSize || overlayBox == null) {
+    return Future.value(null);
+  }
+  final anchorTopLeft = btnBox.localToGlobal(Offset.zero, ancestor: overlayBox);
+  final anchorSize = btnBox.size;
+  final overlaySize = overlayBox.size;
+
+  final completer = Completer<T?>();
+  OverlayEntry? entry;
+  bool closed = false;
+
+  void close(T? result) {
+    if (closed) return;
+    closed = true;
+    entry?.remove();
+    if (!completer.isCompleted) completer.complete(result);
+  }
+
+  // 优先贴上方(悬浮条按钮上方够放才这么摆);上方空间不够就翻到下方。
+  final spaceAbove = anchorTopLeft.dy;
+  final placeAbove = spaceAbove >= panelHeight + gap;
+  final top = placeAbove
+      ? anchorTopLeft.dy - panelHeight - gap
+      : anchorTopLeft.dy + anchorSize.height + gap;
+
+  // 水平方向贴锚点左边对齐,超出屏幕右缘就整体左移贴屏幕边缘。
+  var left = anchorTopLeft.dx;
+  if (left + panelWidth > overlaySize.width) {
+    left = (overlaySize.width - panelWidth - 8).clamp(8, overlaySize.width);
+  }
+
+  void onScroll() => close(null);
+  closeOnScroll?.addListener(onScroll);
+
+  entry = OverlayEntry(
+    builder: (overlayCtx) => Stack(
+      children: [
+        // 透明点击外部关闭层
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => close(null),
+          ),
+        ),
+        Positioned(
+          left: left,
+          top: top.clamp(8, overlaySize.height - panelHeight - 8),
+          child: Material(
+            elevation: 4,
+            borderRadius: BorderRadius.circular(12),
+            clipBehavior: Clip.antiAlias,
+            child: SizedBox(
+              width: panelWidth,
+              height: panelHeight,
+              child: builder(overlayCtx, close),
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+  overlay.insert(entry);
+
+  completer.future.whenComplete(() {
+    closeOnScroll?.removeListener(onScroll);
+  });
+  return completer.future;
+}

--- a/lib/widgets/chat/reaction_chip.dart
+++ b/lib/widgets/chat/reaction_chip.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import '../../constants.dart';
+import '../../models/chat/chat_message.dart';
+import '../../services/emoji_handler.dart';
+import '../../services/discourse_cache_manager.dart';
+import '../common/smart_avatar.dart';
+import '../user/user_card.dart' show showUserCard;
+import 'overlay_anchor.dart';
+
+/// 聊天消息的表情回应气泡:桌面悬浮 / 移动长按弹出"谁回应了"列表。
+/// 对齐官方 `chat-message-reaction.gjs`:hover(桌面)/hold(移动)触发。
+class ReactionChip extends StatefulWidget {
+  const ReactionChip({
+    super.key,
+    required this.reaction,
+    required this.onTap,
+  });
+
+  final ChatReaction reaction;
+  final VoidCallback onTap;
+
+  @override
+  State<ReactionChip> createState() => _ReactionChipState();
+}
+
+class _ReactionChipState extends State<ReactionChip> {
+  final GlobalKey<HoverPopupAnchorState> _anchorKey = GlobalKey();
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final reaction = widget.reaction;
+
+    return HoverPopupAnchor(
+      key: _anchorKey,
+      alignRight: false,
+      gap: 8,
+      canShow: () => reaction.users.isNotEmpty,
+      popupBuilder: (context, closePopup) => SizedBox(
+        width: 220,
+        child: _ReactionUsersPopup(reaction: reaction),
+      ),
+      child: GestureDetector(
+        onLongPress: () {
+          _anchorKey.currentState?.open();
+          Future.delayed(const Duration(seconds: 3), () {
+            _anchorKey.currentState?.closeNow();
+          });
+        },
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: widget.onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+            decoration: BoxDecoration(
+              color: reaction.reacted
+                  ? scheme.primaryContainer
+                  : scheme.surfaceContainerHigh,
+              borderRadius: BorderRadius.circular(12),
+              border: reaction.reacted
+                  ? Border.all(color: scheme.primary, width: 1)
+                  : null,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ReactionEmoji(name: reaction.emoji, size: 14),
+                const SizedBox(width: 3),
+                Text('${reaction.count}', style: const TextStyle(fontSize: 12)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+
+class _ReactionUsersPopup extends StatelessWidget {
+  const _ReactionUsersPopup({required this.reaction});
+
+  final ChatReaction reaction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final users = reaction.users;
+    final extra = reaction.count - users.length;
+
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(10),
+      color: theme.colorScheme.surfaceContainerHigh,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final user in users)
+              Builder(
+                builder: (rowCtx) => InkWell(
+                  onTap: () {
+                    final box = rowCtx.findRenderObject() as RenderBox?;
+                    if (box == null || !box.hasSize) return;
+                    showUserCard(
+                      context: rowCtx,
+                      anchorRect: box.localToGlobal(Offset.zero) & box.size,
+                      username: user.username,
+                      nameFallback: user.name,
+                      avatarFallbackUrl:
+                          user.getAvatarUrl(AppConstants.baseUrl, size: 144),
+                    );
+                  },
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                    child: Row(
+                      children: [
+                        SmartAvatar(
+                          imageUrl:
+                              user.getAvatarUrl(AppConstants.baseUrl, size: 40),
+                          radius: 11,
+                          fallbackText: user.username,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            user.name?.isNotEmpty == true
+                                ? user.name!
+                                : user.username,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            if (extra > 0)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+                child: Text(
+                  '还有 $extra 人',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 表情图片,供聊天消息 reaction 相关组件共用
+class ReactionEmoji extends StatelessWidget {
+  const ReactionEmoji({super.key, required this.name, this.size = 16});
+
+  final String name;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image(
+      image: emojiImageProvider(EmojiHandler().getEmojiUrl(name)),
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      errorBuilder: (context, error, stack) => Text(
+        ':$name:',
+        style: TextStyle(fontSize: size * 0.6),
+      ),
+    );
+  }
+}

--- a/lib/widgets/common/smart_avatar.dart
+++ b/lib/widgets/common/smart_avatar.dart
@@ -17,6 +17,8 @@ class SmartAvatar extends StatefulWidget {
   final Color? backgroundColor;
   final Color? foregroundColor;
   final BoxBorder? border;
+  /// 对齐官方 chat-user-avatar 的 `.is-online` 描边:头像外缘一圈绿色。
+  final bool isOnline;
 
   const SmartAvatar({
     super.key,
@@ -26,6 +28,7 @@ class SmartAvatar extends StatefulWidget {
     this.backgroundColor,
     this.foregroundColor,
     this.border,
+    this.isOnline = false,
   });
 
   @override
@@ -286,6 +289,24 @@ class _SmartAvatarState extends State<SmartAvatar> {
       );
     }
 
+    if (widget.isOnline) {
+      avatar = Stack(
+        clipBehavior: Clip.none,
+        children: [
+          avatar,
+          Positioned.fill(
+            child: CustomPaint(
+              painter: _OnlineRingPainter(
+                isSquare: isSquare,
+                borderRadius: widget.radius * 0.2,
+                gapColor: theme.scaffoldBackgroundColor,
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
     return avatar;
   }
 
@@ -328,6 +349,64 @@ class _SmartAvatarState extends State<SmartAvatar> {
       child: Icon(Symbols.person_rounded, size: radius, color: fgColor),
     );
   }
+}
+
+/// 头像在线态描边:先铺一圈背景色留缝隙,再在最外缘描一圈绿色,
+/// 效果对齐官方 CSS `inset box-shadow: 1px var(--success), 2px var(--secondary)`。
+class _OnlineRingPainter extends CustomPainter {
+  const _OnlineRingPainter({
+    required this.isSquare,
+    required this.borderRadius,
+    required this.gapColor,
+  });
+
+  final bool isSquare;
+  final double borderRadius;
+  final Color gapColor;
+
+  static const Color _ringColor = Color(0xFF2ECC71);
+  static const double _ringWidth = 1.6;
+  static const double _gapWidth = 1.6;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final gapPaint = Paint()
+      ..color = gapColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _gapWidth * 2;
+    final ringPaint = Paint()
+      ..color = _ringColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _ringWidth;
+
+    final gapInset = _gapWidth;
+    final ringInset = _ringWidth / 2;
+
+    if (isSquare) {
+      final gapRect = Rect.fromLTWH(
+        gapInset, gapInset, size.width - gapInset * 2, size.height - gapInset * 2);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(gapRect, Radius.circular(borderRadius)),
+        gapPaint,
+      );
+      final ringRect = Rect.fromLTWH(
+        ringInset, ringInset, size.width - ringInset * 2, size.height - ringInset * 2);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(ringRect, Radius.circular(borderRadius)),
+        ringPaint,
+      );
+    } else {
+      final center = size.center(Offset.zero);
+      canvas.drawCircle(center, size.width / 2 - gapInset, gapPaint);
+      canvas.drawCircle(center, size.width / 2 - ringInset, ringPaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _OnlineRingPainter oldDelegate) =>
+      oldDelegate.isSquare != isSquare ||
+      oldDelegate.borderRadius != borderRadius ||
+      oldDelegate.gapColor != gapColor;
 }
 
 /// SVG 检测和渲染组件

--- a/lib/widgets/common/user_status_icon.dart
+++ b/lib/widgets/common/user_status_icon.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../models/mention_user.dart';
+import '../../services/discourse_cache_manager.dart';
+import '../../services/emoji_handler.dart';
+
+/// 用户自定义状态的小 emoji 图标:悬浮显示状态文字(Tooltip 对触屏长按
+/// 也生效);[onTap] 传 null 则纯展示不可点(列表行场景,避免手机上点
+/// 状态点不进私聊)。
+class UserStatusIcon extends StatelessWidget {
+  const UserStatusIcon({
+    super.key,
+    required this.status,
+    this.size = 14,
+    this.onTap,
+  });
+
+  final UserCustomStatus? status;
+  final double size;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final emoji = status?.emoji;
+    if (emoji == null || emoji.isEmpty) return const SizedBox.shrink();
+    final icon = Image(
+      image: emojiImageProvider(EmojiHandler().getEmojiUrl(emoji)),
+      width: size,
+      height: size,
+      fit: BoxFit.contain,
+      errorBuilder: (context, error, stack) => const SizedBox.shrink(),
+    );
+    final wrapped = Tooltip(
+      message: status?.description ?? '',
+      child: icon,
+    );
+    if (onTap == null) return wrapped;
+    return InkWell(
+      borderRadius: BorderRadius.circular(size),
+      onTap: onTap,
+      child: wrapped,
+    );
+  }
+}

--- a/lib/widgets/layout/pane_empty_state.dart
+++ b/lib/widgets/layout/pane_empty_state.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+/// 平行视界右栏空态占位(统一形态,语义由调用方给)。
+///
+/// 对齐搜索页 _buildParallelEmptyState 的做法:显式铺 scaffold 背景色,
+/// 否则空详情栏会透出 MaterialApp 默认 canvasColor,与左栏形成色断层。
+class PaneEmptyState extends StatelessWidget {
+  const PaneEmptyState({super.key, required this.icon, required this.hint});
+
+  final IconData icon;
+  final String hint;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ColoredBox(
+      color: theme.scaffoldBackgroundColor,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 56, color: theme.colorScheme.outlineVariant),
+            const SizedBox(height: 12),
+            Text(
+              hint,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/markdown_editor/emoji_sticker_panel.dart
+++ b/lib/widgets/markdown_editor/emoji_sticker_panel.dart
@@ -45,6 +45,11 @@ class EmojiStickerPanel extends StatefulWidget {
   /// 搜索面板并预填。
   final String? initialSearch;
 
+  /// 是否显示"表情包"页签。回应(reaction)场景表情包传不进
+  /// Discourse 的 react 接口,与其让用户点了才提示不支持,不如
+  /// 干脆不露出这个入口。
+  final bool showStickerTab;
+
   const EmojiStickerPanel({
     super.key,
     required this.onEmojiSelected,
@@ -54,6 +59,7 @@ class EmojiStickerPanel extends StatefulWidget {
     this.compact = false,
     this.onDismissRequested,
     this.initialSearch,
+    this.showStickerTab = true,
   });
 
   @override
@@ -90,12 +96,13 @@ class _EmojiStickerPanelState extends State<EmojiStickerPanel> {
           compact: widget.compact,
           initialSearch: widget.initialSearch,
         ),
-        StickerPicker(
-          onStickerSelected: widget.onStickerSelected,
-          bottomPadding: bottomPadding,
-          compact: widget.compact,
-          onDismissRequested: widget.onDismissRequested,
-        ),
+        if (widget.showStickerTab)
+          StickerPicker(
+            onStickerSelected: widget.onStickerSelected,
+            bottomPadding: bottomPadding,
+            compact: widget.compact,
+            onDismissRequested: widget.onDismissRequested,
+          ),
       ];
     }
     return _pages!;
@@ -153,8 +160,9 @@ class _EmojiStickerPanelState extends State<EmojiStickerPanel> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final safeBottom = MediaQuery.viewPaddingOf(context).bottom;
-    final tabHeight =
-        widget.compact ? floatingTabHeightCompact : floatingTabHeight;
+    final tabHeight = widget.showStickerTab
+        ? (widget.compact ? floatingTabHeightCompact : floatingTabHeight)
+        : 0.0;
     final totalBottomPadding = tabHeight + safeBottom;
 
     return Stack(
@@ -167,6 +175,9 @@ class _EmojiStickerPanelState extends State<EmojiStickerPanel> {
           },
           child: PageView(
             controller: _pageController,
+            physics: widget.showStickerTab
+                ? null
+                : const NeverScrollableScrollPhysics(),
             onPageChanged: (index) {
               setState(() {
                 _currentPage = index;
@@ -178,20 +189,22 @@ class _EmojiStickerPanelState extends State<EmojiStickerPanel> {
           ),
         ),
 
-        // 悬浮切换 Tab(紧凑模式桌面无安全区,补 6px 底距不贴边)
-        Positioned(
-          left: 0,
-          right: 0,
-          bottom: widget.compact ? safeBottom + 6 : safeBottom,
-          child: Center(
-            child: AnimatedSlide(
-              offset: _tabVisible ? Offset.zero : const Offset(0, 2),
-              duration: const Duration(milliseconds: 200),
-              curve: Curves.easeInOut,
-              child: _buildFloatingTab(context),
+        // 悬浮切换 Tab(紧凑模式桌面无安全区,补 6px 底距不贴边;只有
+        // 表情包页签存在时才需要切换 UI,否则单页无需 Tab)
+        if (widget.showStickerTab)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: widget.compact ? safeBottom + 6 : safeBottom,
+            child: Center(
+              child: AnimatedSlide(
+                offset: _tabVisible ? Offset.zero : const Offset(0, 2),
+                duration: const Duration(milliseconds: 200),
+                curve: Curves.easeInOut,
+                child: _buildFloatingTab(context),
+              ),
             ),
           ),
-        ),
 
         // 悬浮退格键(仅移动端,与 Tab 同层同显隐节奏,靠右)
         if (widget.onBackspace != null && PlatformUtils.isMobile)

--- a/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
+++ b/lib/widgets/markdown_editor/rich_composer/rich_composer_editor.dart
@@ -1639,6 +1639,40 @@ class RichComposerEditorState extends State<RichComposerEditor> {
     }
   }
 
+  /// 通用文件上传(插入菜单「上传文件」):不限类型,走通用
+  /// `uploadFile` 接口(不做 4MB 音视频前置检查/改名,站点扩展名白名单
+  /// 内的常见文档/压缩包直接原名上传),插入 Discourse 标准附件链接
+  /// 语法 `[文件名|attachment](upload://...) (大小)`,cook 后渲染成
+  /// 网页端同款的附件下载条。
+  Future<void> _pickAndInsertFile() async {
+    final picked = await FilePicker.platform.pickFiles();
+    final file = picked?.files.single;
+    final path = file?.path;
+    if (file == null || path == null || !mounted) return;
+    setState(() => _uploadingCount++);
+    try {
+      final uploadResult = await DiscourseService().uploadFile(path);
+      if (!mounted) return;
+      final size = uploadResult.humanFilesize;
+      final snippet = '[${uploadResult.originalFilename}|attachment]'
+          '(${uploadResult.shortUrl})'
+          '${size != null ? ' ($size)' : ''}';
+      await insertMarkdownSnippet(snippet);
+    } catch (e, s) {
+      if (mounted) {
+        final msg = e is Exception
+            ? e.toString().replaceFirst('Exception: ', '')
+            : '文件上传失败';
+        ScaffoldMessenger.maybeOf(context)
+            ?.showSnackBar(SnackBar(content: Text(msg)));
+      } else {
+        AppErrorHandler.handleUnexpected(e, s);
+      }
+    } finally {
+      if (mounted) setState(() => _uploadingCount--);
+    }
+  }
+
   /// 语音消息:录音面板 → 上传([wrap=voice] 语音条标签)→ 插入。
   Future<void> _recordAndInsertVoice() async {
     final path = await showVoiceRecorderSheet(context);
@@ -1777,6 +1811,7 @@ class RichComposerEditorState extends State<RichComposerEditor> {
         item('__audio__', Icons.audiotrack_rounded, '上传音频'),
         item('__video__', Icons.videocam_outlined, '上传视频'),
         item('__voice__', Icons.mic_rounded, '语音消息'),
+        item('__file__', Icons.attach_file_rounded, '上传文件'),
         const PopupMenuDivider(height: 8),
         // 用户自定义模板(与 MD 模式「模板」同一选择器,内容经 cook)
         item('__template__', Icons.assignment_outlined, '我的模板…'),
@@ -1792,6 +1827,8 @@ class RichComposerEditorState extends State<RichComposerEditor> {
       await _pickAndInsertMedia(isAudio: selected == '__audio__');
     } else if (selected == '__voice__') {
       await _recordAndInsertVoice();
+    } else if (selected == '__file__') {
+      await _pickAndInsertFile();
     } else if (selected == '__callout__') {
       await _insertCallout();
     } else if (selected == '__link__') {

--- a/lib/widgets/post/post_item/widgets/post_flag_sheet.dart
+++ b/lib/widgets/post/post_item/widgets/post_flag_sheet.dart
@@ -9,12 +9,18 @@ import '../../../../services/discourse/discourse_service.dart';
 import '../../../../services/toast_service.dart';
 import '../../../common/app_bottom_sheet.dart';
 
-/// 举报底部弹窗
+/// 举报底部弹窗(帖子/私信帖子通用;传 [chatChannelId]+[chatMessageId]
+/// 时切换为举报聊天消息,理由列表按 applies_to 里的 Chat::Message 过滤,
+/// 提交走 chat 插件的 flags 接口)。
 class PostFlagSheet extends StatefulWidget {
   final int postId;
   final String postUsername;
   final DiscourseService service;
   final VoidCallback? onSuccess;
+
+  /// 聊天消息举报模式:两者同时非空生效
+  final int? chatChannelId;
+  final int? chatMessageId;
 
   const PostFlagSheet({
     super.key,
@@ -22,7 +28,11 @@ class PostFlagSheet extends StatefulWidget {
     required this.postUsername,
     required this.service,
     this.onSuccess,
+    this.chatChannelId,
+    this.chatMessageId,
   });
+
+  bool get isChatMode => chatChannelId != null && chatMessageId != null;
 
   @override
   State<PostFlagSheet> createState() => _PostFlagSheetState();
@@ -64,7 +74,12 @@ class _PostFlagSheetState extends State<PostFlagSheet> {
           _flagTypes =
               types
                   .map((t) => FlagType.fromJson(t))
-                  .where((f) => f.isFlag && f.enabled && f.appliesToPost)
+                  .where((f) =>
+                      f.isFlag &&
+                      f.enabled &&
+                      (widget.isChatMode
+                          ? f.appliesToChatMessage
+                          : f.appliesToPost))
                   .toList()
                 ..sort((a, b) => a.position.compareTo(b.position));
         } else {
@@ -88,13 +103,24 @@ class _PostFlagSheetState extends State<PostFlagSheet> {
     setState(() => _isSubmitting = true);
 
     try {
-      await widget.service.flagPost(
-        widget.postId,
-        _selectedType!.id,
-        message: _messageController.text.isNotEmpty
-            ? _messageController.text
-            : null,
-      );
+      if (widget.isChatMode) {
+        await widget.service.flagChatMessage(
+          widget.chatChannelId!,
+          widget.chatMessageId!,
+          _selectedType!.id,
+          message: _messageController.text.isNotEmpty
+              ? _messageController.text
+              : null,
+        );
+      } else {
+        await widget.service.flagPost(
+          widget.postId,
+          _selectedType!.id,
+          message: _messageController.text.isNotEmpty
+              ? _messageController.text
+              : null,
+        );
+      }
 
       if (mounted) {
         Navigator.pop(context);
@@ -250,7 +276,26 @@ class _PostFlagSheetState extends State<PostFlagSheet> {
                   : theme.colorScheme.onSurfaceVariant,
             ),
             const SizedBox(width: 12),
-            Expanded(child: _buildDescriptionText(description, theme)),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // 举报项标题(之前只渲染了描述,标题一直缺失)
+                  if (type.name.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Text(
+                        // 标题同样可能带 %{username} 占位符,和描述走同一套替换
+                        _replaceDescription(type.name),
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  _buildDescriptionText(description, theme),
+                ],
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/widgets/user/user_card.dart
+++ b/lib/widgets/user/user_card.dart
@@ -462,6 +462,7 @@ class _UserCardContentState extends ConsumerState<_UserCardContent> {
 
   bool _isFollowed = false;
   bool _followLoading = false;
+  bool _chatLoading = false;
 
   // normal / mute / ignore
   String _notificationLevel = 'normal';
@@ -507,6 +508,31 @@ class _UserCardContentState extends ConsumerState<_UserCardContent> {
       postNumber: widget.postNumber,
       topicTitle: widget.topicTitle,
     );
+  }
+
+  /// 与"发消息"(传统 PM)是两套独立体系:这里对接 Chat 插件的 DM 频道,
+  /// 不复用 composeMessageToUser。发起/获取频道后直接进详情页。
+  Future<void> _openChat() async {
+    if (_chatLoading) return;
+    setState(() => _chatLoading = true);
+    final service = ref.read(discourseServiceProvider);
+    try {
+      final channel = await service.createOrGetDirectMessageChannel([widget.username]);
+      final anchorContext = widget.anchorContext;
+      if (!mounted || !anchorContext.mounted) return;
+      widget.onClose();
+      // 走统一入口:在平行视界嵌入面板里(卡片是从话题正文/信息流弹出的)
+      // 就压栈显示右栏,不在就全屏 push——跟点头像开资料卡同一套语义。
+      EmbeddedStackScope.openChat(
+        anchorContext,
+        channel.id,
+        title: _user?.name ?? widget.username,
+      );
+    } catch (e, s) {
+      if (mounted) AppErrorHandler.handleUnexpected(e, s);
+    } finally {
+      if (mounted) setState(() => _chatLoading = false);
+    }
   }
 
   Future<void> _toggleFollow() async {
@@ -956,6 +982,10 @@ class _UserCardContentState extends ConsumerState<_UserCardContent> {
       currentUserProvider.select((value) => value.value != null),
     );
     final canMessage = isLoggedIn && user?.canSendPrivateMessageToUser == true;
+    final currentUsername = ref.watch(
+      currentUserProvider.select((value) => value.value?.username),
+    );
+    final canChat = isLoggedIn && currentUsername != null && currentUsername != widget.username;
     final canFollow = isLoggedIn && user?.canFollow == true;
     final canMute = isLoggedIn && user?.canMuteUser == true;
     final canIgnore = isLoggedIn && user?.canIgnoreUser == true;
@@ -1009,6 +1039,20 @@ class _UserCardContentState extends ConsumerState<_UserCardContent> {
                 label: Text(S.current.userCard_viewProfile),
               ),
             ),
+            if (canChat) ...[
+              const SizedBox(width: 8),
+              IconButton.outlined(
+                onPressed: _chatLoading ? null : _openChat,
+                tooltip: '聊天',
+                icon: _chatLoading
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Symbols.chat_rounded, size: 18),
+              ),
+            ],
             if (canMute || canIgnore) ...[
               const SizedBox(width: 8),
               _buildMoreMenu(theme, canMute, canIgnore),


### PR DESCRIPTION
## Summary
dev 上原本没有私聊(Chat 插件 DM)功能,这个 PR 把它整体引入,并带上开发过程中修的一批问题:

**私聊功能本体**(频道列表/DM 分组 tab、频道浏览加入、置顶/星标/静音/消息串开关、成员查找、频道内+全局搜索、消息发送(文字/图片/文件/引用回复/编辑/撤回)、表情回应、书签、举报、消息串基础版、用户状态图标、个人资料卡片接入聊天入口、通知点击跳转、编辑器发送框工具栏)

**今天修的问题:**
- MessageBus 消息丢失(ConcurrentModificationError)+ 频道切换时两处 riverpod 生命周期崩溃
- 贴纸(表情包)伪上传:不占用 upload_ids,复用原 CDN 链接
- 消息串"N 条回复"胶囊改为头像+预览摘要卡片
- 悬浮回应面板超屏修复 + 点击弹用户资料卡
- 气泡宽度测量修复(贴纸/emoji/文字+贴纸组合)
- 在线状态圆环、频道列表头像/群聊图标、群聊已读设置请求体修复
- Spotify 等 oEmbed 类 onebox(裸 `<iframe>`,不含 `<aside class="onebox">`)解析丢失,依赖 fluxdo_render 子模块 PR Lingyan000/fluxdo_render#17,麻烦先看这个

**依赖补齐**(私聊代码实际引用到、但分散在其它不相关提交里的东西,已排除掉草稿列表接入平行视界等真正无关的部分,只补了私聊真正用到的最小集合):`PaneKind.chat`/`chatThread`、`pane_empty_state.dart`、子模块的可逆动作版修饰键判定导出。

## Test plan
- [x] 本地 `flutter build windows --debug` 通过
- [x] 多轮实机验证(未读、频道切换、贴纸发送、spotify onebox、悬浮面板、消息串)
- [ ] 子模块 Lingyan000/fluxdo_render#17 合并后需要重新验证一次子模块指针指向的 commit 在远端可解析