### PR TITLE
增强 Android 预测式返回支持

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:label="FluxDO"
         android:name=".FluxdoApplication"
         android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -918,7 +918,6 @@ class _MainPageState extends ConsumerState<MainPage>
   Timer? _pendingSingleTap;
   List<NavEntry> _lastResolvedEntries = const [];
   Timer? _resumeDebounceTimer;
-  DateTime? _lastBackPressTime;
   bool _clipboardCheckInFlight = false;
 
   // 不能是 const，需要传入 isActive
@@ -1510,57 +1509,53 @@ class _MainPageState extends ConsumerState<MainPage>
         (activeEntryId == NavEntryIds.messages && messageParallelStacked) ||
         (activeEntryId == NavEntryIds.seeking && seekingParallelStacked);
 
-    // 首页的 FAB 由 TopicsScreen 内部处理，避免切换时闪烁
-    Widget page = PopScope(
-      canPop: false,
-      onPopInvokedWithResult: (bool didPop, dynamic result) {
-        if (didPop) return;
-        // 分类侧栏开着：返回=关抽屉。抽屉自身的 LocalHistoryEntry 在
-        // 根路由 canPop:false 下不生效（PopScope 的 doNotPop 判定
-        // 优先于 LocalHistoryRoute 的内部消费），只能在这里兜底。
-        if (CategoryDrawerHost.isOpen) {
-          CategoryDrawerHost.close();
-          return;
-        }
-        if (NotificationQuickPanel.isVisible) {
-          NotificationQuickPanel.dismiss();
-          return;
-        }
-        final now = DateTime.now();
-        if (_lastBackPressTime != null &&
-            now.difference(_lastBackPressTime!).inMilliseconds < 2000) {
-          SystemNavigator.pop();
-        } else {
-          _lastBackPressTime = now;
-          ToastService.showInfo(S.current.toast_pressAgainToExit);
-        }
-      },
-      child: AdaptiveScaffold(
-        selectedIndex: selectedBottomIndex,
-        onDestinationSelected: _onDestinationSelected,
-        destinations: destinations,
-        railBottomLeading: (user != null && !hasNotificationEntry)
-            ? const NotificationIconButton()
-            : null,
-        hideNavigationRail: hideNavigationRail,
-        body: IndexedStack(
-          index: safePageIndex,
-          children: [
-            for (int i = 0; i < pageEntries.length; i++)
-              KeyedSubtree(
-                key: ValueKey('nav-entry-${pageEntries[i].id}'),
-                child: TickerMode(
-                  enabled: safePageIndex == i,
-                  child: ExcludeFocus(
-                    excluding: safePageIndex != i,
-                    child: pageEntries[i].pageBuilder!(
-                      context,
-                      safePageIndex == i,
+    // 首页的 FAB 由 TopicsScreen 内部处理，避免切换时闪烁。
+    // 根路由允许系统处理 bubble，从而支持 Android 单次返回退出及其
+    // 预测式退出动画；需要优先关闭的面板仍通过 PopScope 拦截。
+    Widget page = ValueListenableBuilder<bool>(
+      valueListenable: NotificationQuickPanel.visible,
+      builder: (context, notificationPanelVisible, _) => PopScope(
+        canPop: !notificationPanelVisible,
+        onPopInvokedWithResult: (bool didPop, dynamic result) {
+          if (didPop) return;
+          // 分类侧栏通过 LocalHistoryEntry 消费返回；这里保留兜底，覆盖
+          // 抽屉正在收尾动画等 LocalHistory 尚未同步的短暂状态。
+          if (CategoryDrawerHost.isOpen) {
+            CategoryDrawerHost.close();
+            return;
+          }
+          if (NotificationQuickPanel.isVisible) {
+            NotificationQuickPanel.dismiss();
+            return;
+          }
+        },
+        child: AdaptiveScaffold(
+          selectedIndex: selectedBottomIndex,
+          onDestinationSelected: _onDestinationSelected,
+          destinations: destinations,
+          railBottomLeading: (user != null && !hasNotificationEntry)
+              ? const NotificationIconButton()
+              : null,
+          hideNavigationRail: hideNavigationRail,
+          body: IndexedStack(
+            index: safePageIndex,
+            children: [
+              for (int i = 0; i < pageEntries.length; i++)
+                KeyedSubtree(
+                  key: ValueKey('nav-entry-${pageEntries[i].id}'),
+                  child: TickerMode(
+                    enabled: safePageIndex == i,
+                    child: ExcludeFocus(
+                      excluding: safePageIndex != i,
+                      child: pageEntries[i].pageBuilder!(
+                        context,
+                        safePageIndex == i,
+                      ),
                     ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/pages/image_viewer_page.dart
+++ b/lib/pages/image_viewer_page.dart
@@ -26,6 +26,7 @@ import '../utils/share_utils.dart';
 import '../widgets/common/app_bottom_sheet.dart';
 import '../widgets/common/hero_image.dart';
 import '../widgets/common/image_context_menu.dart';
+import '../widgets/common/predictive_back_cupertino_transitions.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 import '../l10n/s.dart';
 
@@ -128,12 +129,17 @@ class ImageViewerPage extends ConsumerStatefulWidget {
             heroSourceCircular: heroSourceCircular,
           );
         },
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return FadeTransition(
-            opacity: _routeFadeAnimation(animation),
-            child: child,
-          );
-        },
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            buildPredictiveBackPageTransitions(
+              context,
+              animation,
+              secondaryAnimation,
+              child,
+              fallbackBuilder: (_, animation, _, child) => FadeTransition(
+                opacity: _routeFadeAnimation(animation),
+                child: child,
+              ),
+            ),
       ),
     );
   }
@@ -148,12 +154,17 @@ class ImageViewerPage extends ConsumerStatefulWidget {
         pageBuilder: (context, animation, secondaryAnimation) {
           return ImageViewerPage(imageBytes: bytes);
         },
-        transitionsBuilder: (context, animation, secondaryAnimation, child) {
-          return FadeTransition(
-            opacity: _routeFadeAnimation(animation),
-            child: child,
-          );
-        },
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            buildPredictiveBackPageTransitions(
+              context,
+              animation,
+              secondaryAnimation,
+              child,
+              fallbackBuilder: (_, animation, _, child) => FadeTransition(
+                opacity: _routeFadeAnimation(animation),
+                child: child,
+              ),
+            ),
       ),
     );
   }

--- a/lib/pages/mermaid_viewer_page.dart
+++ b/lib/pages/mermaid_viewer_page.dart
@@ -4,6 +4,7 @@ import 'package:app_icons/app_icons.dart';
 import 'package:m3e_ui/m3e_ui.dart';
 
 import '../l10n/s.dart';
+import '../widgets/common/predictive_back_cupertino_transitions.dart';
 import 'image_viewer_page.dart';
 
 /// Mermaid 矢量查看页 —— WebView 顶级文档加载 kroki SVG。
@@ -69,8 +70,15 @@ class _MermaidViewerPageState extends State<MermaidViewerPage> {
           imageUrl: widget.fallbackImageUrl,
           enableShare: true,
         ),
-        transitionsBuilder: (_, animation, _, child) =>
-            FadeTransition(opacity: animation, child: child),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            buildPredictiveBackPageTransitions(
+              context,
+              animation,
+              secondaryAnimation,
+              child,
+              fallbackBuilder: (_, animation, _, child) =>
+                  FadeTransition(opacity: animation, child: child),
+            ),
       ),
     );
   }

--- a/lib/pages/topics_page.dart
+++ b/lib/pages/topics_page.dart
@@ -47,6 +47,7 @@ import '../widgets/layout/master_detail_layout.dart';
 import '../widgets/common/error_view.dart';
 import '../widgets/common/loading_dialog.dart';
 import '../widgets/common/fading_edge_scroll_view.dart';
+import '../widgets/common/predictive_back_cupertino_transitions.dart';
 import '../widgets/offline_indicator.dart';
 import '../l10n/s.dart';
 import '../models/shortcut_binding.dart';
@@ -1320,8 +1321,15 @@ class _TopicsPageState extends ConsumerState<TopicsPage>
         reverseTransitionDuration: const Duration(milliseconds: 280),
         pageBuilder: (_, _, _) =>
             SearchPage(initialFilter: filter, heroCapsule: true),
-        transitionsBuilder: (_, animation, _, child) =>
-            FadeTransition(opacity: animation, child: child),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            buildPredictiveBackPageTransitions(
+              context,
+              animation,
+              secondaryAnimation,
+              child,
+              fallbackBuilder: (_, animation, _, child) =>
+                  FadeTransition(opacity: animation, child: child),
+            ),
       ),
     );
   }

--- a/lib/pages/webview_page.dart
+++ b/lib/pages/webview_page.dart
@@ -97,6 +97,10 @@ class _WebViewPageState extends ConsumerState<WebViewPage> {
     return PopScope(
       // WebView 还有历史时，返回键先回退网页；到首层后交给路由，
       // 这样离开浏览器页面可以使用 Android 预测式返回动画。
+      // _canGoBack 靠 onLoadStop/onUpdateVisitedHistory 异步回填,
+      // 网页刚导航完的一小段窗口内可能过期:过期为 true 时返回键
+      // 走 _handleBackNavigation 的实时查询兜底,行为仍正确;过期
+      // 为 false 时(极短暂)会直接退出页面而非回退网页,可接受。
       canPop: !_canGoBack,
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;

--- a/lib/pages/webview_page.dart
+++ b/lib/pages/webview_page.dart
@@ -95,7 +95,9 @@ class _WebViewPageState extends ConsumerState<WebViewPage> {
     );
 
     return PopScope(
-      canPop: false,
+      // WebView 还有历史时，返回键先回退网页；到首层后交给路由，
+      // 这样离开浏览器页面可以使用 Android 预测式返回动画。
+      canPop: !_canGoBack,
       onPopInvokedWithResult: (didPop, result) async {
         if (didPop) return;
         await _handleBackNavigation();

--- a/lib/widgets/common/predictive_back_cupertino_transitions.dart
+++ b/lib/widgets/common/predictive_back_cupertino_transitions.dart
@@ -35,12 +35,15 @@ import 'package:flutter/services.dart';
 ///
 /// 预测返回手势(Android U+)期间与系统手势联动显示 shared-element 预览;
 /// 其余导航(push、按钮/程序化 pop、其它平台)走 Cupertino 滑动转场。
-class PredictiveBackCupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
+class PredictiveBackCupertinoPageTransitionsBuilder
+    extends PageTransitionsBuilder {
   const PredictiveBackCupertinoPageTransitionsBuilder();
 
   @override
-  Duration get transitionDuration =>
-      const Duration(milliseconds: _PredictiveBackSharedElementPageTransitionState._kTransitionMilliseconds);
+  Duration get transitionDuration => const Duration(
+    milliseconds: _PredictiveBackSharedElementPageTransitionState
+        ._kTransitionMilliseconds,
+  );
 
   @override
   Widget buildTransitions<T>(
@@ -79,11 +82,67 @@ class PredictiveBackCupertinoPageTransitionsBuilder extends PageTransitionsBuild
               );
             }
 
-            return const CupertinoPageTransitionsBuilder()
-                .buildTransitions(route, context, animation, secondaryAnimation, child);
+            return const CupertinoPageTransitionsBuilder().buildTransitions(
+              route,
+              context,
+              animation,
+              secondaryAnimation,
+              child,
+            );
           },
     );
   }
+}
+
+/// Wraps a custom [PageRouteBuilder] transition with Android predictive back.
+///
+/// [PageRouteBuilder] does not use the app-wide [PageTransitionsTheme], so its
+/// transition would otherwise never register as a predictive-back observer.
+/// The supplied fallback keeps the route's existing push and button-pop
+/// animation; only an active Android back gesture uses the shared-element
+/// preview.
+Widget buildPredictiveBackPageTransitions(
+  BuildContext context,
+  Animation<double> animation,
+  Animation<double> secondaryAnimation,
+  Widget child, {
+  required Widget Function(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  )
+  fallbackBuilder,
+}) {
+  final route = ModalRoute.of(context);
+  if (route is! PageRoute<dynamic>) {
+    return fallbackBuilder(context, animation, secondaryAnimation, child);
+  }
+
+  return _PredictiveBackGestureDetector(
+    route: route,
+    builder:
+        (
+          BuildContext context,
+          _PredictiveBackPhase phase,
+          PredictiveBackEvent? startBackEvent,
+          PredictiveBackEvent? currentBackEvent,
+        ) {
+          if (route.popGestureInProgress) {
+            return _PredictiveBackSharedElementPageTransition(
+              isDelegatedTransition: true,
+              animation: animation,
+              phase: phase,
+              secondaryAnimation: secondaryAnimation,
+              startBackEvent: startBackEvent,
+              currentBackEvent: currentBackEvent,
+              child: child,
+            );
+          }
+
+          return fallbackBuilder(context, animation, secondaryAnimation, child);
+        },
+  );
 }
 
 typedef _PredictiveBackGestureDetectorWidgetBuilder =
@@ -117,16 +176,62 @@ enum _PredictiveBackPhase {
 }
 
 class _PredictiveBackGestureDetector extends StatefulWidget {
-  const _PredictiveBackGestureDetector({required this.route, required this.builder});
+  const _PredictiveBackGestureDetector({
+    required this.route,
+    required this.builder,
+  });
 
   final _PredictiveBackGestureDetectorWidgetBuilder builder;
   final PageRoute<dynamic> route;
 
   @override
-  State<_PredictiveBackGestureDetector> createState() => _PredictiveBackGestureDetectorState();
+  State<_PredictiveBackGestureDetector> createState() =>
+      _PredictiveBackGestureDetectorState();
 }
 
-class _PredictiveBackGestureDetectorState extends State<_PredictiveBackGestureDetector>
+/// Lets an embedded overlay consume Android's predictive back gesture without
+/// becoming a Navigator route. The overlay remains responsible for mapping
+/// progress to its own visual animation and for closing on commit.
+class PredictiveBackOverlayHandler with WidgetsBindingObserver {
+  PredictiveBackOverlayHandler({
+    required this.isEnabled,
+    required this.onStart,
+    required this.onUpdate,
+    required this.onCancel,
+    required this.onCommit,
+  });
+
+  final bool Function() isEnabled;
+  final VoidCallback onStart;
+  final ValueChanged<double> onUpdate;
+  final VoidCallback onCancel;
+  final VoidCallback onCommit;
+
+  void attach() => WidgetsBinding.instance.addObserver(this);
+
+  void dispose() => WidgetsBinding.instance.removeObserver(this);
+
+  @override
+  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+    if (backEvent.isButtonEvent || !isEnabled()) return false;
+    onStart();
+    return true;
+  }
+
+  @override
+  void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
+    onUpdate(backEvent.progress.clamp(0.0, 1.0));
+  }
+
+  @override
+  void handleCancelBackGesture() => onCancel();
+
+  @override
+  void handleCommitBackGesture() => onCommit();
+}
+
+class _PredictiveBackGestureDetectorState
+    extends State<_PredictiveBackGestureDetector>
     with WidgetsBindingObserver {
   /// True when the predictive back gesture is enabled.
   bool get _isEnabled {
@@ -178,7 +283,9 @@ class _PredictiveBackGestureDetectorState extends State<_PredictiveBackGestureDe
   void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
     phase = _PredictiveBackPhase.update;
 
-    widget.route.handleUpdateBackGestureProgress(progress: 1 - backEvent.progress);
+    widget.route.handleUpdateBackGestureProgress(
+      progress: 1 - backEvent.progress,
+    );
     currentBackEvent = backEvent;
   }
 
@@ -243,10 +350,14 @@ class _PredictiveBackGestureDetectorState extends State<_PredictiveBackGestureDe
 
   @override
   Widget build(BuildContext context) {
-    final _PredictiveBackPhase effectivePhase = widget.route.popGestureInProgress
-        ? phase
-        : _PredictiveBackPhase.idle;
-    return widget.builder(context, effectivePhase, startBackEvent, currentBackEvent);
+    final _PredictiveBackPhase effectivePhase =
+        widget.route.popGestureInProgress ? phase : _PredictiveBackPhase.idle;
+    return widget.builder(
+      context,
+      effectivePhase,
+      startBackEvent,
+      currentBackEvent,
+    );
   }
 }
 
@@ -318,7 +429,10 @@ class _PredictiveBackSharedElementPageTransitionState
 
   // Provides a smooth transition between the default radius and the
   // _kDeviceBorderRadius, when the display corner radii are unavailable.
-  final Tween<double> _borderRadiusTween = Tween<double>(begin: 0.0, end: _kDeviceBorderRadius);
+  final Tween<double> _borderRadiusTween = Tween<double>(
+    begin: 0.0,
+    end: _kDeviceBorderRadius,
+  );
 
   // The route fades out after commit.
   final Tween<double> _opacityTween = Tween<double>(begin: 1.0, end: 0.0);
@@ -364,7 +478,9 @@ class _PredictiveBackSharedElementPageTransitionState
     final double rawYShift = currentTouchY - startTouchY;
     final double easedYShift =
         // This curve was eyeballed on a Pixel 9 running Android 16.
-        Curves.easeOut.transform(clampDouble(rawYShift.abs() / screenHeight, 0.0, 1.0)) *
+        Curves.easeOut.transform(
+          clampDouble(rawYShift.abs() / screenHeight, 0.0, 1.0),
+        ) *
         rawYShift.sign *
         yShiftMax;
 
@@ -400,8 +516,14 @@ class _PredictiveBackSharedElementPageTransitionState
         // The y position before commit is given by the vertical drag, not by an
         // animation.
         begin: switch (widget.currentBackEvent?.swipeEdge) {
-          SwipeEdge.left => Offset(xShift, _getYShiftPosition(screenSize.height)),
-          SwipeEdge.right => Offset(-xShift, _getYShiftPosition(screenSize.height)),
+          SwipeEdge.left => Offset(
+            xShift,
+            _getYShiftPosition(screenSize.height),
+          ),
+          SwipeEdge.right => Offset(
+            -xShift,
+            _getYShiftPosition(screenSize.height),
+          ),
           null => Offset(xShift, _getYShiftPosition(screenSize.height)),
         },
         end: Offset.zero,
@@ -412,7 +534,10 @@ class _PredictiveBackSharedElementPageTransitionState
   void _updateCurvedAnimations() {
     _curvedAnimation?.dispose();
     _curvedAnimationReversed?.dispose();
-    _curvedAnimation = CurvedAnimation(parent: widget.animation, curve: _kCommitInterval);
+    _curvedAnimation = CurvedAnimation(
+      parent: widget.animation,
+      curve: _kCommitInterval,
+    );
     _curvedAnimationReversed = CurvedAnimation(
       parent: ReverseAnimation(widget.animation),
       curve: _kCommitInterval,
@@ -426,7 +551,8 @@ class _PredictiveBackSharedElementPageTransitionState
     if (widget.animation != oldWidget.animation) {
       _updateCurvedAnimations();
     }
-    if (widget.phase != oldWidget.phase && widget.phase == _PredictiveBackPhase.commit) {
+    if (widget.phase != oldWidget.phase &&
+        widget.phase == _PredictiveBackPhase.commit) {
       _updateAnimations(MediaQuery.sizeOf(context));
     }
   }
@@ -466,7 +592,9 @@ class _PredictiveBackSharedElementPageTransitionState
               child: ClipRRect(
                 borderRadius:
                     MediaQuery.displayCornerRadiiOf(context) ??
-                    BorderRadius.circular(_borderRadiusTween.evaluate(_bounceAnimation)),
+                    BorderRadius.circular(
+                      _borderRadiusTween.evaluate(_bounceAnimation),
+                    ),
                 child: child,
               ),
             ),

--- a/lib/widgets/common/predictive_back_cupertino_transitions.dart
+++ b/lib/widgets/common/predictive_back_cupertino_transitions.dart
@@ -19,6 +19,9 @@
 //    (边缘/全屏)同样置位 popGestureInProgress,原判定会把跟手平移误
 //    渲染成预测返回的缩放预览。预测返回必经 handleStartBackGesture
 //    (phase → start),以此区分手势来源。
+// 5. 文件尾新增 [buildPredictiveBackPageTransitions](上游没有):给不走
+//    PageTransitionsTheme 的 PageRouteBuilder 自定义转场补挂预测返回,
+//    追加在上游内容之后,不打断上游类排布。
 //
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -94,57 +97,6 @@ class PredictiveBackCupertinoPageTransitionsBuilder
   }
 }
 
