### PR TITLE
🐛 修 Base64 CESU-8 文本误判与乱码

### DIFF
--- a/lib/services/crypto/algorithms/encoding_algorithms.dart
+++ b/lib/services/crypto/algorithms/encoding_algorithms.dart
@@ -34,14 +34,7 @@ class Base64Algorithm extends CryptoAlgorithm {
   String decrypt(String ciphertext, CryptoParams params) {
     final normalized = _normalize(ciphertext);
     try {
-      return utf8.decode(base64.decode(normalized));
-    } on FormatException {
-      // 非 UTF-8 字节也允许以 Latin-1 兜底展示（CyberChef 行为）
-      try {
-        return latin1.decode(base64.decode(normalized));
-      } catch (_) {
-        throw const CryptoException('无效的 Base64 密文');
-      }
+      return decodeUtf8Compat(base64.decode(normalized));
     } catch (_) {
       throw const CryptoException('无效的 Base64 密文');
     }
@@ -63,6 +56,79 @@ class Base64Algorithm extends CryptoAlgorithm {
     return text;
   }
 }
+
+
+/// Decode text-like Base64 payloads without corrupting valid UTF-8 when a
+/// small part of the byte stream uses CESU-8/WTF-8 or is truncated.
+String decodeUtf8Compat(List<int> bytes) {
+  final normalized = _normalizeCesu8SurrogatePairs(bytes);
+  try {
+    return utf8.decode(normalized);
+  } on FormatException {
+    final repaired = utf8.decode(normalized, allowMalformed: true);
+    if (_looksReadableUtf8(repaired)) return repaired;
+    // Keep the previous behavior for genuinely non-UTF-8 byte payloads.
+    return latin1.decode(bytes);
+  }
+}
+
+/// Heuristic used by Base64 sniffing. It accepts paired CESU-8 surrogates and
+/// a very small number of malformed bytes, while still rejecting binary data.
+bool isMostlyUtf8TextBytes(List<int> bytes) {
+  if (bytes.isEmpty) return false;
+  final normalized = _normalizeCesu8SurrogatePairs(bytes);
+  final decoded = utf8.decode(normalized, allowMalformed: true);
+  return _looksReadableUtf8(decoded);
+}
+
+bool _looksReadableUtf8(String decoded) {
+  if (decoded.isEmpty) return false;
+  var runeCount = 0;
+  var replacements = 0;
+  for (final rune in decoded.runes) {
+    runeCount++;
+    if (rune == 0xfffd) replacements++;
+    if (rune < 0x20 && rune != 0x09 && rune != 0x0a && rune != 0x0d) {
+      return false;
+    }
+  }
+  // One-off truncation should not turn an otherwise readable text payload into
+  // a symmetric-cipher suggestion. Random binary data normally fails this bar.
+  return replacements * 20 <= runeCount;
+}
+
+Uint8List _normalizeCesu8SurrogatePairs(List<int> bytes) {
+  final out = BytesBuilder(copy: false);
+  var i = 0;
+  while (i < bytes.length) {
+    if (i + 5 < bytes.length &&
+        bytes[i] == 0xed &&
+        bytes[i + 1] >= 0xa0 &&
+        bytes[i + 1] <= 0xaf &&
+        _isUtf8Continuation(bytes[i + 2]) &&
+        bytes[i + 3] == 0xed &&
+        bytes[i + 4] >= 0xb0 &&
+        bytes[i + 4] <= 0xbf &&
+        _isUtf8Continuation(bytes[i + 5])) {
+      final high = 0xd000 |
+          ((bytes[i + 1] & 0x3f) << 6) |
+          (bytes[i + 2] & 0x3f);
+      final low = 0xd000 |
+          ((bytes[i + 4] & 0x3f) << 6) |
+          (bytes[i + 5] & 0x3f);
+      final scalar =
+          0x10000 + ((high - 0xd800) << 10) + (low - 0xdc00);
+      out.add(utf8.encode(String.fromCharCode(scalar)));
+      i += 6;
+      continue;
+    }
+    out.addByte(bytes[i]);
+    i++;
+  }
+  return out.takeBytes();
+}
+
+bool _isUtf8Continuation(int byte) => byte >= 0x80 && byte <= 0xbf;
 
 /// Hex（小写输出，解码大小写均可）
 class HexAlgorithm extends CryptoAlgorithm {

--- a/lib/services/crypto/algorithms/encoding_algorithms.dart
+++ b/lib/services/crypto/algorithms/encoding_algorithms.dart
@@ -57,68 +57,104 @@ class Base64Algorithm extends CryptoAlgorithm {
   }
 }
 
-
-/// Decode text-like Base64 payloads without corrupting valid UTF-8 when a
-/// small part of the byte stream uses CESU-8/WTF-8 or is truncated.
+/// 编码文本类 payload 的 UTF-8 兼容解码（Base64 / Hex / Base32 共用）。
+///
+/// 依次容忍三种上游怪癖：
+/// 1. CESU-8/WTF-8：emoji 等 BMP 外字符被拆成 UTF-16 代理对、各按 3 字节编码
+///    （Java JNI、`writeUTF`、MySQL utf8mb3 等会这么干）；
+/// 2. 个别字节损坏（如划词把 base64 尾巴选漏）：只把坏字节替成 U+FFFD，
+///    保住其余正文，不再整段改换编码；
+/// 3. 整段本就不是 UTF-8（Latin-1 等）：回退 Latin-1（CyberChef 行为）。
+///
+/// 2 与 3 的取舍不看长度、不拍阈值：两个候选各数一次「可疑字符」后取优。
+/// 真 UTF-8 被 Latin-1 硬解会漏出成片 C1 控制字符，真 Latin-1 文本几乎没有，
+/// 两者天然可分——否则「几个重音字母」和「几个截断字节」只能靠长度瞎猜。
 String decodeUtf8Compat(List<int> bytes) {
   final normalized = _normalizeCesu8SurrogatePairs(bytes);
   try {
     return utf8.decode(normalized);
   } on FormatException {
     final repaired = utf8.decode(normalized, allowMalformed: true);
-    if (_looksReadableUtf8(repaired)) return repaired;
-    // Keep the previous behavior for genuinely non-UTF-8 byte payloads.
-    return latin1.decode(bytes);
+    final fallback = latin1.decode(bytes, allowInvalid: true);
+    return _countSuspiciousRunes(repaired) <= _countSuspiciousRunes(fallback)
+        ? repaired
+        : fallback;
   }
 }
 
-/// Heuristic used by Base64 sniffing. It accepts paired CESU-8 surrogates and
-/// a very small number of malformed bytes, while still rejecting binary data.
-bool isMostlyUtf8TextBytes(List<int> bytes) {
+/// 嗅探端判据：payload 按 UTF-8 解出来是否像人类可读文本。
+///
+/// 用于「这段 base64/hex 是真文本编码，还是加密后的裸 payload」二选一。
+/// 刻意只看 UTF-8 解释：Latin-1 是解码端的补救手段，不能拿来给二进制洗白
+/// 身份——随机字节硬解 Latin-1 也能凑出「没有控制字符」的假象（实测 16 字节
+/// 随机 payload 有约 1.8% 会蒙混过关）。
+bool looksLikeReadableText(List<int> bytes) {
   if (bytes.isEmpty) return false;
-  final normalized = _normalizeCesu8SurrogatePairs(bytes);
-  final decoded = utf8.decode(normalized, allowMalformed: true);
-  return _looksReadableUtf8(decoded);
-}
-
-bool _looksReadableUtf8(String decoded) {
+  final decoded =
+      utf8.decode(_normalizeCesu8SurrogatePairs(bytes), allowMalformed: true);
   if (decoded.isEmpty) return false;
   var runeCount = 0;
   var replacements = 0;
+  var firstReplacementAt = -1;
   for (final rune in decoded.runes) {
-    runeCount++;
-    if (rune == 0xfffd) replacements++;
-    if (rune < 0x20 && rune != 0x09 && rune != 0x0a && rune != 0x0d) {
-      return false;
+    // 控制字符是二进制内容最强的信号，出现即判非文本
+    if (_isC0Control(rune) || _isC1Control(rune)) return false;
+    if (rune == 0xfffd) {
+      if (firstReplacementAt < 0) firstReplacementAt = runeCount;
+      replacements++;
     }
+    runeCount++;
   }
-  // One-off truncation should not turn an otherwise readable text payload into
-  // a symmetric-cipher suggestion. Random binary data normally fails this bar.
-  return replacements * 20 <= runeCount;
+  if (replacements == 0) return true;
+  // CESU-8 已在归一化阶段还原，这里只需再容忍「划词把 base64 尾巴选漏」。
+  // 截断只会毁掉末尾那一个多字节序列，所以要求替换符紧贴结尾——散落在正文
+  // 中间的损坏按二进制处理。不按占比放宽：占比会随文本变长越放越松，长文本
+  // 能静默吞掉几十个坏字节，且随机字节能靠「凑出几个合法多字节序列」蒙过去。
+  return replacements <= _maxTruncatedTailReplacements &&
+      firstReplacementAt >= runeCount - _maxTruncatedTailReplacements;
 }
 
+/// 尾部截断最多毁掉一个多字节序列，留一点余量
+const int _maxTruncatedTailReplacements = 2;
+
+/// 可疑字符：U+FFFD 替换符、C0 控制字符、C1 控制区。
+///
+/// C1（U+0080-009F）是关键项：正常文本几乎不用，但 UTF-8 多字节序列被
+/// Latin-1 硬解时后续字节会成片落进这里，正是「谁解错了」的指纹。
+bool _isSuspiciousRune(int rune) =>
+    rune == 0xfffd || _isC0Control(rune) || _isC1Control(rune);
+
+bool _isC0Control(int rune) =>
+    rune < 0x20 && rune != 0x09 && rune != 0x0a && rune != 0x0d;
+
+bool _isC1Control(int rune) => rune >= 0x80 && rune <= 0x9f;
+
+int _countSuspiciousRunes(String text) {
+  var count = 0;
+  for (final rune in text.runes) {
+    if (_isSuspiciousRune(rune)) count++;
+  }
+  return count;
+}
+
+/// CESU-8 代理序列的首字节
+const int _cesu8Lead = 0xed;
+
+/// 把成对的 CESU-8 代理序列（6 字节）还原成标准 UTF-8（4 字节）。
+///
+/// 合法 UTF-8 里 `0xED` 后接 `0xA0-0xBF` 恰好落在 U+D800-DFFF 代理区，
+/// 而该区在 UTF-8 中永远非法，所以这个还原不可能误伤正常内容。
 Uint8List _normalizeCesu8SurrogatePairs(List<int> bytes) {
-  final out = BytesBuilder(copy: false);
-  var i = 0;
+  final firstLead = bytes.indexOf(_cesu8Lead);
+  // 绝大多数 payload 不含 CESU-8：零拷贝原样返回
+  if (firstLead < 0) {
+    return bytes is Uint8List ? bytes : Uint8List.fromList(bytes);
+  }
+  final out = BytesBuilder()..add(bytes.sublist(0, firstLead));
+  var i = firstLead;
   while (i < bytes.length) {
-    if (i + 5 < bytes.length &&
-        bytes[i] == 0xed &&
-        bytes[i + 1] >= 0xa0 &&
-        bytes[i + 1] <= 0xaf &&
-        _isUtf8Continuation(bytes[i + 2]) &&
-        bytes[i + 3] == 0xed &&
-        bytes[i + 4] >= 0xb0 &&
-        bytes[i + 4] <= 0xbf &&
-        _isUtf8Continuation(bytes[i + 5])) {
-      final high = 0xd000 |
-          ((bytes[i + 1] & 0x3f) << 6) |
-          (bytes[i + 2] & 0x3f);
-      final low = 0xd000 |
-          ((bytes[i + 4] & 0x3f) << 6) |
-          (bytes[i + 5] & 0x3f);
-      final scalar =
-          0x10000 + ((high - 0xd800) << 10) + (low - 0xdc00);
-      out.add(utf8.encode(String.fromCharCode(scalar)));
+    if (i + 5 < bytes.length && _isCesu8SurrogatePair(bytes, i)) {
+      out.add(utf8.encode(String.fromCharCode(_decodeCesu8Pair(bytes, i))));
       i += 6;
       continue;
     }
@@ -126,6 +162,24 @@ Uint8List _normalizeCesu8SurrogatePairs(List<int> bytes) {
     i++;
   }
   return out.takeBytes();
+}
+
+/// `ED A0-AF xx` + `ED B0-BF xx`：高代理 + 低代理各一段 3 字节
+bool _isCesu8SurrogatePair(List<int> b, int i) =>
+    b[i] == _cesu8Lead &&
+    b[i + 1] >= 0xa0 &&
+    b[i + 1] <= 0xaf &&
+    _isUtf8Continuation(b[i + 2]) &&
+    b[i + 3] == _cesu8Lead &&
+    b[i + 4] >= 0xb0 &&
+    b[i + 4] <= 0xbf &&
+    _isUtf8Continuation(b[i + 5]);
+
+/// 两段 3 字节代理还原成单个码点（首字节固定 0xED 即高 4 位 0xD）
+int _decodeCesu8Pair(List<int> b, int i) {
+  final high = 0xd000 | ((b[i + 1] & 0x3f) << 6) | (b[i + 2] & 0x3f);
+  final low = 0xd000 | ((b[i + 4] & 0x3f) << 6) | (b[i + 5] & 0x3f);
+  return 0x10000 + ((high - 0xd800) << 10) + (low - 0xdc00);
 }
 
 bool _isUtf8Continuation(int byte) => byte >= 0x80 && byte <= 0xbf;
@@ -157,7 +211,7 @@ class HexAlgorithm extends CryptoAlgorithm {
       throw const CryptoException('无效的 Hex 密文（需为偶数长度的十六进制字符）');
     }
     try {
-      return utf8.decode(_hexDecode(text));
+      return decodeUtf8Compat(_hexDecode(text));
     } catch (_) {
       throw const CryptoException('Hex 解码失败：内容不是有效的 UTF-8 文本');
     }
@@ -257,7 +311,7 @@ class Base32Algorithm extends CryptoAlgorithm {
       buffer &= (1 << bits) - 1;
     }
     try {
-      return utf8.decode(out);
+      return decodeUtf8Compat(out);
     } catch (_) {
       throw const CryptoException('Base32 解码失败：内容不是有效的 UTF-8 文本');
     }

--- a/lib/services/crypto/crypto_toolbox.dart
+++ b/lib/services/crypto/crypto_toolbox.dart
@@ -231,17 +231,17 @@ class CryptoToolbox {
           SniffedCipherKind.opensslSalted,
         );
       case SniffedCipherKind.plainBase64:
-        // 内容探测：解码后是 UTF-8 可读文本 → 真是 base64 编码；
+        // 内容探测：解码后是可读文本 → 真是 base64 编码；
         // 二进制 → 更像加密密文裸 payload（对称算法自解析 salt|iv|ct）
         final bytes = _tryDecodeBase64(ciphertext);
-        if (bytes != null && !_looksLikeUtf8Text(bytes)) {
+        if (bytes != null && !looksLikeReadableText(bytes)) {
           return const DecryptSuggestion(
               defaultAlgorithmId, SniffedCipherKind.plainBase64);
         }
         return const DecryptSuggestion('base64', SniffedCipherKind.plainBase64);
       case SniffedCipherKind.plainHex:
         final bytes = _tryDecodeHex(ciphertext);
-        if (bytes != null && !_looksLikeUtf8Text(bytes)) {
+        if (bytes != null && !looksLikeReadableText(bytes)) {
           return const DecryptSuggestion(
               defaultAlgorithmId, SniffedCipherKind.plainHex);
         }
@@ -277,11 +277,6 @@ class CryptoToolbox {
     } catch (_) {
       return null;
     }
-  }
-
-  /// 解码内容是否像 UTF-8 可读文本（无明显控制字符/替换符）
-  static bool _looksLikeUtf8Text(Uint8List bytes) {
-    return isMostlyUtf8TextBytes(bytes);
   }
 }
 

--- a/lib/services/crypto/crypto_toolbox.dart
+++ b/lib/services/crypto/crypto_toolbox.dart
@@ -281,21 +281,7 @@ class CryptoToolbox {
 
   /// 解码内容是否像 UTF-8 可读文本（无明显控制字符/替换符）
   static bool _looksLikeUtf8Text(Uint8List bytes) {
-    final String decoded;
-    try {
-      decoded = utf8.decode(bytes); // 严格模式：坏序列直接失败
-    } catch (_) {
-      return false;
-    }
-    var control = 0;
-    for (final unit in decoded.codeUnits) {
-      // C0 控制字符（排除 \t\n\r）与 U+FFFD 替换符计入「不像文本」
-      if ((unit < 0x20 && unit != 0x09 && unit != 0x0a && unit != 0x0d) ||
-          unit == 0xfffd) {
-        control++;
-      }
-    }
-    return control == 0;
+    return isMostlyUtf8TextBytes(bytes);
   }
 }
 

--- a/test/services/crypto/crypto_toolbox_test.dart
+++ b/test/services/crypto/crypto_toolbox_test.dart
@@ -306,13 +306,13 @@ void main() {
       expect(suggestion.algorithmId, 'aes-256-cbc');
     });
 
-    test('Base64 keeps UTF-8 text with CESU-8 emoji and one bad byte', () {
+    test('CESU-8 emoji + \u4e2a\u522b\u574f\u5b57\u8282\uff1a\u4fdd\u4f4f\u6b63\u6587\u4e14\u4e0d\u8bef\u5224\u6210\u5bf9\u79f0\u7b97\u6cd5', () {
       final bytes = <int>[
         ...utf8.encode('Synthetic UTF-8 text with \u4e2d\u6587 '),
-        // U+1F449 encoded as CESU-8: D83D DC49 -> ED A0 BD ED B1 89.
+        // U+1F449 \u7684 CESU-8 \u5f62\u6001\uff1aD83D DC49 -> ED A0 BD ED B1 89
         0xed, 0xa0, 0xbd, 0xed, 0xb1, 0x89,
         ...utf8.encode(' tail with enough readable text'),
-        0xff, // one malformed trailing byte
+        0xff, // \u5355\u4e2a\u635f\u574f\u5c3e\u5b57\u8282
       ];
       final sample = base64.encode(bytes);
 
@@ -328,7 +328,7 @@ void main() {
       );
     });
 
-    test('Base64 keeps Latin-1 fallback for genuinely non-UTF-8 bytes', () {
+    test('\u6210\u7247\u975e UTF-8 \u5b57\u8282\uff1a\u4ecd\u56de\u9000 Latin-1', () {
       final sample = base64.encode(<int>[0x43, 0x61, 0x66, 0xe9]);
       expect(
         CryptoToolbox.decrypt(
@@ -337,6 +337,97 @@ void main() {
           params: const CryptoParams(),
         ),
         'Caf\u00e9',
+      );
+    });
+
+    test('\u957f Latin-1 \u6587\u672c\uff1a\u574f\u5b57\u8282\u5360\u6bd4\u4f4e\u4e5f\u4e0d\u8bb8\u6309 UTF-8 \u635f\u574f\u89e3', () {
+      // \u5224\u636e\u82e5\u6309\u300c\u66ff\u6362\u7b26\u5360\u6bd4\u300d\u62cd\u9608\u503c\uff0c\u957f\u6587\u672c\u91cc\u7684\u96f6\u661f\u91cd\u97f3\u5b57\u6bcd\u4f1a\u88ab\u541e\u6210 U+FFFD\uff0c
+      // \u53cd\u800c\u662f\u91cd\u97f3\u8d8a\u5c11\u8d8a\u5bb9\u6613\u635f\u574f\u3002\u8fd9\u91cc\u9489\u4f4f\u300c\u53d6\u4f18\u300d\u800c\u975e\u300c\u770b\u957f\u5ea6\u300d\u3002
+      final bytes = <int>[
+        ...utf8.encode('A' * 60),
+        0xe9, // \u00e9
+        ...utf8.encode('B' * 60),
+        0xe8, // \u00e8
+        ...utf8.encode('C' * 60),
+        0xfc, // \u00fc
+        ...utf8.encode('D' * 20),
+      ];
+      final decoded = CryptoToolbox.decrypt(
+        ciphertext: base64.encode(bytes),
+        algorithmId: 'base64',
+        params: const CryptoParams(),
+      );
+      expect(
+        decoded,
+        '${'A' * 60}\u00e9${'B' * 60}\u00e8${'C' * 60}\u00fc${'D' * 20}',
+      );
+      expect(decoded.contains('\uFFFD'), isFalse);
+    });
+
+    test('\u622a\u65ad\u7684 UTF-8 \u4e2d\u6587\uff1a\u53ea\u4e22\u5c3e\u5b57\uff0c\u6b63\u6587\u4e0d\u6574\u6bb5\u9000 Latin-1', () {
+      final full = utf8.encode('\u4e2d\u6587\u6d4b\u8bd5\u5185\u5bb9\u591f\u957f\u4e00\u4e9b');
+      final truncated = full.sublist(0, full.length - 1);
+      final sample = base64.encode(truncated);
+      // \u5c3e\u90e8\u622a\u65ad\u4ecd\u5e94\u8ba4\u4f5c\u6587\u672c\u7f16\u7801\uff0c\u4e0d\u8be5\u88ab\u63a8\u53bb\u5efa\u8bae\u5bf9\u79f0\u7b97\u6cd5
+      expect(CryptoToolbox.suggestDecrypt(sample).algorithmId, 'base64');
+      final decoded = CryptoToolbox.decrypt(
+        ciphertext: sample,
+        algorithmId: 'base64',
+        params: const CryptoParams(),
+      );
+      expect(decoded, startsWith('\u4e2d\u6587\u6d4b\u8bd5\u5185\u5bb9\u591f\u957f\u4e00'));
+      // \u8001\u884c\u4e3a\u4f1a\u6574\u6bb5\u9000 Latin-1\uff0c\u628a\u6b63\u5e38\u4e2d\u6587\u4e00\u8d77\u53d8\u6210 \u00e4\u00b8\u00ad\u00e6 \u8fd9\u7c7b\u4e71\u7801
+      expect(decoded.contains('\u00e4'), isFalse);
+    });
+
+    test('Hex \u901a\u9053\uff1a\u55c5\u63a2\u5efa\u8bae hex \u540e\u5fc5\u987b\u771f\u80fd\u89e3\u51fa\uff0c\u4e0d\u80fd\u9009\u4e2d\u5373\u62a5\u9519', () {
+      final bytes = <int>[
+        ...utf8.encode('hello world this is a fairly long hex payload here ok'),
+        0xff,
+      ];
+      final hexText =
+          bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+      expect(CryptoToolbox.suggestDecrypt(hexText).algorithmId, 'hex');
+      expect(
+        () => CryptoToolbox.decrypt(
+          ciphertext: hexText,
+          algorithmId: 'hex',
+          params: const CryptoParams(),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('Hex / Base32 \u901a\u9053\u540c\u6837\u4fee\u590d CESU-8', () {
+      // U+1F389 \u7684 CESU-8 \u5f62\u6001\uff1aD83C DF89 -> ED A0 BC ED BE 89
+      final bytes = <int>[
+        0xed, 0xa0, 0xbc, 0xed, 0xbe, 0x89,
+        ...utf8.encode(' \u4f1a\u8bae'),
+      ];
+      final hexText =
+          bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+      expect(
+        CryptoToolbox.decrypt(
+          ciphertext: hexText,
+          algorithmId: 'hex',
+          params: const CryptoParams(),
+        ),
+        '\u{1F389} \u4f1a\u8bae',
+      );
+
+      final base32Text = CryptoToolbox.encrypt(
+        plaintext: '\u{1F389} \u4f1a\u8bae',
+        algorithmId: 'base32',
+        params: const CryptoParams(),
+      );
+      expect(
+        CryptoToolbox.decrypt(
+          ciphertext: base32Text,
+          algorithmId: 'base32',
+          params: const CryptoParams(),
+        ),
+        '\u{1F389} \u4f1a\u8bae',
       );
     });
 

--- a/test/services/crypto/crypto_toolbox_test.dart
+++ b/test/services/crypto/crypto_toolbox_test.dart
@@ -306,6 +306,40 @@ void main() {
       expect(suggestion.algorithmId, 'aes-256-cbc');
     });
 
+    test('Base64 keeps UTF-8 text with CESU-8 emoji and one bad byte', () {
+      final bytes = <int>[
+        ...utf8.encode('Synthetic UTF-8 text with \u4e2d\u6587 '),
+        // U+1F449 encoded as CESU-8: D83D DC49 -> ED A0 BD ED B1 89.
+        0xed, 0xa0, 0xbd, 0xed, 0xb1, 0x89,
+        ...utf8.encode(' tail with enough readable text'),
+        0xff, // one malformed trailing byte
+      ];
+      final sample = base64.encode(bytes);
+
+      expect(CryptoToolbox.suggestDecrypt(sample).algorithmId, 'base64');
+      expect(
+        CryptoToolbox.decrypt(
+          ciphertext: sample,
+          algorithmId: 'base64',
+          params: const CryptoParams(),
+        ),
+        'Synthetic UTF-8 text with \u4e2d\u6587 \u{1F449} '
+        'tail with enough readable text\uFFFD',
+      );
+    });
+
+    test('Base64 keeps Latin-1 fallback for genuinely non-UTF-8 bytes', () {
+      final sample = base64.encode(<int>[0x43, 0x61, 0x66, 0xe9]);
+      expect(
+        CryptoToolbox.decrypt(
+          ciphertext: sample,
+          algorithmId: 'base64',
+          params: const CryptoParams(),
+        ),
+        'Caf\u00e9',
+      );
+    });
+
     test('纯 base64 内容探测：UTF-8 文本建议 base64、二进制建议对称算法', () {
       // UTF-8 可读 → base64 编码
       expect(


### PR DESCRIPTION
## 问题

Base64 解码遇到部分非标准 UTF-8 文本时，会出现自动识别错误和整段乱码。

例如部分上游会将 emoji 的 UTF-16 surrogate pair 按 CESU-8/WTF-8 形式编码。此时：

- Base64 嗅探的严格 UTF-8 检查失败，会把本来主要是文本的内容误判为二进制 payload，自动建议 AES-256-CBC
- 手动选择 Base64 后，严格 UTF-8 解码失败，整段回退 Latin-1，导致原本正常的 UTF-8 中文一起变成乱码

## 修复

- Base64 文本解码兼容成对的 CESU-8 surrogate pair
- 对只有少量损坏字节的文本保留正常 UTF-8 内容，并使用 U+FFFD 替代坏字节
- 嗅探阶段同步使用兼容后的文本判断，避免误建议 AES-256-CBC
- 保留真正非 UTF-8 字节内容的 Latin-1 fallback
- 增加人工构造的回归测试，不包含真实用户内容

## 验证

- `git diff --check` 通过
- 新增 CESU-8 emoji + 单个损坏字节的 Base64 回归用例
- 新增 Latin-1 fallback 回归用例