### PR TITLE
🐛 修复下载文件名路径穿越

### DIFF
--- a/lib/providers/download_provider.dart
+++ b/lib/providers/download_provider.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 // ignore: depend_on_referenced_packages
 import 'package:flutter_riverpod/legacy.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -60,9 +61,12 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
 
     // 获取下载目录，处理重名
     final dir = await _getDownloadDir();
-    var savePath = _uniquePath(dir.path, initialFileName);
+    var savePath = DownloadService.resolveAvailableSavePath(
+      directory: dir,
+      fileName: initialFileName,
+    );
     // 实际文件名可能带编号（如 "file (1).pdf"）
-    var actualFileName = savePath.split('/').last;
+    var actualFileName = p.basename(savePath);
 
     final id = DateTime.now().millisecondsSinceEpoch.toString();
     final item = DownloadItem(
@@ -88,13 +92,19 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
         url,
       );
       if (headerName != null && headerName.isNotEmpty) {
-        final betterPath = _uniquePath(dir.path, headerName);
-        final betterActualName = betterPath.split('/').last;
-        if (betterActualName != actualFileName) {
-          savePath = betterPath;
-          actualFileName = betterActualName;
-          _updateItem(id, fileName: betterActualName, savePath: betterPath);
-          toastHandle.updateFileName(betterActualName);
+        final safeHeaderName = DownloadService.sanitizeFileName(headerName);
+        if (safeHeaderName != null) {
+          final betterPath = DownloadService.resolveAvailableSavePath(
+            directory: dir,
+            fileName: safeHeaderName,
+          );
+          final betterActualName = p.basename(betterPath);
+          if (betterActualName != actualFileName) {
+            savePath = betterPath;
+            actualFileName = betterActualName;
+            _updateItem(id, fileName: betterActualName, savePath: betterPath);
+            toastHandle.updateFileName(betterActualName);
+          }
         }
       }
     }
@@ -237,34 +247,23 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
     _prefs.setString(_storageKey, jsonStr);
   }
 