-/// Wraps a custom [PageRouteBuilder] transition with Android predictive back.
-///
-/// [PageRouteBuilder] does not use the app-wide [PageTransitionsTheme], so its
-/// transition would otherwise never register as a predictive-back observer.
-/// The supplied fallback keeps the route's existing push and button-pop
-/// animation; only an active Android back gesture uses the shared-element
-/// preview.
-Widget buildPredictiveBackPageTransitions(
-  BuildContext context,
-  Animation<double> animation,
-  Animation<double> secondaryAnimation,
-  Widget child, {
-  required Widget Function(
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  )
-  fallbackBuilder,
-}) {
-  final route = ModalRoute.of(context);
-  if (route is! PageRoute<dynamic>) {
-    return fallbackBuilder(context, animation, secondaryAnimation, child);
-  }
-
-  return _PredictiveBackGestureDetector(
-    route: route,
-    builder:
-        (
-          BuildContext context,
-          _PredictiveBackPhase phase,
-          PredictiveBackEvent? startBackEvent,
-          PredictiveBackEvent? currentBackEvent,
-        ) {
-          if (route.popGestureInProgress) {
-            return _PredictiveBackSharedElementPageTransition(
-              isDelegatedTransition: true,
-              animation: animation,
-              phase: phase,
-              secondaryAnimation: secondaryAnimation,
-              startBackEvent: startBackEvent,
-              currentBackEvent: currentBackEvent,
-              child: child,
-            );
-          }
-
-          return fallbackBuilder(context, animation, secondaryAnimation, child);
-        },
-  );
-}
-
 typedef _PredictiveBackGestureDetectorWidgetBuilder =
     Widget Function(
       BuildContext context,
@@ -187,47 +139,6 @@ class _PredictiveBackGestureDetector extends StatefulWidget {
   @override
   State<_PredictiveBackGestureDetector> createState() =>
       _PredictiveBackGestureDetectorState();
-}
-
-/// Lets an embedded overlay consume Android's predictive back gesture without
-/// becoming a Navigator route. The overlay remains responsible for mapping
-/// progress to its own visual animation and for closing on commit.
-class PredictiveBackOverlayHandler with WidgetsBindingObserver {
-  PredictiveBackOverlayHandler({
-    required this.isEnabled,
-    required this.onStart,
-    required this.onUpdate,
-    required this.onCancel,
-    required this.onCommit,
-  });
-
-  final bool Function() isEnabled;
-  final VoidCallback onStart;
-  final ValueChanged<double> onUpdate;
-  final VoidCallback onCancel;
-  final VoidCallback onCommit;
-
-  void attach() => WidgetsBinding.instance.addObserver(this);
-
-  void dispose() => WidgetsBinding.instance.removeObserver(this);
-
-  @override
-  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
-    if (backEvent.isButtonEvent || !isEnabled()) return false;
-    onStart();
-    return true;
-  }
-
-  @override
-  void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
-    onUpdate(backEvent.progress.clamp(0.0, 1.0));
-  }
-
-  @override
-  void handleCancelBackGesture() => onCancel();
-
-  @override
-  void handleCommitBackGesture() => onCommit();
 }
 
 class _PredictiveBackGestureDetectorState
