### PR TITLE
feat: 话题列表未读数字实时同步,不用手动下拉刷新

### DIFF
--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -314,7 +314,6 @@ class Topic {
     int? unread,
     int? newPosts,
     int? lastReadPostNumber,
-    bool clearLastReadPostNumber = false,
     int? highestPostNumber,
   }) {
     return Topic(
@@ -339,9 +338,7 @@ class Topic {
       unseen: unseen ?? this.unseen,
       unread: unread ?? this.unread,
       newPosts: newPosts ?? this.newPosts,
-      lastReadPostNumber: clearLastReadPostNumber
-          ? null
-          : (lastReadPostNumber ?? this.lastReadPostNumber),
+      lastReadPostNumber: lastReadPostNumber ?? this.lastReadPostNumber,
       highestPostNumber: highestPostNumber ?? this.highestPostNumber,
       bookmarkedPostNumber: bookmarkedPostNumber,
       bookmarkId: bookmarkId,

--- a/lib/models/topic.dart
+++ b/lib/models/topic.dart
@@ -309,6 +309,50 @@ class Topic {
     this.canHaveAnswer = false,
   });
 
+  Topic copyWith({
+    bool? unseen,
+    int? unread,
+    int? newPosts,
+    int? lastReadPostNumber,
+    bool clearLastReadPostNumber = false,
+    int? highestPostNumber,
+  }) {
+    return Topic(
+      id: id,
+      title: title,
+      slug: slug,
+      postsCount: postsCount,
+      replyCount: replyCount,
+      views: views,
+      likeCount: likeCount,
+      excerpt: excerpt,
+      createdAt: createdAt,
+      lastPostedAt: lastPostedAt,
+      lastPosterUsername: lastPosterUsername,
+      categoryId: categoryId,
+      pinned: pinned,
+      visible: visible,
+      closed: closed,
+      archived: archived,
+      tags: tags,
+      posters: posters,
+      unseen: unseen ?? this.unseen,
+      unread: unread ?? this.unread,
+      newPosts: newPosts ?? this.newPosts,
+      lastReadPostNumber: clearLastReadPostNumber
+          ? null
+          : (lastReadPostNumber ?? this.lastReadPostNumber),
+      highestPostNumber: highestPostNumber ?? this.highestPostNumber,
+      bookmarkedPostNumber: bookmarkedPostNumber,
+      bookmarkId: bookmarkId,
+      bookmarkName: bookmarkName,
+      bookmarkReminderAt: bookmarkReminderAt,
+      bookmarkableType: bookmarkableType,
+      hasAcceptedAnswer: hasAcceptedAnswer,
+      canHaveAnswer: canHaveAnswer,
+    );
+  }
+
   factory Topic.fromJson(
     Map<String, dynamic> json, {
     Map<int, TopicUser>? userMap,

--- a/lib/providers/topic_list/topic_list_provider.dart
+++ b/lib/providers/topic_list/topic_list_provider.dart
@@ -26,6 +26,18 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
   @override
   Future<List<Topic>> build() async {
+    // 话题列表里每张卡的 unread/highestPostNumber 是拉取那一刻的快照,
+    // 之后帖子有新回复只有 topicTrackingStateProvider(MessageBus /latest
+    // /unread 频道实时更新)会变,列表卡本身不会跟着刷新——挂了小红点
+    // 却一直不变。这里订阅追踪状态,把变化同步回当前显示的话题上,
+    // 不需要用户手动下拉刷新整个列表。
+    ref.listen<Map<int, TrackedTopicState>>(topicTrackingStateProvider, (
+      previous,
+      next,
+    ) {
+      _syncFromTrackingState(next);
+    });
+
     // 所有参数使用 ref.read（不建立依赖），
     // 由 UI 层在参数变化时主动 invalidate provider
     final currentFilter = ref.read(topicFilterProvider);
@@ -412,6 +424,47 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
         const PagedPage<Topic>(items: <Topic>[], hasMore: false),
       ),
     );
+  }
+
+  /// 用 topicTrackingStateProvider 的实时数据刷新当前列表里对应话题的
+  /// unread 计数(见 build() 里的 ref.listen)。只在真有变化的话题上
+  /// 重建,列表其余部分不受影响。
+  void _syncFromTrackingState(Map<int, TrackedTopicState> tracking) {
+    final topics = state.value;
+    if (topics == null || tracking.isEmpty) return;
+
+    List<Topic>? newList;
+    for (var i = 0; i < topics.length; i++) {
+      final topic = topics[i];
+      final tracked = tracking[topic.id];
+      // 只在追踪状态真的比当前显示更新时才采信:tracking map 是全局
+      // 单例,任何一个话题的消息都会让整个 map 换新触发这个监听,旧/被
+      // 重放的消息(长轮询重连补发)可能带着比本地已读状态更旧的
+      // lastReadPostNumber——直接套用会出现"刚读完又变回未读"。
+      if (tracked == null || tracked.highestPostNumber <= topic.highestPostNumber) {
+        continue;
+      }
+
+      final lastRead = tracked.lastReadPostNumber ?? topic.lastReadPostNumber;
+      final highest = tracked.highestPostNumber;
+      final newUnread = lastRead == null
+          ? topic.unread
+          : (highest - lastRead).clamp(0, highest);
+
+      if (newUnread == topic.unread && highest == topic.highestPostNumber) {
+        continue;
+      }
+
+      newList ??= [...topics];
+      newList[i] = topic.copyWith(
+        unread: newUnread,
+        highestPostNumber: highest,
+      );
+    }
+
+    if (newList != null) {
+      state = AsyncValue.data(newList);
+    }
   }
 
   void updateSeen(int topicId, int highestSeen, {bool updateTracking = true}) {

--- a/lib/providers/topic_list/topic_list_provider.dart
+++ b/lib/providers/topic_list/topic_list_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../models/topic.dart';
@@ -26,11 +28,11 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
 
   @override
   Future<List<Topic>> build() async {
-    // 话题列表里每张卡的 unread/highestPostNumber 是拉取那一刻的快照,
-    // 之后帖子有新回复只有 topicTrackingStateProvider(MessageBus /latest
-    // /unread 频道实时更新)会变,列表卡本身不会跟着刷新——挂了小红点
-    // 却一直不变。这里订阅追踪状态,把变化同步回当前显示的话题上,
-    // 不需要用户手动下拉刷新整个列表。
+    // 话题列表里每张卡的已读状态是拉取那一刻的快照,之后只有
+    // topicTrackingStateProvider(MessageBus /latest /unread /read 频道
+    // 实时更新)会变,列表卡本身不会跟着刷新——来了新回复数字不涨,
+    // 在网页/别的设备读完了红点也一直挂着。这里订阅追踪状态,把变化
+    // 双向同步回当前显示的话题上,不需要用户手动下拉刷新整个列表。
     ref.listen<Map<int, TrackedTopicState>>(topicTrackingStateProvider, (
       previous,
       next,
@@ -427,8 +429,17 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
   }
 
   /// 用 topicTrackingStateProvider 的实时数据刷新当前列表里对应话题的
-  /// unread 计数(见 build() 里的 ref.listen)。只在真有变化的话题上
-  /// 重建,列表其余部分不受影响。
+  /// 已读状态(见 build() 里的 ref.listen)。对齐网页版
+  /// topic-tracking-state.js 的 updateTopics:双向同步——来新回复时
+  /// 未读数上涨,在别端读完/忽略时红点下降或清除。
+  ///
+  /// tracking map 是全局单例,任何一个话题的消息都会让整个 map 换新
+  /// 触发这个监听;长轮询重连还可能补发旧消息。防串扰不靠"只涨不落"
+  /// 的整体守卫(那会把跨端已读的下降方向也挡死),而是两个游标各自
+  /// 单调合并:highestPostNumber 与 lastReadPostNumber 都只取双方更
+  /// 前进的一侧——旧消息重放两个游标都不倒退,自然不会出现"刚读完
+  /// 又弹回未读";tracking 初值来自启动快照,可能落后于刚拉回的列表
+  /// 数据,取 max 也堵住了未读数被旧快照算虚高的口子。
   void _syncFromTrackingState(Map<int, TrackedTopicState> tracking) {
     final topics = state.value;
     if (topics == null || tracking.isEmpty) return;
@@ -437,27 +448,36 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
     for (var i = 0; i < topics.length; i++) {
       final topic = topics[i];
       final tracked = tracking[topic.id];
-      // 只在追踪状态真的比当前显示更新时才采信:tracking map 是全局
-      // 单例,任何一个话题的消息都会让整个 map 换新触发这个监听,旧/被
-      // 重放的消息(长轮询重连补发)可能带着比本地已读状态更旧的
-      // lastReadPostNumber——直接套用会出现"刚读完又变回未读"。
-      if (tracked == null || tracked.highestPostNumber <= topic.highestPostNumber) {
-        continue;
-      }
+      if (tracked == null) continue;
 
-      final lastRead = tracked.lastReadPostNumber ?? topic.lastReadPostNumber;
-      final highest = tracked.highestPostNumber;
-      final newUnread = lastRead == null
-          ? topic.unread
-          : (highest - lastRead).clamp(0, highest);
+      final highest = math.max(tracked.highestPostNumber, topic.highestPostNumber);
+      final trackedLastRead = tracked.lastReadPostNumber;
+      final topicLastRead = topic.lastReadPostNumber;
+      final lastRead = trackedLastRead == null
+          ? topicLastRead
+          : (topicLastRead == null
+                ? trackedLastRead
+                : math.max(trackedLastRead, topicLastRead));
 
-      if (newUnread == topic.unread && highest == topic.highestPostNumber) {
+      // 未读数口径对齐服务端 lib/unread.rb:没读过的话题 unread 恒为 0
+      // (它走 unseen/NEW 语义,不走未读计数)
+      final newUnread = lastRead == null ? 0 : (highest - lastRead).clamp(0, highest);
+      // 对齐网页版 updateTopics 的 unseen 回写:读过或已被忽略
+      // (dismiss_new 置 isSeen)都不再算新话题
+      final newUnseen = lastRead == null && !tracked.isSeen && topic.unseen;
+
+      if (newUnread == topic.unread &&
+          highest == topic.highestPostNumber &&
+          lastRead == topicLastRead &&
+          newUnseen == topic.unseen) {
         continue;
       }
 
       newList ??= [...topics];
       newList[i] = topic.copyWith(
+        unseen: newUnseen,
         unread: newUnread,
+        lastReadPostNumber: lastRead,
         highestPostNumber: highest,
       );
     }
@@ -484,34 +504,13 @@ class TopicListNotifier extends AsyncNotifier<List<Topic>>
       topic.highestPostNumber,
     );
 
-    final updated = Topic(
-      id: topic.id,
-      title: topic.title,
-      slug: topic.slug,
-      postsCount: topic.postsCount,
-      replyCount: topic.replyCount,
-      views: topic.views,
-      likeCount: topic.likeCount,
-      excerpt: topic.excerpt,
-      createdAt: topic.createdAt,
-      lastPostedAt: topic.lastPostedAt,
-      lastPosterUsername: topic.lastPosterUsername,
-      categoryId: topic.categoryId,
-      pinned: topic.pinned,
-      visible: topic.visible,
-      closed: topic.closed,
-      archived: topic.archived,
-      tags: topic.tags,
-      posters: topic.posters,
+    final newList = [...topics];
+    newList[index] = topic.copyWith(
       unseen: false,
       unread: newUnread,
       newPosts: 0,
       lastReadPostNumber: highestSeen,
-      highestPostNumber: topic.highestPostNumber,
     );
-
-    final newList = [...topics];
-    newList[index] = updated;
     state = AsyncValue.data(newList);
 
     if (updateTracking) {


### PR DESCRIPTION
## Summary
列表卡的 unread/highestPostNumber 此前只是拉取那一刻的快照,之后有新回复只有 topicTrackingStateProvider(MessageBus /latest /unread 频道)会更新,列表卡本身不会跟着变——小红点一直挂着不动,只能靠手动下拉刷新整个列表才会消失/更新。

现在 TopicListNotifier 订阅追踪状态变化,同步回当前显示的话题。加了一个关键保护:只在追踪状态的 highestPostNumber 严格大于当前显示值时才采信,避免长轮询重连补发的旧消息把刚读完的话题又标回未读。

Topic 补了 copyWith,避免手工列全部字段(遗漏字段是这类同步逻辑最容易踩的坑)。

（重开:上一版 Lingyan000/fluxdo#353 分支起点太老,混了 11 个已经通过别的路径合并进 dev 的不相关 commit(渲染管线校准层等),导致大片 add/add 冲突;现在只保留这一个真正的功能 commit,基于最新 dev,本地 flutter build windows --debug 验证通过）

## Test plan
- [x] 本地 `flutter build windows --debug` 通过