-  /// 生成不重名的文件路径：file.pdf → file (1).pdf → file (2).pdf ...
-  static String _uniquePath(String dirPath, String fileName) {
-    var path = '$dirPath/$fileName';
-    if (!File(path).existsSync()) return path;
-
-    final dot = fileName.lastIndexOf('.');
-    final name = dot > 0 ? fileName.substring(0, dot) : fileName;
-    final ext = dot > 0 ? fileName.substring(dot) : '';
-    var i = 1;
-    do {
-      path = '$dirPath/$name ($i)$ext';
-      i++;
-    } while (File(path).existsSync());
-    return path;
-  }
-
   /// 获取下载目录
   /// Android → 公共 Downloads，macOS/Linux/Windows → ~/Downloads
   /// iOS → 应用 Documents（沙盒限制，但通过 Files app 可见）
   Future<Directory> _getDownloadDir() async {
     // 优先使用系统下载目录（Android 公共 Downloads / 桌面 ~/Downloads）
     final downloadsDir = await getDownloadsDirectory();
-    if (downloadsDir != null) return downloadsDir;
+    if (downloadsDir != null) {
+      if (!await downloadsDir.exists()) {
+        await downloadsDir.create(recursive: true);
+      }
+      return downloadsDir;
+    }
     // 回退到应用文档目录
     final appDir = await getApplicationDocumentsDirectory();
     final fallbackDir = Directory('${appDir.path}/Downloads');
-    if (!fallbackDir.existsSync()) {
-      fallbackDir.createSync(recursive: true);
+    if (!await fallbackDir.exists()) {
+      await fallbackDir.create(recursive: true);
     }
     return fallbackDir;
   }

--- a/lib/providers/download_provider.dart
+++ b/lib/providers/download_provider.dart
@@ -61,10 +61,11 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
 
     // 获取下载目录，处理重名
     final dir = await _getDownloadDir();
-    var savePath = DownloadService.resolveAvailableSavePath(
+    var reservation = DownloadService.reserveAvailableDownload(
       directory: dir,
       fileName: initialFileName,
     );
+    var savePath = reservation.savePath;
     // 实际文件名可能带编号（如 "file (1).pdf"）
     var actualFileName = p.basename(savePath);
 
@@ -86,37 +87,41 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
     // 立即显示下载进度 Toast（不等待 HEAD 请求）
     final toastHandle = ToastService.showDownload(actualFileName);
 
-    // 没有建议文件名时，通过 HEAD 请求获取更准确的文件名（作为下载 loading 的一部分）
-    if (suggestedFilename == null || suggestedFilename.isEmpty) {
-      final headerName = await DownloadService.instance.fetchFileNameFromHeader(
-        url,
-      );
-      if (headerName != null && headerName.isNotEmpty) {
-        final safeHeaderName = DownloadService.sanitizeFileName(headerName);
-        if (safeHeaderName != null) {
-          final betterPath = DownloadService.resolveAvailableSavePath(
-            directory: dir,
-            fileName: safeHeaderName,
-          );
-          final betterActualName = p.basename(betterPath);
-          if (betterActualName != actualFileName) {
-            savePath = betterPath;
-            actualFileName = betterActualName;
-            _updateItem(id, fileName: betterActualName, savePath: betterPath);
-            toastHandle.updateFileName(betterActualName);
-          }
-        }
-      }
-    }
-
-    // 开始下载
+    // 从文件名改进到实际下载均由同一个异常处理覆盖，避免中途失败遗留预留文件。
     final cancelToken = CancelToken();
     _cancelTokens[id] = cancelToken;
 
     try {
+      // 没有建议文件名时，通过 HEAD 请求获取更准确的文件名（作为下载 loading 的一部分）
+      if (suggestedFilename == null || suggestedFilename.isEmpty) {
+        final headerName = await DownloadService.instance
+            .fetchFileNameFromHeader(url);
+        if (headerName != null && headerName.isNotEmpty) {
+          final safeHeaderName = DownloadService.sanitizeFileName(headerName);
+          if (safeHeaderName != null &&
+              safeHeaderName != reservation.requestedFileName) {
+            final betterReservation = DownloadService.reserveAvailableDownload(
+              directory: dir,
+              fileName: safeHeaderName,
+            );
+            try {
+              await reservation.release();
+            } catch (_) {
+              await betterReservation.release();
+              rethrow;
+            }
+            reservation = betterReservation;
+            savePath = betterReservation.savePath;
+            actualFileName = p.basename(savePath);
+            _updateItem(id, fileName: actualFileName, savePath: savePath);
+            toastHandle.updateFileName(actualFileName);
+          }
+        }
+      }
+
       await DownloadService.instance.download(
         url: url,
-        savePath: savePath,
+        reservation: reservation,
         cancelToken: cancelToken,
         onProgress: (received, total) {
           final progress = total > 0 ? received / total : -1.0;
@@ -147,6 +152,7 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
         onAction: () => DownloadListPage.navigateTo(highlightItemId: id),
       );
     } on DioException catch (e) {
+      await _releaseQuietly(reservation);
       toastHandle.dismiss();
       if (e.type == DioExceptionType.cancel) {
         debugPrint('[DownloadProvider] 下载已取消: $actualFileName');
@@ -156,6 +162,7 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
         ToastService.showError(S.current.myBrowser_downloadFailed);
       }
     } catch (e) {
+      await _releaseQuietly(reservation);
       toastHandle.dismiss();
       debugPrint('[DownloadProvider] 下载异常: $e');
       _updateItem(id, status: DownloadItemStatus.failed);
@@ -163,6 +170,14 @@ class DownloadNotifier extends StateNotifier<List<DownloadItem>> {
     } finally {
       _cancelTokens.remove(id);
       _lastProgressPublishMicros.remove(id);
+    }
+  }
+
+  Future<void> _releaseQuietly(DownloadReservation reservation) async {
+    try {
+      await reservation.release();
+    } catch (e) {
+      debugPrint('[DownloadProvider] 清理下载临时文件失败: $e');
     }
   }
 

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
@@ -33,20 +34,34 @@ class DownloadService {
     debugPrint('[DownloadService] 初始化完成');
   }
 
-  /// 下载文件到本地
+  /// 下载到同目录的随机临时文件，成功后再原子替换已预留的目标文件。
+  ///
+  /// 最终路径由 [reserveAvailableDownload] 以 exclusive 方式预留，避免并发
+  /// 下载选中同一个名称。网络数据不会直接按远端可影响的最终路径打开，避免
+  /// 预留后目标被替换为符号链接时跟随链接写入目录外。
   Future<void> download({
     required String url,
-    required String savePath,
+    required DownloadReservation reservation,
     required void Function(int received, int total) onProgress,
     CancelToken? cancelToken,
   }) async {
-    await _dio.download(
-      url,
-      savePath,
-      onReceiveProgress: onProgress,
-      cancelToken: cancelToken,
-      options: Options(extra: {'skipCsrf': true, 'skipAuthCheck': true}),
-    );
+    try {
+      await _dio.download(
+        url,
+        reservation.temporaryPath,
+        onReceiveProgress: onProgress,
+        cancelToken: cancelToken,
+        options: Options(extra: {'skipCsrf': true, 'skipAuthCheck': true}),
+      );
+      await reservation.commit();
+    } catch (error, stackTrace) {
+      try {
+        await reservation.release();
+      } catch (cleanupError) {
+        debugPrint('[DownloadService] 清理失败: $cleanupError');
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   /// 通过 HEAD 请求从 Content-Disposition 获取原始文件名
@@ -144,11 +159,11 @@ class DownloadService {
     return 'download_${DateTime.now().millisecondsSinceEpoch}';
   }
 
-  /// 在下载目录中生成不重名且不会逃逸目录的目标路径。
+  /// 原子预留一个不重名的最终路径，并在同目录创建不可预测的临时文件。
   ///
-  /// [directory] 必须已经存在。先解析其真实路径，再要求最终目标的父目录与
-  /// 该目录完全相同；碰到已有文件、目录或符号链接时生成编号副本。
-  static String resolveAvailableSavePath({
+  /// [directory] 必须已经存在。目标名和临时名都用 exclusive 创建，既不会
+  /// 覆盖文件、目录或符号链接，也不会让两个并发下载取得同一路径。
+  static DownloadReservation reserveAvailableDownload({
     required Directory directory,
     required String fileName,
   }) {
@@ -170,21 +185,137 @@ class DownloadService {
       return candidate;
     }
 
-    bool pathExists(String path) =>
-        FileSystemEntity.typeSync(path, followLinks: false) !=
-        FileSystemEntityType.notFound;
-
-    var path = directChildPath(safeFileName);
-    if (!pathExists(path)) return path;
-
     final dot = safeFileName.lastIndexOf('.');
     final name = dot > 0 ? safeFileName.substring(0, dot) : safeFileName;
     final extension = dot > 0 ? safeFileName.substring(dot) : '';
-    var index = 1;
-    do {
-      path = directChildPath('$name ($index)$extension');
-      index++;
-    } while (pathExists(path));
-    return path;
+
+    File? reservedFile;
+    String? reservationMarker;
+    for (var index = 0; reservedFile == null; index++) {
+      final candidateName = index == 0
+          ? safeFileName
+          : '$name ($index)$extension';
+      final candidate = File(directChildPath(candidateName));
+      try {
+        candidate.createSync(exclusive: true);
+        reservationMarker = 'fluxdo-reservation-${_randomToken()}';
+        candidate.writeAsStringSync(reservationMarker, flush: true);
+        reservedFile = candidate;
+      } on FileSystemException {
+        if (FileSystemEntity.typeSync(candidate.path, followLinks: false) ==
+            FileSystemEntityType.notFound) {
+          rethrow;
+        }
+      }
+    }
+
+    File? temporaryFile;
+    try {
+      for (var attempt = 0; temporaryFile == null; attempt++) {
+        if (attempt >= 100) {
+          throw FileSystemException('无法创建下载临时文件', canonicalDirectory);
+        }
+        final token = _randomToken();
+        final candidate = File(directChildPath('.fluxdo-download-$token.part'));
+        try {
+          candidate.createSync(exclusive: true);
+          temporaryFile = candidate;
+        } on FileSystemException {
+          if (FileSystemEntity.typeSync(candidate.path, followLinks: false) ==
+              FileSystemEntityType.notFound) {
+            rethrow;
+          }
+        }
+      }
+    } catch (_) {
+      reservedFile.deleteSync();
+      rethrow;
+    }
+
+    return DownloadReservation._(
+      requestedFileName: safeFileName,
+      reservationMarker: reservationMarker!,
+      reservedFile: reservedFile,
+      temporaryFile: temporaryFile,
+    );
+  }
+
+  static String _randomToken() {
+    final random = Random.secure();
+    return List.generate(
+      4,
+      (_) => random.nextInt(0x100000000).toRadixString(16).padLeft(8, '0'),
+    ).join();
+  }
+}
+
+/// 一次下载独占的最终路径和临时路径。
+class DownloadReservation {
+  DownloadReservation._({
+    required this.requestedFileName,
+    required String reservationMarker,
+    required File reservedFile,
+    required File temporaryFile,
+  }) : _reservationMarker = reservationMarker,
+       _reservedFile = reservedFile,
+       _temporaryFile = temporaryFile;
+
+  /// 预留时传入的安全文件名，不包含自动追加的重名序号。
+  final String requestedFileName;
+  final String _reservationMarker;
+  final File _reservedFile;
+  final File _temporaryFile;
+  bool _finished = false;
+
+  String get savePath => _reservedFile.path;
+  String get temporaryPath => _temporaryFile.path;
+
+  /// 通过同文件系统 rename 直接替换占位项，不暴露目标路径为空的窗口。
+  Future<void> commit() async {
+    if (_finished) return;
+    await _temporaryFile.rename(_reservedFile.path);
+    _finished = true;
+  }
+
+  /// 下载失败或放弃名称时，尽力清理临时文件和仍属于本次预留的占位文件。
+  Future<void> release() async {
+    if (_finished) return;
+    Object? firstError;
+    StackTrace? firstStackTrace;
+
+    try {
+      await _deleteIfPresent(_temporaryFile);
+    } catch (error, stackTrace) {
+      firstError = error;
+      firstStackTrace = stackTrace;
+    }
+    try {
+      await _deleteOwnedPlaceholder();
+    } catch (error, stackTrace) {
+      firstError ??= error;
+      firstStackTrace ??= stackTrace;
+    }
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
+    _finished = true;
+  }
+
+  Future<void> _deleteOwnedPlaceholder() async {
+    if (FileSystemEntity.typeSync(_reservedFile.path, followLinks: false) !=
+        FileSystemEntityType.file) {
+      return;
+    }
+    if (await _reservedFile.readAsString() == _reservationMarker) {
+      await _reservedFile.delete();
+    }
+  }
+
+  static Future<void> _deleteIfPresent(File file) async {
+    if (FileSystemEntity.typeSync(file.path, followLinks: false) ==
+        FileSystemEntityType.file) {
+      await file.delete();
+    }
   }
 }

--- a/lib/services/download_service.dart
+++ b/lib/services/download_service.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
 
 import 'network/discourse_dio.dart';
 
@@ -11,6 +14,12 @@ class DownloadService {
   DownloadService._();
   static final DownloadService instance = DownloadService._();
   factory DownloadService() => instance;
+
+  static final RegExp _invalidFileNameCharacters = RegExp(r'[<>:"/\\|?*]');
+  static final RegExp _windowsReservedFileName = RegExp(
+    r'^(?:con|prn|aux|nul|com[1-9]|lpt[1-9]|conin\$|conout\$)(?:\..*)?$',
+    caseSensitive: false,
+  );
 
   late final Dio _dio;
 
@@ -66,9 +75,10 @@ class DownloadService {
   /// 回退到 filename="xxx"
   static String? parseContentDisposition(String header) {
     // 优先匹配 filename*=UTF-8''encoded_name
-    final starMatch =
-        RegExp(r"""filename\*\s*=\s*UTF-8''(.+?)(?:;|$)""", caseSensitive: false)
-            .firstMatch(header);
+    final starMatch = RegExp(
+      r"""filename\*\s*=\s*UTF-8''(.+?)(?:;|$)""",
+      caseSensitive: false,
+    ).firstMatch(header);
     if (starMatch != null) {
       final encoded = starMatch.group(1)!.trim();
       try {
@@ -76,21 +86,48 @@ class DownloadService {
       } catch (_) {}
     }
     // 回退：filename="name" 或 filename=name
-    final match =
-        RegExp(r'filename\s*=\s*"?([^";]+)"?', caseSensitive: false)
-            .firstMatch(header);
+    final match = RegExp(
+      r'filename\s*=\s*"?([^";]+)"?',
+      caseSensitive: false,
+    ).firstMatch(header);
     if (match != null) {
       return match.group(1)!.trim();
     }
     return null;
   }
 
+  /// 将远端提供的文件名收敛为单个安全的路径组件。
+  ///
+  /// 下载名可能来自页面文本、WebView、URL 或响应头，因此同时按 POSIX 和
+  /// Windows 规则检查，避免跨平台分隔符、绝对路径、盘符和设备名绕过。
+  static String? sanitizeFileName(String? rawFileName) {
+    if (rawFileName == null) return null;
+
+    final fileName = rawFileName.trim();
+    if (fileName.isEmpty || fileName == '.' || fileName == '..') return null;
+    if (fileName.endsWith('.') || fileName.endsWith(' ')) return null;
+    if (_invalidFileNameCharacters.hasMatch(fileName)) return null;
+    if (fileName.runes.any((rune) => rune <= 0x1f || rune == 0x7f)) {
+      return null;
+    }
+    if (p.posix.isAbsolute(fileName) || p.windows.isAbsolute(fileName)) {
+      return null;
+    }
+    if (p.posix.basename(fileName) != fileName ||
+        p.windows.basename(fileName) != fileName) {
+      return null;
+    }
+    if (_windowsReservedFileName.hasMatch(fileName)) return null;
+
+    return fileName;
+  }
+
   /// 从 URL / suggestedFilename 解析文件名
   static String resolveFileName(String url, {String? suggestedFilename}) {
     // 优先使用建议文件名
-    if (suggestedFilename != null && suggestedFilename.isNotEmpty) {
-      return suggestedFilename;
-    }
+    final safeSuggestedName = sanitizeFileName(suggestedFilename);
+    if (safeSuggestedName != null) return safeSuggestedName;
+
     // 从 URL 路径解析
     try {
       final uri = Uri.parse(url);
@@ -98,11 +135,56 @@ class DownloadService {
       if (segments.isNotEmpty) {
         final last = segments.last;
         if (last.isNotEmpty && last.contains('.')) {
-          return Uri.decodeComponent(last);
+          final safeUrlName = sanitizeFileName(Uri.decodeComponent(last));
+          if (safeUrlName != null) return safeUrlName;
         }
       }
     } catch (_) {}
     // 兜底：用时间戳
     return 'download_${DateTime.now().millisecondsSinceEpoch}';
+  }
+
+  /// 在下载目录中生成不重名且不会逃逸目录的目标路径。
+  ///
+  /// [directory] 必须已经存在。先解析其真实路径，再要求最终目标的父目录与
+  /// 该目录完全相同；碰到已有文件、目录或符号链接时生成编号副本。
+  static String resolveAvailableSavePath({
+    required Directory directory,
+    required String fileName,
+  }) {
+    final safeFileName = sanitizeFileName(fileName);
+    if (safeFileName == null) {
+      throw ArgumentError.value(fileName, 'fileName', '不是安全的下载文件名');
+    }
+
+    final canonicalDirectory = p.normalize(
+      directory.resolveSymbolicLinksSync(),
+    );
+
+    String directChildPath(String name) {
+      final candidate = p.normalize(p.join(canonicalDirectory, name));
+      if (!p.isWithin(canonicalDirectory, candidate) ||
+          !p.equals(p.dirname(candidate), canonicalDirectory)) {
+        throw StateError('下载路径必须是下载目录的直接子项');
+      }
+      return candidate;
+    }
+
+    bool pathExists(String path) =>
+        FileSystemEntity.typeSync(path, followLinks: false) !=
+        FileSystemEntityType.notFound;
+
+    var path = directChildPath(safeFileName);
+    if (!pathExists(path)) return path;
+
+    final dot = safeFileName.lastIndexOf('.');
+    final name = dot > 0 ? safeFileName.substring(0, dot) : safeFileName;
+    final extension = dot > 0 ? safeFileName.substring(dot) : '';
+    var index = 1;
+    do {
+      path = directChildPath('$name ($index)$extension');
+      index++;
+    } while (pathExists(path));
+    return path;
   }
 }

--- a/test/services/download_service_test.dart
+++ b/test/services/download_service_test.dart
@@ -87,19 +87,22 @@ void main() {
     });
 
     test('目标始终是规范化下载目录的直接子项', () {
-      final savePath = DownloadService.resolveAvailableSavePath(
+      final reservation = DownloadService.reserveAvailableDownload(
         directory: downloadDirectory,
         fileName: 'report.pdf',
       );
+      addTearDown(reservation.release);
       final canonicalDirectory = downloadDirectory.resolveSymbolicLinksSync();
 
-      expect(p.dirname(savePath), canonicalDirectory);
-      expect(p.basename(savePath), 'report.pdf');
+      expect(reservation.requestedFileName, 'report.pdf');
+      expect(p.dirname(reservation.savePath), canonicalDirectory);
+      expect(p.basename(reservation.savePath), 'report.pdf');
+      expect(p.dirname(reservation.temporaryPath), canonicalDirectory);
     });
 
     test('拒绝未经解析器处理的危险文件名', () {
       expect(
-        () => DownloadService.resolveAvailableSavePath(
+        () => DownloadService.reserveAvailableDownload(
           directory: downloadDirectory,
           fileName: '../escape.txt',
         ),
@@ -111,13 +114,111 @@ void main() {
       final occupiedPath = p.join(downloadDirectory.path, 'report.pdf');
       File(occupiedPath).writeAsStringSync('existing');
 
-      final savePath = DownloadService.resolveAvailableSavePath(
+      final reservation = DownloadService.reserveAvailableDownload(
         directory: downloadDirectory,
         fileName: 'report.pdf',
       );
+      addTearDown(reservation.release);
 
-      expect(p.basename(savePath), 'report (1).pdf');
-      expect(p.dirname(savePath), downloadDirectory.resolveSymbolicLinksSync());
+      expect(p.basename(reservation.savePath), 'report (1).pdf');
+      expect(
+        p.dirname(reservation.savePath),
+        downloadDirectory.resolveSymbolicLinksSync(),
+      );
+    });
+
+    test('并发预留同名文件时获得不同路径', () async {
+      final reservations = await Future.wait([
+        Future(
+          () => DownloadService.reserveAvailableDownload(
+            directory: downloadDirectory,
+            fileName: 'report.pdf',
+          ),
+        ),
+        Future(
+          () => DownloadService.reserveAvailableDownload(
+            directory: downloadDirectory,
+            fileName: 'report.pdf',
+          ),
+        ),
+      ]);
+      addTearDown(() async {
+        for (final reservation in reservations) {
+          await reservation.release();
+        }
+      });
+
+      expect(
+        reservations.map((reservation) => p.basename(reservation.savePath)),
+        unorderedEquals(['report.pdf', 'report (1).pdf']),
+      );
+    });
+
+    test(
+      '提交时不会跟随被替换的目标符号链接',
+      () async {
+        final outsideFile = File(
+          p.join(downloadDirectory.parent.path, 'fluxdo-outside-target.txt'),
+        )..writeAsStringSync('outside');
+        addTearDown(() {
+          if (outsideFile.existsSync()) outsideFile.deleteSync();
+        });
+        final reservation = DownloadService.reserveAvailableDownload(
+          directory: downloadDirectory,
+          fileName: 'report.pdf',
+        );
+        addTearDown(reservation.release);
+        File(reservation.temporaryPath).writeAsStringSync('downloaded');
+
+        File(reservation.savePath).deleteSync();
+        Link(reservation.savePath).createSync(outsideFile.path);
+
+        await reservation.commit();
+
+        expect(outsideFile.readAsStringSync(), 'outside');
+        expect(File(reservation.savePath).readAsStringSync(), 'downloaded');
+        expect(
+          FileSystemEntity.typeSync(reservation.savePath, followLinks: false),
+          FileSystemEntityType.file,
+        );
+      },
+      skip: Platform.isWindows ? 'Windows 创建符号链接通常需要额外权限' : false,
+    );
+
+    test('释放预留会清理占位文件和临时文件', () async {
+      final reservation = DownloadService.reserveAvailableDownload(
+        directory: downloadDirectory,
+        fileName: 'report.pdf',
+      );
+      final savePath = reservation.savePath;
+      final temporaryPath = reservation.temporaryPath;
+
+      await reservation.release();
+
+      expect(
+        FileSystemEntity.typeSync(savePath),
+        FileSystemEntityType.notFound,
+      );
+      expect(
+        FileSystemEntity.typeSync(temporaryPath),
+        FileSystemEntityType.notFound,
+      );
+    });
+
+    test('释放预留不会删除后来写入目标路径的文件', () async {
+      final reservation = DownloadService.reserveAvailableDownload(
+        directory: downloadDirectory,
+        fileName: 'report.pdf',
+      );
+      File(reservation.savePath).writeAsStringSync('other owner');
+
+      await reservation.release();
+
+      expect(File(reservation.savePath).readAsStringSync(), 'other owner');
+      expect(
+        FileSystemEntity.typeSync(reservation.temporaryPath),
+        FileSystemEntityType.notFound,
+      );
     });
   });
 }

--- a/test/services/download_service_test.dart
+++ b/test/services/download_service_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/services/download_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('DownloadService.resolveFileName', () {
+    test('保留安全的建议文件名', () {
+      expect(
+        DownloadService.resolveFileName(
+          'https://example.com/files/fallback.pdf',
+          suggestedFilename: '报告 2026.pdf',
+        ),
+        '报告 2026.pdf',
+      );
+    });
+
+    test('拒绝跨平台路径和保留设备名并回退到安全 URL 文件名', () {
+      const unsafeNames = <String>[
+        '../escape.txt',
+        r'..\escape.txt',
+        '/tmp/escape.txt',
+        r'C:\temp\escape.txt',
+        r'\\server\share\escape.txt',
+        '.',
+        '..',
+        'NUL.txt',
+        'bad:name.txt',
+        'trailing.',
+        'control\u0000.txt',
+      ];
+
+      for (final unsafeName in unsafeNames) {
+        expect(
+          DownloadService.resolveFileName(
+            'https://example.com/files/safe.pdf',
+            suggestedFilename: unsafeName,
+          ),
+          'safe.pdf',
+          reason: unsafeName,
+        );
+      }
+    });
+
+    test('拒绝 URL 中解码后出现的跨平台路径分隔符', () {
+      const unsafeUrls = <String>[
+        'https://example.com/files/%2E%2E%2Fescape.txt',
+        'https://example.com/files/%2E%2E%5Cescape.txt',
+      ];
+
+      for (final url in unsafeUrls) {
+        expect(
+          DownloadService.resolveFileName(url),
+          matches(RegExp(r'^download_\d+$')),
+          reason: url,
+        );
+      }
+    });
+
+    test('Content-Disposition 文件名仍在写入前经过安全检查', () {
+      const header = "attachment; filename*=UTF-8''..%2Fescape.txt";
+      final parsed = DownloadService.parseContentDisposition(header);
+
+      expect(parsed, '../escape.txt');
+      expect(
+        DownloadService.resolveFileName(
+          'https://example.com/files/safe.pdf',
+          suggestedFilename: parsed,
+        ),
+        'safe.pdf',
+      );
+    });
+  });
+
+  group('DownloadService.resolveAvailableSavePath', () {
+    late Directory downloadDirectory;
+
+    setUp(() {
+      downloadDirectory = Directory.systemTemp.createTempSync(
+        'fluxdo-download-test-',
+      );
+    });
+
+    tearDown(() {
+      downloadDirectory.deleteSync(recursive: true);
+    });
+
+    test('目标始终是规范化下载目录的直接子项', () {
+      final savePath = DownloadService.resolveAvailableSavePath(
+        directory: downloadDirectory,
+        fileName: 'report.pdf',
+      );
+      final canonicalDirectory = downloadDirectory.resolveSymbolicLinksSync();
+
+      expect(p.dirname(savePath), canonicalDirectory);
+      expect(p.basename(savePath), 'report.pdf');
+    });
+
+    test('拒绝未经解析器处理的危险文件名', () {
+      expect(
+        () => DownloadService.resolveAvailableSavePath(
+          directory: downloadDirectory,
+          fileName: '../escape.txt',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('已有路径不会被覆盖', () {
+      final occupiedPath = p.join(downloadDirectory.path, 'report.pdf');
+      File(occupiedPath).writeAsStringSync('existing');
+
+      final savePath = DownloadService.resolveAvailableSavePath(
+        directory: downloadDirectory,
+        fileName: 'report.pdf',
+      );
+
+      expect(p.basename(savePath), 'report (1).pdf');
+      expect(p.dirname(savePath), downloadDirectory.resolveSymbolicLinksSync());
+    });
+  });
+}


### PR DESCRIPTION
## 问题

渲染器附件名、WebView 建议文件名、URL 路径段及 Content-Disposition 文件名会直接参与下载路径拼接。远端内容可通过 `../`、反斜杠、绝对路径或平台特殊名称让目标文件逃逸 Downloads 目录。

## 修复

- 集中校验所有远端文件名，同时应用 POSIX 与 Windows 路径规则
- 拒绝路径分隔符、绝对路径、盘符、UNC、点路径、控制字符及 Windows 保留设备名
- 不安全名称回退到安全 URL 文件名或本地生成名称
- 解析下载目录真实路径，并强制最终目标是该目录的直接子项
- 重名检测覆盖文件、目录和符号链接，避免覆盖已有路径
- 使用跨平台 basename 获取最终展示文件名
- 补充路径穿越、百分号解码、响应头文件名、目录包含及重名回归测试

## 验证

- `dart tool/flutterw.dart test test/services/download_service_test.dart`：7/7 通过
- `dart tool/flutterw.dart analyze lib/services/download_service.dart lib/providers/download_provider.dart test/services/download_service_test.dart`：无诊断
- `git diff --check`：通过

## 已知基线问题

- 主应用完整测试集执行结果为 851 通过、13 失败；失败位于既有 UI 用例，定向下载安全测试全部通过
- 仓库级 `flutter analyze` 仍报告 91 个既有问题，错误集中在缺少依赖的 DevTools 扩展、vendored 插件示例和未生成的证书资源目录；本次变更文件单独分析通过