@@ -604,4 +515,64 @@ class _PredictiveBackSharedElementPageTransitionState
       child: widget.child,
     );
   }
+}
+
+// —— 以下为本仓库追加,上游无对应物(差异点 5)——
+
+/// 给 [PageRouteBuilder] 自定义转场补挂 Android 预测返回。
+///
+/// PageRouteBuilder 不走全局 PageTransitionsTheme,其转场树里没有
+/// _PredictiveBackGestureDetector,预测返回手势无人认领 → 系统只能整
+/// app 缩走。本函数在自定义转场外围补挂探测器:预测返回手势期间渲染
+/// shared-element 预览,其余(push、按钮/程序化 pop、其它平台)保持
+/// 路由原有的 [fallbackBuilder] 转场。
+///
+/// 判定与 [PredictiveBackCupertinoPageTransitionsBuilder] 同标准
+/// (popGestureInProgress 且 phase 非 idle,见文件头差异点 4):这些
+/// 路由今天没挂 app 内拖拽返回手势,但 fullscreen_swipe_back 等手势
+/// 源置位的是 Navigator 级 userGestureInProgress,宽松判定会在共存时
+/// 误判,统一收紧避免踩坑。
+Widget buildPredictiveBackPageTransitions(
+  BuildContext context,
+  Animation<double> animation,
+  Animation<double> secondaryAnimation,
+  Widget child, {
+  required Widget Function(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  )
+  fallbackBuilder,
+}) {
+  final route = ModalRoute.of(context);
+  if (route is! PageRoute<dynamic>) {
+    return fallbackBuilder(context, animation, secondaryAnimation, child);
+  }
+
+  return _PredictiveBackGestureDetector(
+    route: route,
+    builder:
+        (
+          BuildContext context,
+          _PredictiveBackPhase phase,
+          PredictiveBackEvent? startBackEvent,
+          PredictiveBackEvent? currentBackEvent,
+        ) {
+          if (route.popGestureInProgress &&
+              phase != _PredictiveBackPhase.idle) {
+            return _PredictiveBackSharedElementPageTransition(
+              isDelegatedTransition: true,
+              animation: animation,
+              phase: phase,
+              secondaryAnimation: secondaryAnimation,
+              startBackEvent: startBackEvent,
+              currentBackEvent: currentBackEvent,
+              child: child,
+            );
+          }
+
+          return fallbackBuilder(context, animation, secondaryAnimation, child);
+        },
+  );
 }

--- a/lib/widgets/common/predictive_back_overlay_handler.dart
+++ b/lib/widgets/common/predictive_back_overlay_handler.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/services.dart' show PredictiveBackEvent;
+import 'package:flutter/widgets.dart';
+
+/// 让非路由的嵌入式浮层(分类抽屉/侧栏通知面板)消费 Android 预测
+/// 返回手势:浮层自己把手势进度映射到收起动画,commit 时关闭。
+///
+/// 框架侧机制:WidgetsBinding 在 startBackGesture 时按注册顺序询问
+/// 所有 observer,[handleStartBackGesture] 返回 true 即认领,后续
+/// update/commit/cancel 只派发给认领者。同一时刻可能有多个浮层
+/// 都处于可关闭状态,各自的 [isEnabled] 必须互斥(只允许 z 序最
+/// 上层的浮层认领),否则一次手势会同时关掉多层。
+class PredictiveBackOverlayHandler with WidgetsBindingObserver {
+  PredictiveBackOverlayHandler({
+    required this.isEnabled,
+    required this.onStart,
+    required this.onUpdate,
+    required this.onCancel,
+    required this.onCommit,
+  });
+
+  final bool Function() isEnabled;
+  final VoidCallback onStart;
+  final ValueChanged<double> onUpdate;
+  final VoidCallback onCancel;
+  final VoidCallback onCommit;
+
+  void attach() => WidgetsBinding.instance.addObserver(this);
+
+  void dispose() => WidgetsBinding.instance.removeObserver(this);
+
+  @override
+  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+    if (backEvent.isButtonEvent || !isEnabled()) return false;
+    onStart();
+    return true;
+  }
+
+  @override
+  void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
+    onUpdate(backEvent.progress.clamp(0.0, 1.0));
+  }
+
+  @override
+  void handleCancelBackGesture() => onCancel();
+
+  @override
+  void handleCommitBackGesture() => onCommit();
+}

--- a/lib/widgets/notification/notification_quick_panel.dart
+++ b/lib/widgets/notification/notification_quick_panel.dart
@@ -9,15 +9,17 @@ import '../../providers/preferences_provider.dart';
 import '../../pages/notifications_page.dart';
 import '../../services/dynamic_content_suspension_service.dart';
 import '../../utils/blur_config.dart';
+import '../../utils/dialog_utils.dart';
 import '../../utils/responsive.dart';
 import '../../utils/notification_navigation.dart';
 import '../../utils/blocked_user_filter.dart';
+import '../common/predictive_back_cupertino_transitions.dart';
 import 'notification_item.dart';
 import 'notification_list_skeleton.dart';
 
 /// 通知快捷面板控制器
 /// 侧栏模式：在 widget 树中渲染（低于路由层，新页面自然覆盖）
-/// 手机模式：showModalBottomSheet
+/// 手机模式：ModalBottomSheetRoute
 class NotificationQuickPanel {
   NotificationQuickPanel._();
 
@@ -25,15 +27,54 @@ class NotificationQuickPanel {
   static final ValueNotifier<bool> _visible = ValueNotifier(false);
   static ValueNotifier<bool> get visible => _visible;
   static bool get isVisible => _visible.value;
+  static Future<void>? _mobileFuture;
+  static NavigatorState? _mobileNavigator;
 
   /// 弹出或关闭快捷面板
   static Future<void> show(BuildContext context) {
+    if (!Responsive.showNavigationRail(context)) {
+      final existing = _mobileFuture;
+      if (existing != null) return existing;
+
+      _mobileNavigator = Navigator.of(context, rootNavigator: true);
+      final future = showAppBottomSheet<void>(
+        context: context,
+        useRootNavigator: true,
+        isScrollControlled: true,
+        showDragHandle: true,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        builder: (_) => const _MobileNotificationPanel(),
+      ).then<void>((_) {});
+      _mobileFuture = future;
+      future.then<void>(
+        (_) {
+          if (identical(_mobileFuture, future)) {
+            _mobileFuture = null;
+            _mobileNavigator = null;
+          }
+        },
+        onError: (Object _, StackTrace _) {
+          if (identical(_mobileFuture, future)) {
+            _mobileFuture = null;
+            _mobileNavigator = null;
+          }
+        },
+      );
+      return future;
+    }
+
     _visible.value = !_visible.value;
     return Future.value();
   }
 
-  /// 关闭侧栏面板
+  /// 关闭当前通知面板
   static void dismiss() {
+    if (_mobileFuture != null) {
+      _mobileNavigator?.pop();
+      return;
+    }
     _visible.value = false;
   }
 }
@@ -54,6 +95,7 @@ class _SidebarNotificationPanelState
   late AnimationController _animController;
   late Animation<double> _animation;
   late final ShortcutSurfaceBinding _shortcutSurfaceBinding;
+  late final PredictiveBackOverlayHandler _predictiveBackHandler;
   final ScrollController _scrollController = ScrollController();
   bool _wasVisible = false;
   DynamicContentSuspensionLease? _dynamicContentLease;
@@ -70,6 +112,15 @@ class _SidebarNotificationPanelState
       curve: Curves.easeOutCubic,
       reverseCurve: Curves.easeInCubic,
     );
+    _predictiveBackHandler = PredictiveBackOverlayHandler(
+      isEnabled: () =>
+          (ModalRoute.of(context)?.isCurrent ?? false) &&
+          NotificationQuickPanel.isVisible,
+      onStart: _onPredictiveBackStart,
+      onUpdate: _onPredictiveBackUpdate,
+      onCancel: _onPredictiveBackCancel,
+      onCommit: NotificationQuickPanel.dismiss,
+    )..attach();
     _shortcutSurfaceBinding = ShortcutSurfaceBinding(
       ref: ref,
       id: ShortcutSurfaceIds.notifications,
@@ -91,6 +142,7 @@ class _SidebarNotificationPanelState
 
   @override
   void dispose() {
+    _predictiveBackHandler.dispose();
     NotificationQuickPanel._visible.removeListener(_onVisibilityChanged);
     _animController.removeStatusListener(_onAnimationStatusChanged);
     _shortcutSurfaceBinding.disposeDeferred();
@@ -98,6 +150,25 @@ class _SidebarNotificationPanelState
     _animController.dispose();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _onPredictiveBackStart() {
+    _animController.stop();
+    if (_dragOffset != 0) setState(() => _dragOffset = 0);
+  }
+
+  void _onPredictiveBackUpdate(double progress) {
+    _animController.value = 1.0 - progress;
+  }
+
+  void _onPredictiveBackCancel() {
+    if (NotificationQuickPanel.isVisible) {
+      _animController.animateTo(
+        1.0,
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+      );
+    }
   }
 
   void _onAnimationStatusChanged(AnimationStatus status) {
@@ -175,6 +246,7 @@ class _SidebarNotificationPanelState
         children: [
           _NotificationHeader(
             padding: EdgeInsets.fromLTRB(20, showRail ? 16 : 12, 12, 8),
+            onClose: NotificationQuickPanel.dismiss,
           ),
           _NotificationBody(scrollController: _scrollController),
         ],
@@ -402,11 +474,66 @@ class _DragHandle extends StatelessWidget {
   }
 }
 
+/// 手机端通知面板作为真正的 ModalBottomSheetRoute 渲染，
+/// 让系统返回手势可以驱动路由动画并在取消时恢复。
+class _MobileNotificationPanel extends StatefulWidget {
+  const _MobileNotificationPanel();
+
+  @override
+  State<_MobileNotificationPanel> createState() =>
+      _MobileNotificationPanelState();
+}
+
+class _MobileNotificationPanelState extends State<_MobileNotificationPanel> {
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _openAllNotifications() {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    navigator.pop();
+    navigator.push(
+      MaterialPageRoute(builder: (_) => const NotificationsPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.sizeOf(context).height * 0.8;
+    return SafeArea(
+      bottom: false,
+      child: SizedBox(
+        height: height,
+        child: Column(
+          children: [
+            _NotificationHeader(
+              padding: const EdgeInsets.fromLTRB(20, 12, 12, 8),
+              onClose: () => Navigator.of(context).pop(),
+              onViewAll: _openAllNotifications,
+            ),
+            _NotificationBody(scrollController: _scrollController),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 /// 共用标题栏
 class _NotificationHeader extends ConsumerWidget {
-  const _NotificationHeader({required this.padding});
+  const _NotificationHeader({
+    required this.padding,
+    required this.onClose,
+    this.onViewAll,
+  });
 
   final EdgeInsets padding;
+  final VoidCallback onClose;
+  final VoidCallback? onViewAll;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -436,12 +563,16 @@ class _NotificationHeader extends ConsumerWidget {
           ),
           const SizedBox(width: 4),
           TextButton(
-            onPressed: () {
-              NotificationQuickPanel.dismiss();
-              Navigator.of(context, rootNavigator: true).push(
-                MaterialPageRoute(builder: (_) => const NotificationsPage()),
-              );
-            },
+            onPressed:
+                onViewAll ??
+                () {
+                  onClose();
+                  Navigator.of(context, rootNavigator: true).push(
+                    MaterialPageRoute(
+                      builder: (_) => const NotificationsPage(),
+                    ),
+                  );
+                },
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [

--- a/lib/widgets/notification/notification_quick_panel.dart
+++ b/lib/widgets/notification/notification_quick_panel.dart
@@ -13,7 +13,8 @@ import '../../utils/dialog_utils.dart';
 import '../../utils/responsive.dart';
 import '../../utils/notification_navigation.dart';
 import '../../utils/blocked_user_filter.dart';
-import '../common/predictive_back_cupertino_transitions.dart';
+import '../common/predictive_back_overlay_handler.dart';
+import '../topic/category_drawer.dart' show CategoryDrawerHost;
 import 'notification_item.dart';
 import 'notification_list_skeleton.dart';
 
@@ -28,15 +29,22 @@ class NotificationQuickPanel {
   static ValueNotifier<bool> get visible => _visible;
   static bool get isVisible => _visible.value;
   static Future<void>? _mobileFuture;
-  static NavigatorState? _mobileNavigator;
 
-  /// 弹出或关闭快捷面板
+  /// 手机 sheet 自身的路由,由 [_MobileNotificationPanelState] 在挂载后
+  /// 回填。dismiss 必须锚定这条路由而非「navigator 栈顶」:通知条目的
+  /// 点击顺序是「先 push 详情页再关面板」,此刻栈顶是详情页,盲目 pop
+  /// 会把刚打开的详情页弹掉。
+  static ModalRoute<dynamic>? _mobileRoute;
+
+  /// 弹出或关闭快捷面板(重复触发 = 收起,两种模式同语义)
   static Future<void> show(BuildContext context) {
     if (!Responsive.showNavigationRail(context)) {
       final existing = _mobileFuture;
-      if (existing != null) return existing;
+      if (existing != null) {
+        dismiss();
+        return existing;
+      }
 
-      _mobileNavigator = Navigator.of(context, rootNavigator: true);
       final future = showAppBottomSheet<void>(
         context: context,
         useRootNavigator: true,
@@ -45,23 +53,22 @@ class NotificationQuickPanel {
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
         ),
+        shortcutSurface: const ShortcutSurfaceConfig(
+          id: ShortcutSurfaceIds.notifications,
+          triggerAction: ShortcutAction.toggleNotifications,
+          repeatBehavior: ShortcutSurfaceRepeatBehavior.toggle,
+        ),
         builder: (_) => const _MobileNotificationPanel(),
       ).then<void>((_) {});
       _mobileFuture = future;
-      future.then<void>(
-        (_) {
-          if (identical(_mobileFuture, future)) {
-            _mobileFuture = null;
-            _mobileNavigator = null;
-          }
-        },
-        onError: (Object _, StackTrace _) {
-          if (identical(_mobileFuture, future)) {
-            _mobileFuture = null;
-            _mobileNavigator = null;
-          }
-        },
-      );
+      future
+          .whenComplete(() {
+            if (identical(_mobileFuture, future)) {
+              _mobileFuture = null;
+              _mobileRoute = null;
+            }
+          })
+          .ignore();
       return future;
     }
 
@@ -71,8 +78,18 @@ class NotificationQuickPanel {
 
   /// 关闭当前通知面板
   static void dismiss() {
-    if (_mobileFuture != null) {
-      _mobileNavigator?.pop();
+    final route = _mobileRoute;
+    if (route != null) {
+      final navigator = route.navigator;
+      if (navigator != null && route.isActive) {
+        if (route.isCurrent) {
+          navigator.pop();
+        } else {
+          // 上面已经盖了别的路由(点通知先 push 详情页):无动画抽掉
+          // sheet,详情页保持在原位。
+          navigator.removeRoute(route);
+        }
+      }
       return;
     }
     _visible.value = false;
@@ -113,9 +130,12 @@ class _SidebarNotificationPanelState
       reverseCurve: Curves.easeInCubic,
     );
     _predictiveBackHandler = PredictiveBackOverlayHandler(
+      // 分类抽屉在 Stack 里盖在本面板之上,两者同开时手势归抽屉,
+      // 这里让位(见 PredictiveBackOverlayHandler 的互斥说明)。
       isEnabled: () =>
           (ModalRoute.of(context)?.isCurrent ?? false) &&
-          NotificationQuickPanel.isVisible,
+          NotificationQuickPanel.isVisible &&
+          !CategoryDrawerHost.isOpen,
       onStart: _onPredictiveBackStart,
       onUpdate: _onPredictiveBackUpdate,
       onCancel: _onPredictiveBackCancel,
@@ -488,6 +508,13 @@ class _MobileNotificationPanelState extends State<_MobileNotificationPanel> {
   final ScrollController _scrollController = ScrollController();
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // 回填 sheet 自身路由,供 dismiss 精确锚定(而非盲 pop 栈顶)
+    NotificationQuickPanel._mobileRoute = ModalRoute.of(context);
+  }
+
+  @override
   void dispose() {
     _scrollController.dispose();
     super.dispose();
@@ -512,7 +539,7 @@ class _MobileNotificationPanelState extends State<_MobileNotificationPanel> {
           children: [
             _NotificationHeader(
               padding: const EdgeInsets.fromLTRB(20, 12, 12, 8),
-              onClose: () => Navigator.of(context).pop(),
+              onClose: NotificationQuickPanel.dismiss,
               onViewAll: _openAllNotifications,
             ),
             _NotificationBody(scrollController: _scrollController),

--- a/lib/widgets/topic/category_drawer.dart
+++ b/lib/widgets/topic/category_drawer.dart
@@ -14,7 +14,7 @@ import '../../utils/motion_springs.dart';
 import '../../utils/number_utils.dart';
 import '../../utils/tag_icon_list.dart';
 import '../../utils/url_helper.dart';
-import '../common/predictive_back_cupertino_transitions.dart';
+import '../common/predictive_back_overlay_handler.dart';
 import '../../services/discourse_cache_manager.dart';
 import '../../pages/category_topics_page.dart';
 import '../../pages/tag_topics_page.dart';

--- a/lib/widgets/topic/category_drawer.dart
+++ b/lib/widgets/topic/category_drawer.dart
@@ -14,6 +14,7 @@ import '../../utils/motion_springs.dart';
 import '../../utils/number_utils.dart';
 import '../../utils/tag_icon_list.dart';
 import '../../utils/url_helper.dart';
+import '../common/predictive_back_cupertino_transitions.dart';
 import '../../services/discourse_cache_manager.dart';
 import '../../pages/category_topics_page.dart';
 import '../../pages/tag_topics_page.dart';
@@ -53,10 +54,8 @@ class CategoryDrawerHost {
 /// 外部只能 open/close —— 做不了"TabBarView 首缘 overscroll 逐帧
 /// 喂增量"的跟手拖出（用户点名：右滑慢慢打开，不是触发即弹）。
 /// 开着时面板/遮罩上水平拖拽关闭、点遮罩关闭、返回键关闭，语义与系统
-/// 抽屉一致。返回键有两路：LocalHistoryEntry 覆盖普通路由;首页根路由
-/// 挂着 canPop:false 的 PopScope（双击退出），其 doNotPop 判定优先于
-/// LocalHistory 内部消费，故由首页 PopScope 回调查 [CategoryDrawerHost.isOpen]
-/// 兜底关闭。
+/// 抽屉一致。返回键由 LocalHistoryEntry 消费；首页根路由仍保留 PopScope
+/// 作为抽屉动画收尾期间的兜底关闭逻辑。
 class ControlledCategoryDrawer extends StatefulWidget {
   const ControlledCategoryDrawer({super.key, required this.onPinnedSelected});
 
@@ -82,6 +81,19 @@ class ControlledCategoryDrawerState extends State<ControlledCategoryDrawer>
 
   LocalHistoryEntry? _history;
   bool _removingHistory = false;
+  late final PredictiveBackOverlayHandler _predictiveBackHandler;
+
+  @override
+  void initState() {
+    super.initState();
+    _predictiveBackHandler = PredictiveBackOverlayHandler(
+      isEnabled: () => (ModalRoute.of(context)?.isCurrent ?? false) && isOpen,
+      onStart: _onPredictiveBackStart,
+      onUpdate: _onPredictiveBackUpdate,
+      onCancel: _onPredictiveBackCancel,
+      onCommit: close,
+    )..attach();
+  }
 
   /// 抽屉是否可见（含拖拽/动画中间态）
   bool get isOpen => _anim.value > 0;
@@ -105,6 +117,19 @@ class ControlledCategoryDrawerState extends State<ControlledCategoryDrawer>
       target = _anim.value >= 0.5 ? 1.0 : 0.0;
     }
     _springTo(target, velocity: v);
+  }
+
+  void _onPredictiveBackStart() {
+    _anim.stop();
+  }
+
+  void _onPredictiveBackUpdate(double progress) {
+    _anim.stop();
+    _anim.value = 1.0 - progress;
+  }
+
+  void _onPredictiveBackCancel() {
+    if (isOpen) _springTo(1.0);
   }
 
   void _springTo(double target, {double velocity = 0}) {
@@ -142,6 +167,7 @@ class ControlledCategoryDrawerState extends State<ControlledCategoryDrawer>
 
   @override
   void dispose() {
+    _predictiveBackHandler.dispose();
     _history?.remove();
     _anim.dispose();
     super.dispose();


### PR DESCRIPTION
## 变更内容

- 为图片查看器、Mermaid 页面、搜索页面和 WebView 增加预测式返回支持。
- 为分类抽屉和通知侧栏增加返回手势跟手关闭。
- 移除首页双击返回退出逻辑，恢复 Android 单次返回退出。
- BottomSheet/Dialog 保留 Flutter 原生 PopupRoute 动画，不再接入自定义预测返回动画。

## 验证

- 目标文件静态分析通过。
- Debug APK 构建成功。