### PR TITLE
fix: align emoji market group file paths

### DIFF
--- a/lib/l10n/modules/emojiSticker/emojiSticker_en.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_en.arb
@@ -24,6 +24,8 @@
   "sticker_groupEmpty": "No stickers in this group",
   "sticker_loadFailed": "Failed to load stickers",
   "sticker_marketEmpty": "No stickers available",
+  "sticker_marketSearchEmpty": "No matching sticker packs",
+  "sticker_marketSearchHint": "Search sticker packs...",
   "sticker_marketLoadFailed": "Failed to load market",
   "sticker_marketTitle": "Sticker market",
   "sticker_noStickers": "No stickers yet",

--- a/lib/l10n/modules/emojiSticker/emojiSticker_en.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_en.arb
@@ -24,9 +24,9 @@
   "sticker_groupEmpty": "No stickers in this group",
   "sticker_loadFailed": "Failed to load stickers",
   "sticker_marketEmpty": "No stickers available",
+  "sticker_marketLoadFailed": "Failed to load market",
   "sticker_marketSearchEmpty": "No matching sticker packs",
   "sticker_marketSearchHint": "Search sticker packs...",
-  "sticker_marketLoadFailed": "Failed to load market",
   "sticker_marketTitle": "Sticker market",
   "sticker_noStickers": "No stickers yet",
   "sticker_tab": "Stickers"

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh.arb
@@ -31,6 +31,8 @@
   "sticker_groupEmpty": "该分组暂无表情包",
   "sticker_loadFailed": "加载表情包失败",
   "sticker_marketEmpty": "暂无可用的表情包",
+  "sticker_marketSearchEmpty": "未找到匹配的表情包",
+  "sticker_marketSearchHint": "搜索表情包...",
   "sticker_marketLoadFailed": "加载市场失败",
   "sticker_marketTitle": "表情包市场",
   "sticker_noStickers": "还没有表情包",

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh.arb
@@ -31,9 +31,9 @@
   "sticker_groupEmpty": "该分组暂无表情包",
   "sticker_loadFailed": "加载表情包失败",
   "sticker_marketEmpty": "暂无可用的表情包",
+  "sticker_marketLoadFailed": "加载市场失败",
   "sticker_marketSearchEmpty": "未找到匹配的表情包",
   "sticker_marketSearchHint": "搜索表情包...",
-  "sticker_marketLoadFailed": "加载市场失败",
   "sticker_marketTitle": "表情包市场",
   "sticker_noStickers": "还没有表情包",
   "sticker_tab": "表情包"

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh_HK.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh_HK.arb
@@ -31,6 +31,8 @@
   "sticker_groupEmpty": "該分組暫無表情包",
   "sticker_loadFailed": "加載表情包失敗",
   "sticker_marketEmpty": "暫無可用的表情包",
+  "sticker_marketSearchEmpty": "未找到相符的表情包",
+  "sticker_marketSearchHint": "搜尋表情包...",
   "sticker_marketLoadFailed": "加載市場失敗",
   "sticker_marketTitle": "表情包市場",
   "sticker_noStickers": "還沒有表情包",

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh_HK.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh_HK.arb
@@ -31,9 +31,9 @@
   "sticker_groupEmpty": "該分組暫無表情包",
   "sticker_loadFailed": "加載表情包失敗",
   "sticker_marketEmpty": "暫無可用的表情包",
+  "sticker_marketLoadFailed": "加載市場失敗",
   "sticker_marketSearchEmpty": "未找到相符的表情包",
   "sticker_marketSearchHint": "搜尋表情包...",
-  "sticker_marketLoadFailed": "加載市場失敗",
   "sticker_marketTitle": "表情包市場",
   "sticker_noStickers": "還沒有表情包",
   "sticker_tab": "表情包"

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh_TW.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh_TW.arb
@@ -31,6 +31,8 @@
   "sticker_groupEmpty": "該分組暫無表情包",
   "sticker_loadFailed": "載入表情包失敗",
   "sticker_marketEmpty": "暫無可用的表情包",
+  "sticker_marketSearchEmpty": "未找到符合的表情包",
+  "sticker_marketSearchHint": "搜尋表情包...",
   "sticker_marketLoadFailed": "載入市場失敗",
   "sticker_marketTitle": "表情包市場",
   "sticker_noStickers": "還沒有表情包",

--- a/lib/l10n/modules/emojiSticker/emojiSticker_zh_TW.arb
+++ b/lib/l10n/modules/emojiSticker/emojiSticker_zh_TW.arb
@@ -31,9 +31,9 @@
   "sticker_groupEmpty": "該分組暫無表情包",
   "sticker_loadFailed": "載入表情包失敗",
   "sticker_marketEmpty": "暫無可用的表情包",
+  "sticker_marketLoadFailed": "載入市場失敗",
   "sticker_marketSearchEmpty": "未找到符合的表情包",
   "sticker_marketSearchHint": "搜尋表情包...",
-  "sticker_marketLoadFailed": "載入市場失敗",
   "sticker_marketTitle": "表情包市場",
   "sticker_noStickers": "還沒有表情包",
   "sticker_tab": "表情包"

--- a/lib/models/sticker.dart
+++ b/lib/models/sticker.dart
@@ -4,17 +4,51 @@ class StickerMarketIndex {
   final int pageSize;
   final int totalGroups;
 
+  /// 市场 topic（分类）列表，首项恒为「全部」。
+  /// 来自 index.json 的 topics 字段；旧版索引无此字段时为空列表。
+  final List<StickerMarketTopic> topics;
+
   const StickerMarketIndex({
     required this.totalPages,
     required this.pageSize,
     required this.totalGroups,
+    this.topics = const [],
   });
 
   factory StickerMarketIndex.fromJson(Map<String, dynamic> json) {
+    final rawTopics = json['topics'] as List<dynamic>? ?? [];
     return StickerMarketIndex(
       totalPages: json['totalPages'] as int? ?? 0,
       pageSize: json['pageSize'] as int? ?? 0,
       totalGroups: json['totalGroups'] as int? ?? 0,
+      topics: rawTopics
+          .whereType<Map<String, dynamic>>()
+          .map(StickerMarketTopic.fromJson)
+          .toList(),
+    );
+  }
+}
+
+/// 市场分类（topic）
+class StickerMarketTopic {
+  final String id;
+  final String label;
+  final int totalGroups;
+  final int totalPages;
+
+  const StickerMarketTopic({
+    required this.id,
+    required this.label,
+    required this.totalGroups,
+    required this.totalPages,
+  });
+
+  factory StickerMarketTopic.fromJson(Map<String, dynamic> json) {
+    return StickerMarketTopic(
+      id: json['id'] as String? ?? '',
+      label: json['label'] as String? ?? '',
+      totalGroups: json['totalGroups'] as int? ?? 0,
+      totalPages: json['totalPages'] as int? ?? 0,
     );
   }
 }
@@ -28,6 +62,9 @@ class StickerGroup {
   final int emojiCount;
   final bool isArchived;
 
+  /// 所属市场分类 id（旧数据可能缺失，空串表示未知）
+  final String topic;
+
   const StickerGroup({
     required this.id,
     required this.name,
@@ -35,8 +72,8 @@ class StickerGroup {
     required this.order,
     required this.emojiCount,
     required this.isArchived,
+    this.topic = '',
   });
-
   factory StickerGroup.fromJson(Map<String, dynamic> json) {
     return StickerGroup(
       id: json['id'] as String? ?? '',
@@ -45,6 +82,7 @@ class StickerGroup {
       order: json['order'] as int? ?? 0,
       emojiCount: json['emojiCount'] as int? ?? 0,
       isArchived: json['isArchived'] as bool? ?? false,
+      topic: json['topic'] as String? ?? '',
     );
   }
 }
@@ -79,13 +117,13 @@ class StickerItem {
   }
 
   Map<String, dynamic> toJson() => {
-        'id': id,
-        'name': name,
-        'url': url,
-        'width': width,
-        'height': height,
-        'groupId': groupId,
-      };
+    'id': id,
+    'name': name,
+    'url': url,
+    'width': width,
+    'height': height,
+    'groupId': groupId,
+  };
 
   /// 转换为 Markdown 图片格式
   String toMarkdown() => '![$name|${width}x$height,30%]($url)';
@@ -110,7 +148,8 @@ class StickerGroupDetail {
       id: json['id'] as String? ?? '',
       name: json['name'] as String? ?? '',
       icon: json['icon'] as String? ?? '',
-      emojis: (json['emojis'] as List<dynamic>?)
+      emojis:
+          (json['emojis'] as List<dynamic>?)
               ?.map((e) => StickerItem.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],

--- a/lib/models/sticker.dart
+++ b/lib/models/sticker.dart
@@ -4,27 +4,17 @@ class StickerMarketIndex {
   final int pageSize;
   final int totalGroups;
 
-  /// 市场 topic（分类）列表，首项恒为「全部」。
-  /// 来自 index.json 的 topics 字段；旧版索引无此字段时为空列表。
-  final List<StickerMarketTopic> topics;
-
   const StickerMarketIndex({
     required this.totalPages,
     required this.pageSize,
     required this.totalGroups,
-    this.topics = const [],
   });
 
   factory StickerMarketIndex.fromJson(Map<String, dynamic> json) {
-    final rawTopics = json['topics'] as List<dynamic>? ?? [];
     return StickerMarketIndex(
       totalPages: json['totalPages'] as int? ?? 0,
       pageSize: json['pageSize'] as int? ?? 0,
       totalGroups: json['totalGroups'] as int? ?? 0,
-      topics: rawTopics
-          .whereType<Map<String, dynamic>>()
-          .map(StickerMarketTopic.fromJson)
-          .toList(),
     );
   }
 }

--- a/lib/providers/sticker_provider.dart
+++ b/lib/providers/sticker_provider.dart
@@ -115,7 +115,21 @@ Future<void> _prefetchFirstScreenThumbnails(
   }
 }
 
+/// 市场分类（topic）列表（市场面板的分类 chips 数据源）
+final marketTopicsProvider =
+    FutureProvider.autoDispose<List<StickerMarketTopic>>((ref) async {
+      final service = ref.watch(stickerMarketServiceProvider);
+      final index = await service.getIndex();
+      return index.topics;
+    });
+
 /// 市场分组分页加载（供市场浏览面板使用）
+///
+/// 两种模式：
+/// - 浏览模式：按页懒加载当前分类（topic）的分组，滚动到底自动翻页；
+/// - 搜索模式：查询非空时先按已加载结果即时过滤，同时并行拉全当前
+///   分类的剩余页再全量过滤（全市场 ~300 组，全量拉取代价可忽略，
+///   页数据本就有 24h 缓存）。
 final marketGroupsProvider =
     StateNotifierProvider.autoDispose<
       MarketGroupsNotifier,
@@ -127,66 +141,151 @@ final marketGroupsProvider =
 
 class MarketGroupsNotifier
     extends StateNotifier<AsyncValue<List<StickerGroup>>> {
+  MarketGroupsNotifier(this._service) : super(const AsyncValue.loading()) {
+    _loadFirstPage();
+  }
+
   final StickerMarketService _service;
+
+  /// 当前分类 id（'all' = 全部）
+  String _topic = 'all';
+  String _query = '';
   int _loadedPages = 0;
   int _totalPages = 0;
   bool _isLoadingMore = false;
   bool _isLoadMoreFailed = false;
 
-  MarketGroupsNotifier(this._service) : super(const AsyncValue.loading()) {
-    _loadFirstPage();
-  }
+  /// 浏览模式下已加载的分组（未过滤；搜索过滤在其上进行）
+  List<StickerGroup> _groups = [];
 
-  bool get hasMore => _loadedPages < _totalPages;
+  /// 单飞序号：分类切换/搜索拉全量页是异步的，过期结果按序号丢弃
+  int _seq = 0;
+
+  bool get isSearchMode => _query.isNotEmpty;
+  bool get hasMore => !isSearchMode && _loadedPages < _totalPages;
   bool get isLoadingMore => _isLoadingMore;
   bool get isLoadMoreFailed => _isLoadMoreFailed;
 
-  void _emitCurrentData() {
-    final groups = state.value;
-    if (groups != null && mounted) {
-      state = AsyncValue.data(List<StickerGroup>.of(groups));
-    }
+  void _emit(List<StickerGroup> groups, {bool loading = false}) {
+    if (!mounted) return;
+    state = loading
+        ? const AsyncValue.loading()
+        : AsyncValue.data(List<StickerGroup>.of(groups));
+  }
+
+  List<StickerGroup> _applyQuery() {
+    if (_query.isEmpty) return _groups;
+    final q = _query.toLowerCase();
+    return _groups.where((g) => g.name.toLowerCase().contains(q)).toList();
   }
 
   Future<void> _loadFirstPage() async {
+    final seq = ++_seq;
+    _emit(const [], loading: true);
     try {
-      // 并行请求索引和第一页
-      final results = await Future.wait([
-        _service.getIndex(),
-        _service.getGroupsPage(1),
-      ]);
-      _totalPages = (results[0] as StickerMarketIndex).totalPages;
+      final (groups, totalPages) = await _service.getGroupsPageWithMeta(
+        1,
+        topic: _topic,
+      );
+      if (seq != _seq || !mounted) return;
+      _groups = groups;
       _loadedPages = 1;
+      _totalPages = totalPages;
       _isLoadMoreFailed = false;
-      state = AsyncValue.data(results[1] as List<StickerGroup>);
+      _emit(_applyQuery());
     } catch (e, st) {
+      if (seq != _seq || !mounted) return;
       AppLogger.error(
         '加载表情包市场首页失败',
         tag: 'Sticker',
         error: e,
         stackTrace: st,
-        fields: {'baseUrl': _service.baseUrl},
+        fields: {'baseUrl': _service.baseUrl, 'topic': _topic},
       );
       state = AsyncValue.error(e, st);
     }
   }
 
+  /// 切换分类。清空搜索词（UI 侧同步清空输入框），重载该分类第一页。
+  Future<void> setTopic(String topic) async {
+    if (topic == _topic) return;
+    _topic = topic;
+    _query = '';
+    _groups = [];
+    _loadedPages = 0;
+    _totalPages = 0;
+    _isLoadingMore = false;
+    _isLoadMoreFailed = false;
+    await _loadFirstPage();
+  }
+
+  /// 设置搜索词。空串退出搜索模式回到浏览态；非空先即时过滤已加载
+  /// 结果，缺页时后台拉全再全量过滤。
+  Future<void> setQuery(String rawQuery) async {
+    final query = rawQuery.trim();
+    if (query == _query) return;
+    _query = query;
+    final seq = ++_seq;
+    if (_query.isEmpty) {
+      _emit(_groups);
+      return;
+    }
+
+    // 先展示已加载部分的过滤结果（首键即有反馈）
+    _emit(_applyQuery());
+    if (_loadedPages >= _totalPages) return;
+
+    try {
+      final missingPages = [
+        for (var p = _loadedPages + 1; p <= _totalPages; p++) p,
+      ];
+      final fetched = await Future.wait(
+        missingPages.map((p) => _service.getGroupsPage(p, topic: _topic)),
+      );
+      if (seq != _seq || !mounted) return;
+      for (final pageGroups in fetched) {
+        _groups.addAll(pageGroups);
+      }
+      _loadedPages = _totalPages;
+    } catch (e, st) {
+      if (seq != _seq || !mounted) return;
+      AppLogger.warning(
+        '表情包市场搜索拉全量页失败，按已加载结果过滤',
+        tag: 'Sticker',
+        fields: {
+          'topic': _topic,
+          'query': _query,
+          'error': e.toString(),
+          'stackTrace': st.toString(),
+        },
+      );
+    }
+    _emit(_applyQuery());
+  }
+
   Future<void> loadMore() async {
-    if (_isLoadingMore || !hasMore || state is! AsyncData || _isLoadMoreFailed) return;
+    if (_isLoadingMore ||
+        !hasMore ||
+        state is! AsyncData ||
+        _isLoadMoreFailed) {
+      return;
+    }
     _isLoadingMore = true;
     _isLoadMoreFailed = false;
-    _emitCurrentData();
+    _emit(_applyQuery());
     try {
       final nextPage = _loadedPages + 1;
-      final newGroups = await _service.getGroupsPage(nextPage);
+      final (newGroups, totalPages) = await _service.getGroupsPageWithMeta(
+        nextPage,
+        topic: _topic,
+      );
       _loadedPages = nextPage;
-      if (newGroups.isEmpty) {
-        _totalPages = nextPage;
-      }
+      _totalPages = totalPages;
+      _groups.addAll(newGroups);
       if (!mounted) return;
 
       // 单次提交新页面，避免滚动过程中连续多次 rebuild 整个列表。
-      state = AsyncValue.data([...state.value!, ...newGroups]);
+      _emit(_applyQuery());
     } catch (e, st) {
       _isLoadMoreFailed = true;
       AppLogger.warning(
@@ -194,6 +293,7 @@ class MarketGroupsNotifier
         tag: 'Sticker',
         fields: {
           'page': _loadedPages + 1,
+          'topic': _topic,
           'baseUrl': _service.baseUrl,
           'error': e.toString(),
           'stackTrace': st.toString(),
@@ -201,19 +301,22 @@ class MarketGroupsNotifier
       );
     } finally {
       _isLoadingMore = false;
-      _emitCurrentData();
+      _emit(_applyQuery());
     }
   }
 
   Future<void> retryLoadMore() async {
     if (!_isLoadMoreFailed) return;
     _isLoadMoreFailed = false;
-    _emitCurrentData();
+    _emit(_applyQuery());
     await loadMore();
   }
 
+  /// 重载当前分类第一页（错误重试入口）。同时退出搜索模式。
   Future<void> refresh() async {
-    state = const AsyncValue.loading();
+    _seq++; // 作废在飞的搜索/翻页请求
+    _query = '';
+    _groups = [];
     _loadedPages = 0;
     _totalPages = 0;
     _isLoadingMore = false;

--- a/lib/providers/sticker_provider.dart
+++ b/lib/providers/sticker_provider.dart
@@ -116,11 +116,12 @@ Future<void> _prefetchFirstScreenThumbnails(
 }
 
 /// 市场分类（topic）列表（市场面板的分类 chips 数据源）
+///
+/// 唯一来源是服务端 topics.json，分类增删不需要发版。
 final marketTopicsProvider =
     FutureProvider.autoDispose<List<StickerMarketTopic>>((ref) async {
       final service = ref.watch(stickerMarketServiceProvider);
-      final index = await service.getIndex();
-      return index.topics;
+      return service.getTopics();
     });
 
 /// 市场分组分页加载（供市场浏览面板使用）

--- a/lib/providers/sticker_provider.dart
+++ b/lib/providers/sticker_provider.dart
@@ -159,8 +159,15 @@ class MarketGroupsNotifier
   /// 浏览模式下已加载的分组（未过滤；搜索过滤在其上进行）
   List<StickerGroup> _groups = [];
 
-  /// 单飞序号：分类切换/搜索拉全量页是异步的，过期结果按序号丢弃
-  int _seq = 0;
+  /// 数据世代：分类切换 / refresh 时递增。首页加载与翻页都带世代出门，
+  /// 回来发现世代变了就整包丢弃 —— 旧分类的页混进新分类不仅内容错，
+  /// 还会打乱 `_loadedPages/_totalPages` 游标，把后续翻页导向不存在的
+  /// `{topic}-page-N.json`。
+  int _dataSeq = 0;
+
+  /// 搜索世代：仅搜索补页用。搜索是在同一份数据上过滤，**不能**作废
+  /// 在飞的首页加载，因此必须与 [_dataSeq] 分开计数。
+  int _querySeq = 0;
 
   bool get isSearchMode => _query.isNotEmpty;
   bool get hasMore => !isSearchMode && _loadedPages < _totalPages;
@@ -181,21 +188,24 @@ class MarketGroupsNotifier
   }
 
   Future<void> _loadFirstPage() async {
-    final seq = ++_seq;
+    // 世代由调用方（构造/setTopic/refresh）负责递增，这里只读取快照。
+    final dataSeq = _dataSeq;
     _emit(const [], loading: true);
     try {
       final (groups, totalPages) = await _service.getGroupsPageWithMeta(
         1,
         topic: _topic,
       );
-      if (seq != _seq || !mounted) return;
+      if (dataSeq != _dataSeq || !mounted) return;
       _groups = groups;
       _loadedPages = 1;
       _totalPages = totalPages;
       _isLoadMoreFailed = false;
       _emit(_applyQuery());
+      // 首屏 loading 期间就输入了搜索词：此时缺页还没补，补齐后才是完整结果。
+      if (isSearchMode) await _ensureAllPagesLoaded();
     } catch (e, st) {
-      if (seq != _seq || !mounted) return;
+      if (dataSeq != _dataSeq || !mounted) return;
       AppLogger.error(
         '加载表情包市场首页失败',
         tag: 'Sticker',
@@ -207,9 +217,45 @@ class MarketGroupsNotifier
     }
   }
 
+  /// 补齐当前分类剩余页。搜索要在全量数据上过滤才不会漏结果；
+  /// 全市场 ~300 组、页数据本就有 24h 缓存，全量拉取代价可忽略。
+  Future<void> _ensureAllPagesLoaded() async {
+    if (_loadedPages == 0 || _loadedPages >= _totalPages) return;
+    final dataSeq = _dataSeq;
+    final querySeq = ++_querySeq;
+    try {
+      final missingPages = [
+        for (var p = _loadedPages + 1; p <= _totalPages; p++) p,
+      ];
+      final fetched = await Future.wait(
+        missingPages.map((p) => _service.getGroupsPage(p, topic: _topic)),
+      );
+      if (dataSeq != _dataSeq || querySeq != _querySeq || !mounted) return;
+      for (final pageGroups in fetched) {
+        _groups.addAll(pageGroups);
+      }
+      _loadedPages = _totalPages;
+    } catch (e, st) {
+      if (dataSeq != _dataSeq || querySeq != _querySeq || !mounted) return;
+      AppLogger.warning(
+        '表情包市场搜索拉全量页失败，按已加载结果过滤',
+        tag: 'Sticker',
+        fields: {
+          'topic': _topic,
+          'query': _query,
+          'error': e.toString(),
+          'stackTrace': st.toString(),
+        },
+      );
+    }
+    _emit(_applyQuery());
+  }
+
   /// 切换分类。清空搜索词（UI 侧同步清空输入框），重载该分类第一页。
   Future<void> setTopic(String topic) async {
     if (topic == _topic) return;
+    _dataSeq++; // 作废在飞的首页加载 / 翻页
+    _querySeq++; // 作废在飞的搜索补页
     _topic = topic;
     _query = '';
     _groups = [];
@@ -226,42 +272,15 @@ class MarketGroupsNotifier
     final query = rawQuery.trim();
     if (query == _query) return;
     _query = query;
-    final seq = ++_seq;
     if (_query.isEmpty) {
+      _querySeq++; // 作废在飞的补页
       _emit(_groups);
       return;
     }
 
     // 先展示已加载部分的过滤结果（首键即有反馈）
     _emit(_applyQuery());
-    if (_loadedPages >= _totalPages) return;
-
-    try {
-      final missingPages = [
-        for (var p = _loadedPages + 1; p <= _totalPages; p++) p,
-      ];
-      final fetched = await Future.wait(
-        missingPages.map((p) => _service.getGroupsPage(p, topic: _topic)),
-      );
-      if (seq != _seq || !mounted) return;
-      for (final pageGroups in fetched) {
-        _groups.addAll(pageGroups);
-      }
-      _loadedPages = _totalPages;
-    } catch (e, st) {
-      if (seq != _seq || !mounted) return;
-      AppLogger.warning(
-        '表情包市场搜索拉全量页失败，按已加载结果过滤',
-        tag: 'Sticker',
-        fields: {
-          'topic': _topic,
-          'query': _query,
-          'error': e.toString(),
-          'stackTrace': st.toString(),
-        },
-      );
-    }
-    _emit(_applyQuery());
+    await _ensureAllPagesLoaded();
   }
 
   Future<void> loadMore() async {
@@ -271,6 +290,7 @@ class MarketGroupsNotifier
         _isLoadMoreFailed) {
       return;
     }
+    final dataSeq = _dataSeq;
     _isLoadingMore = true;
     _isLoadMoreFailed = false;
     _emit(_applyQuery());
@@ -280,14 +300,15 @@ class MarketGroupsNotifier
         nextPage,
         topic: _topic,
       );
+      if (dataSeq != _dataSeq || !mounted) return;
       _loadedPages = nextPage;
       _totalPages = totalPages;
       _groups.addAll(newGroups);
-      if (!mounted) return;
 
       // 单次提交新页面，避免滚动过程中连续多次 rebuild 整个列表。
       _emit(_applyQuery());
     } catch (e, st) {
+      if (dataSeq != _dataSeq || !mounted) return;
       _isLoadMoreFailed = true;
       AppLogger.warning(
         '加载表情包市场分页失败',
@@ -301,8 +322,11 @@ class MarketGroupsNotifier
         },
       );
     } finally {
-      _isLoadingMore = false;
-      _emit(_applyQuery());
+      // 世代已变说明 setTopic/refresh 早已重置过这些字段，不能再回写。
+      if (dataSeq == _dataSeq) {
+        _isLoadingMore = false;
+        _emit(_applyQuery());
+      }
     }
   }
 
@@ -315,7 +339,8 @@ class MarketGroupsNotifier
 
   /// 重载当前分类第一页（错误重试入口）。同时退出搜索模式。
   Future<void> refresh() async {
-    _seq++; // 作废在飞的搜索/翻页请求
+    _dataSeq++; // 作废在飞的首页加载 / 翻页
+    _querySeq++; // 作废在飞的搜索补页
     _query = '';
     _groups = [];
     _loadedPages = 0;

--- a/lib/services/sticker_market_service.dart
+++ b/lib/services/sticker_market_service.dart
@@ -62,6 +62,22 @@ class StickerMarketService {
     return StickerMarketIndex.fromJson(data);
   }
 
+  /// 获取市场分类列表
+  ///
+  /// 分类唯一来源是独立的 topics.json（与 index.json 解耦，分类可独立
+  /// 于分组数据更新）。
+  Future<List<StickerMarketTopic>> getTopics() async {
+    final data = await _fetchWithCache(
+      'topics',
+      '$baseUrl/assets/market/index/topics.json',
+    );
+    final list = data['topics'] as List<dynamic>? ?? [];
+    return list
+        .whereType<Map<String, dynamic>>()
+        .map(StickerMarketTopic.fromJson)
+        .toList();
+  }
+
   /// 获取全部非归档分组
   Future<List<StickerGroup>> getAllGroups() async {
     final index = await getIndex();
@@ -78,8 +94,7 @@ class StickerMarketService {
 
   /// 获取单页分组数据
   ///
-  /// [topic] 为市场分类 id；'all'（全部）走顶层 `page-N.json`，
-  /// 其余分类走 `{topic}-page-N.json`（与 index.json topics[].pages 对应）。
+  /// 其余分类走 `{topic}-page-N.json`（分类清单见 topics.json）。
   Future<List<StickerGroup>> getGroupsPage(
     int page, {
     String topic = 'all',

--- a/lib/services/sticker_market_service.dart
+++ b/lib/services/sticker_market_service.dart
@@ -28,13 +28,15 @@ class StickerMarketService {
   final SharedPreferences _prefs;
   late final Dio _dio;
 
-  StickerMarketService(this._prefs) {
-    _dio = Dio(
-      BaseOptions(
-        connectTimeout: const Duration(seconds: 15),
-        receiveTimeout: const Duration(seconds: 15),
-      ),
-    );
+  StickerMarketService(this._prefs, {Dio? dio}) {
+    _dio =
+        dio ??
+        Dio(
+          BaseOptions(
+            connectTimeout: const Duration(seconds: 15),
+            receiveTimeout: const Duration(seconds: 15),
+          ),
+        );
   }
 
   /// 当前 baseUrl
@@ -126,9 +128,14 @@ class StickerMarketService {
 
   /// 获取分组详情
   Future<StickerGroupDetail> getGroupDetail(String groupId) async {
+    // 市场分组 id 通常已经包含 `group-` 前缀，不能再次拼接成
+    // `group-group-*.json`；兼容仍使用裸 id 的旧数据。
+    final groupFileName = groupId.startsWith('group-')
+        ? '$groupId.json'
+        : 'group-$groupId.json';
     final data = await _fetchWithCache(
       'group_$groupId',
-      '$baseUrl/assets/market/group-$groupId.json',
+      '$baseUrl/assets/market/$groupFileName',
     );
     return compute(_parseGroupDetail, data);
   }

--- a/lib/services/sticker_market_service.dart
+++ b/lib/services/sticker_market_service.dart
@@ -29,10 +29,12 @@ class StickerMarketService {
   late final Dio _dio;
 
   StickerMarketService(this._prefs) {
-    _dio = Dio(BaseOptions(
-      connectTimeout: const Duration(seconds: 15),
-      receiveTimeout: const Duration(seconds: 15),
-    ));
+    _dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 15),
+      ),
+    );
   }
 
   /// 当前 baseUrl
@@ -75,15 +77,36 @@ class StickerMarketService {
   }
 
   /// 获取单页分组数据
-  Future<List<StickerGroup>> getGroupsPage(int page) async {
+  ///
+  /// [topic] 为市场分类 id；'all'（全部）走顶层 `page-N.json`，
+  /// 其余分类走 `{topic}-page-N.json`（与 index.json topics[].pages 对应）。
+  Future<List<StickerGroup>> getGroupsPage(
+    int page, {
+    String topic = 'all',
+  }) async {
+    final (groups, _) = await getGroupsPageWithMeta(page, topic: topic);
+    return groups;
+  }
+
+  /// 获取单页分组数据 + 该分类的分页元信息（totalPages）。
+  ///
+  /// 每个分类的页文件自带该分类的 totalPages（与「全部」的互不相同），
+  /// 分类切换后必须以页文件里的元信息为准，不能沿用索引顶层值。
+  Future<(List<StickerGroup>, int totalPages)> getGroupsPageWithMeta(
+    int page, {
+    String topic = 'all',
+  }) async {
     final data = await _fetchWithCache(
-      'page_$page',
-      '$baseUrl/assets/market/index/page-$page.json',
+      topic == 'all' ? 'page_$page' : 'page_${topic}_$page',
+      topic == 'all'
+          ? '$baseUrl/assets/market/index/page-$page.json'
+          : '$baseUrl/assets/market/index/$topic-page-$page.json',
     );
     final list = data['groups'] as List<dynamic>? ?? [];
-    return list
+    final groups = list
         .map((item) => StickerGroup.fromJson(item as Map<String, dynamic>))
         .toList();
+    return (groups, data['totalPages'] as int? ?? 1);
   }
 
   /// 获取分组详情
@@ -132,8 +155,7 @@ class StickerMarketService {
     return raw
         .map((s) {
           try {
-            return StickerItem.fromJson(
-                json.decode(s) as Map<String, dynamic>);
+            return StickerItem.fromJson(json.decode(s) as Map<String, dynamic>);
           } catch (_) {
             return null;
           }
@@ -159,8 +181,9 @@ class StickerMarketService {
     list.insert(0, encoded);
 
     // 限制数量
-    final trimmed =
-        list.length > _maxRecentStickers ? list.sublist(0, _maxRecentStickers) : list;
+    final trimmed = list.length > _maxRecentStickers
+        ? list.sublist(0, _maxRecentStickers)
+        : list;
     await _prefs.setStringList(_recentStickersKey, trimmed);
   }
 

--- a/lib/widgets/markdown_editor/emoji_picker.dart
+++ b/lib/widgets/markdown_editor/emoji_picker.dart
@@ -722,8 +722,9 @@ class _EmojiSearchViewState extends State<_EmojiSearchView> {
                 child: Container(
                   height: 36,
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHighest
-                        .withValues(alpha: 0.5),
+                    color: theme.colorScheme.surfaceContainerHighest.withValues(
+                      alpha: 0.5,
+                    ),
                     borderRadius: BorderRadius.circular(10),
                   ),
                   child: TextField(
@@ -747,8 +748,10 @@ class _EmojiSearchViewState extends State<_EmojiSearchView> {
                       ),
                       suffixIcon: _query.isNotEmpty
                           ? IconButton(
-                              icon: const Icon(Symbols.cancel_rounded,
-                                  size: 16),
+                              icon: const Icon(
+                                Symbols.cancel_rounded,
+                                size: 16,
+                              ),
                               color: theme.colorScheme.onSurfaceVariant,
                               onPressed: () => _searchController.clear(),
                             )
@@ -765,18 +768,14 @@ class _EmojiSearchViewState extends State<_EmojiSearchView> {
               ? Center(
                   child: Text(
                     S.current.emoji_searchPrompt,
-                    style: TextStyle(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
                   ),
                 )
               : results.isEmpty
               ? Center(
                   child: Text(
                     S.current.emoji_searchNotFound,
-                    style: TextStyle(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
                   ),
                 )
               : GridView.builder(
@@ -786,12 +785,11 @@ class _EmojiSearchViewState extends State<_EmojiSearchView> {
                     12,
                     12 + widget.bottomPadding,
                   ),
-                  gridDelegate:
-                      const SliverGridDelegateWithMaxCrossAxisExtent(
-                        maxCrossAxisExtent: 40,
-                        mainAxisSpacing: 8,
-                        crossAxisSpacing: 8,
-                      ),
+                  gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 40,
+                    mainAxisSpacing: 8,
+                    crossAxisSpacing: 8,
+                  ),
                   itemCount: results.length,
                   itemBuilder: (context, index) {
                     final emoji = results[index];
@@ -920,7 +918,10 @@ class _EmojiSearchSheetState extends State<_EmojiSearchSheet> {
                         ),
                         suffixIcon: _query.isNotEmpty
                             ? IconButton(
-                                icon: const Icon(Symbols.cancel_rounded, size: 18),
+                                icon: const Icon(
+                                  Symbols.cancel_rounded,
+                                  size: 18,
+                                ),
                                 color: theme.colorScheme.onSurfaceVariant,
                                 onPressed: () => _searchController.clear(),
                               )

--- a/lib/widgets/markdown_editor/emoji_picker.dart
+++ b/lib/widgets/markdown_editor/emoji_picker.dart
@@ -592,7 +592,10 @@ class _EmojiPickerState extends ConsumerState<EmojiPicker>
 extension StringExtension on String {
   String capitalize() {
     if (isEmpty) return this;
-    return "${this[0].toUpperCase()}${substring(1)}";
+    // 按字素簇取首字符:分组名可能以增补平面 emoji 开头(如 "🍟 藤田言音"),
+    // this[0] 会把代理对从中间切开,渲染成乱码。
+    final chars = characters;
+    return "${chars.first.toUpperCase()}${chars.skip(1).join()}";
   }
 }
 

--- a/lib/widgets/markdown_editor/sticker_market_sheet.dart
+++ b/lib/widgets/markdown_editor/sticker_market_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:app_icons/app_icons.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
@@ -34,6 +36,12 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
     releaseDistance: 600,
   );
 
+  final TextEditingController _searchController = TextEditingController();
+  Timer? _searchDebounce;
+
+  /// 当前选中分类 id（'all' = 全部）；与 notifier 同步，驱动 chip 选中态
+  String _selectedTopic = 'all';
+
   @override
   void initState() {
     super.initState();
@@ -42,6 +50,8 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
 
   @override
   void dispose() {
+    _searchDebounce?.cancel();
+    _searchController.dispose();
     _scrollController.dispose();
     super.dispose();
   }
@@ -73,6 +83,7 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
   @override
   Widget build(BuildContext context) {
     final groupsAsync = ref.watch(marketGroupsProvider);
+    final topicsAsync = ref.watch(marketTopicsProvider);
 
     return AppSheetScaffold(
       title: S.current.sticker_marketTitle,
@@ -90,17 +101,139 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
           child: Text(S.current.common_done),
         ),
       ],
-      child: (() {
-        final groups = groupsAsync.value;
-        if (groups != null) {
-          return _buildGroupList(groups);
-        }
-        return groupsAsync.when(
-          data: (groups) => _buildGroupList(groups),
-          loading: () => const Center(child: LoadingSpinner()),
-          error: (err, stack) => _buildError(err, stack),
-        );
-      })(),
+      child: Column(
+        children: [
+          _buildSearchField(),
+          _buildTopicChips(topicsAsync),
+          Expanded(
+            child: (() {
+              final groups = groupsAsync.value;
+              if (groups != null) {
+                return _buildGroupList(groups);
+              }
+              return groupsAsync.when(
+                data: (groups) => _buildGroupList(groups),
+                loading: () => const Center(child: LoadingSpinner()),
+                error: _buildError,
+              );
+            })(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ==================== 搜索与分类 ====================
+
+  void _scheduleSearch() {
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 200), () {
+      ref.read(marketGroupsProvider.notifier).setQuery(_searchController.text);
+    });
+  }
+
+  void _selectTopic(String topicId) {
+    if (topicId == _selectedTopic) return;
+    setState(() => _selectedTopic = topicId);
+    _searchDebounce?.cancel();
+    _searchController.clear();
+    ref.read(marketGroupsProvider.notifier).setTopic(topicId);
+  }
+
+  Widget _buildSearchField() {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: ValueListenableBuilder<TextEditingValue>(
+        valueListenable: _searchController,
+        builder: (context, value, _) {
+          return TextField(
+            controller: _searchController,
+            textInputAction: TextInputAction.search,
+            onChanged: (_) => _scheduleSearch(),
+            style: const TextStyle(fontSize: 14),
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: S.current.sticker_marketSearchHint,
+              hintStyle: TextStyle(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontSize: 14,
+              ),
+              prefixIcon: const Icon(Symbols.search_rounded, size: 18),
+              suffixIcon: value.text.isEmpty
+                  ? null
+                  : IconButton(
+                      visualDensity: VisualDensity.compact,
+                      icon: const Icon(Symbols.close_rounded, size: 16),
+                      onPressed: () {
+                        _searchDebounce?.cancel();
+                        _searchController.clear();
+                        ref.read(marketGroupsProvider.notifier).setQuery('');
+                      },
+                    ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: theme.colorScheme.outlineVariant),
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: theme.colorScheme.outlineVariant),
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+                borderSide: BorderSide(color: theme.colorScheme.primary),
+              ),
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 10,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  /// 分类 chips（横向滚动）。索引无 topics（旧版数据）或全部为空分类时
+  /// 整行不占位；totalGroups == 0 的空分类不展示（点了只会看到空列表）。
+  Widget _buildTopicChips(AsyncValue<List<StickerMarketTopic>> topicsAsync) {
+    final theme = Theme.of(context);
+    final topics = (topicsAsync.value ?? const <StickerMarketTopic>[])
+        .where((t) => t.totalGroups > 0)
+        .toList(growable: false);
+    if (topics.isEmpty) return const SizedBox.shrink();
+
+    return SizedBox(
+      height: 44,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        itemCount: topics.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 8),
+        itemBuilder: (context, index) {
+          final topic = topics[index];
+          final selected = topic.id == _selectedTopic;
+          return ChoiceChip(
+            label: Text(topic.label),
+            selected: selected,
+            onSelected: (_) => _selectTopic(topic.id),
+            labelStyle: TextStyle(
+              fontSize: 12,
+              color: selected
+                  ? theme.colorScheme.onPrimary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+            selectedColor: theme.colorScheme.primary,
+            showCheckmark: false,
+            visualDensity: VisualDensity.compact,
+            side: BorderSide(
+              color: selected
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.outlineVariant,
+            ),
+          );
+        },
+      ),
     );
   }
 
@@ -170,9 +303,12 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
 
   Widget _buildGroupList(List<StickerGroup> groups) {
     if (groups.isEmpty) {
+      final notifier = ref.read(marketGroupsProvider.notifier);
       return Center(
         child: Text(
-          S.current.sticker_marketEmpty,
+          notifier.isSearchMode
+              ? S.current.sticker_marketSearchEmpty
+              : S.current.sticker_marketEmpty,
           style: TextStyle(
             color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),

--- a/lib/widgets/markdown_editor/sticker_market_sheet.dart
+++ b/lib/widgets/markdown_editor/sticker_market_sheet.dart
@@ -111,7 +111,11 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Symbols.error_rounded, size: 48, color: theme.colorScheme.outline),
+          Icon(
+            Symbols.error_rounded,
+            size: 48,
+            color: theme.colorScheme.outline,
+          ),
           const SizedBox(height: 12),
           Text(
             S.current.sticker_marketLoadFailed,
@@ -310,7 +314,7 @@ class _StickerGroupTile extends ConsumerWidget {
       ),
       child: Center(
         child: Text(
-          group.name.isNotEmpty ? group.name[0] : '?',
+          group.name.isNotEmpty ? group.name.characters.first : '?',
           style: TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.w600,

--- a/lib/widgets/markdown_editor/sticker_market_sheet.dart
+++ b/lib/widgets/markdown_editor/sticker_market_sheet.dart
@@ -194,8 +194,9 @@ class _StickerMarketSheetState extends ConsumerState<StickerMarketSheet> {
     );
   }
 
-  /// 分类 chips（横向滚动）。索引无 topics（旧版数据）或全部为空分类时
-  /// 整行不占位；totalGroups == 0 的空分类不展示（点了只会看到空列表）。
+  /// 分类 chips（横向滚动）。topics.json 取不到（旧版服务端 / 请求失败）或
+  /// 全部是空分类时整行不占位，此时只剩「全部」的浏览行为；totalGroups == 0
+  /// 的空分类不展示（点了只会看到空列表）。
   Widget _buildTopicChips(AsyncValue<List<StickerMarketTopic>> topicsAsync) {
     final theme = Theme.of(context);
     final topics = (topicsAsync.value ?? const <StickerMarketTopic>[])

--- a/lib/widgets/markdown_editor/sticker_picker.dart
+++ b/lib/widgets/markdown_editor/sticker_picker.dart
@@ -309,7 +309,11 @@ class _StickerPickerState extends ConsumerState<StickerPicker>
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(Symbols.error_rounded, size: 48, color: theme.colorScheme.outline),
+          Icon(
+            Symbols.error_rounded,
+            size: 48,
+            color: theme.colorScheme.outline,
+          ),
           const SizedBox(height: 12),
           Text(
             S.current.sticker_loadFailed,

--- a/lib/widgets/markdown_editor/sticker_picker.dart
+++ b/lib/widgets/markdown_editor/sticker_picker.dart
@@ -536,8 +536,9 @@ class _StickerPickerState extends ConsumerState<StickerPicker>
   }
 
   Widget _buildFallbackIcon(String name) {
+    // characters.first:名字以 🍟 等增补平面 emoji 开头时 name[0] 会切开代理对
     return Text(
-      name.isNotEmpty ? name[0] : '?',
+      name.isNotEmpty ? name.characters.first : '?',
       style: TextStyle(
         fontSize: 14,
         fontWeight: FontWeight.w600,

--- a/test/providers/sticker_market_groups_test.dart
+++ b/test/providers/sticker_market_groups_test.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:fluxdo/providers/sticker_provider.dart';
+import 'package:fluxdo/services/sticker_market_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 表情包市场分页 / 搜索的并发时序回归测试。
+///
+/// 这里锁的两件事都只在「异步还在飞的时候用户又操作了一下」时才现形，
+/// 手动点很难稳定复现，所以用可挂起的 adapter 把时序固定下来。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<MarketGroupsNotifier> newNotifier(_FakeMarketAdapter adapter) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = StickerMarketService(
+      prefs,
+      dio: Dio()..httpClientAdapter = adapter,
+    );
+    return MarketGroupsNotifier(service);
+  }
+
+  List<String> namesOf(MarketGroupsNotifier n) =>
+      (n.state.value ?? const []).map((g) => g.name).toList();
+
+  test('切分类时在飞的翻页结果不会混进新分类', () async {
+    final adapter = _FakeMarketAdapter({
+      '/assets/market/index/page-1.json': _page(['all-1', 'all-2'], 2),
+      '/assets/market/index/page-2.json': _page(['all-3'], 2),
+      '/assets/market/index/x-page-1.json': _page(['x-1'], 1),
+    })..hold('/assets/market/index/page-2.json');
+
+    final notifier = await newNotifier(adapter);
+    await pumpEventQueue();
+    expect(namesOf(notifier), ['all-1', 'all-2']);
+
+    // page-2 起飞后立刻切到别的分类，然后才让 page-2 落地
+    final pending = notifier.loadMore();
+    await notifier.setTopic('x');
+    adapter.release('/assets/market/index/page-2.json');
+    await pending;
+    await pumpEventQueue();
+
+    expect(namesOf(notifier), ['x-1'], reason: '旧分类的页必须整包丢弃');
+    expect(notifier.hasMore, isFalse, reason: '分页游标不能被旧分类的 totalPages 覆盖');
+  });
+
+  test('首屏还在加载时就输入搜索词，首页数据不会被丢弃', () async {
+    final adapter = _FakeMarketAdapter({
+      '/assets/market/index/page-1.json': _page(['alpha', 'beta'], 1),
+    })..hold('/assets/market/index/page-1.json');
+
+    final notifier = await newNotifier(adapter);
+    // 首页仍在飞：搜索只能作废「搜索补页」，不能作废首页加载
+    final searching = notifier.setQuery('alpha');
+    adapter.release('/assets/market/index/page-1.json');
+    await searching;
+    await pumpEventQueue();
+
+    expect(namesOf(notifier), ['alpha']);
+
+    // 清空搜索词应回到完整浏览态，而不是空列表
+    await notifier.setQuery('');
+    expect(namesOf(notifier), ['alpha', 'beta']);
+  });
+
+  test('首屏加载完成后若已处于搜索态，会补齐剩余页再过滤', () async {
+    final adapter = _FakeMarketAdapter({
+      '/assets/market/index/page-1.json': _page(['alpha', 'beta'], 2),
+      '/assets/market/index/page-2.json': _page(['alphabet'], 2),
+    })..hold('/assets/market/index/page-1.json');
+
+    final notifier = await newNotifier(adapter);
+    final searching = notifier.setQuery('alpha');
+    adapter.release('/assets/market/index/page-1.json');
+    await searching;
+    await pumpEventQueue();
+
+    expect(namesOf(notifier), [
+      'alpha',
+      'alphabet',
+    ], reason: '第 2 页的命中不能因为搜索发生在首屏之前就漏掉');
+  });
+}
+
+Map<String, dynamic> _page(List<String> names, int totalPages) => {
+  'totalPages': totalPages,
+  'groups': [
+    for (final name in names)
+      {
+        'id': 'group-$name',
+        'name': name,
+        'icon': '',
+        'order': 0,
+        'emojiCount': 1,
+        'isArchived': false,
+      },
+  ],
+};
+
+/// 按路径返回固定 body 的假适配器，可对指定路径「扣住」响应以固定时序。
+class _FakeMarketAdapter implements HttpClientAdapter {
+  _FakeMarketAdapter(this.bodies);
+
+  final Map<String, Map<String, dynamic>> bodies;
+  final Map<String, Completer<void>> _gates = {};
+
+  void hold(String path) => _gates[path] = Completer<void>();
+
+  void release(String path) => _gates.remove(path)?.complete();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.uri.path;
+    await _gates[path]?.future;
+    final body = bodies[path];
+    if (body == null) {
+      throw StateError('测试未配置的路径：$path');
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/services/sticker_market_service_test.dart
+++ b/test/services/sticker_market_service_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:fluxdo/services/sticker_market_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'uses canonical filename when group id already has group prefix',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final paths = <String>[];
+      final prefs = await SharedPreferences.getInstance();
+      final service = StickerMarketService(prefs, dio: _buildDio(paths));
+
+      await service.getGroupDetail('group-123');
+
+      expect(paths, ['/assets/market/group-123.json']);
+    },
+  );
+
+  test('adds group prefix for legacy bare group ids', () async {
+    SharedPreferences.setMockInitialValues({});
+    final paths = <String>[];
+    final prefs = await SharedPreferences.getInstance();
+    final service = StickerMarketService(prefs, dio: _buildDio(paths));
+
+    await service.getGroupDetail('123');
+
+    expect(paths, ['/assets/market/group-123.json']);
+  });
+}
+
+Dio _buildDio(List<String> paths) {
+  return Dio()..httpClientAdapter = _RecordingAdapter(paths);
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  _RecordingAdapter(this.paths);
+
+  final List<String> paths;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    paths.add(options.uri.path);
+    return ResponseBody.fromString(
+      jsonEncode({
+        'id': 'group-123',
+        'name': 'test',
+        'icon': '🙂',
+        'emojis': [],
+      }),
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/test/services/sticker_market_service_test.dart
+++ b/test/services/sticker_market_service_test.dart
@@ -9,40 +9,104 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test(
-    'uses canonical filename when group id already has group prefix',
-    () async {
-      SharedPreferences.setMockInitialValues({});
-      final paths = <String>[];
-      final prefs = await SharedPreferences.getInstance();
-      final service = StickerMarketService(prefs, dio: _buildDio(paths));
+  Future<StickerMarketService> newService(_RecordingAdapter adapter) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    return StickerMarketService(prefs, dio: Dio()..httpClientAdapter = adapter);
+  }
+
+  group('分组详情文件名', () {
+    test('id 已带 group- 前缀时不再重复拼接', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
 
       await service.getGroupDetail('group-123');
 
-      expect(paths, ['/assets/market/group-123.json']);
-    },
-  );
+      expect(adapter.paths, ['/assets/market/group-123.json']);
+    });
 
-  test('adds group prefix for legacy bare group ids', () async {
-    SharedPreferences.setMockInitialValues({});
-    final paths = <String>[];
-    final prefs = await SharedPreferences.getInstance();
-    final service = StickerMarketService(prefs, dio: _buildDio(paths));
+    test('兼容仍使用裸 id 的旧数据', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
 
-    await service.getGroupDetail('123');
+      await service.getGroupDetail('123');
 
-    expect(paths, ['/assets/market/group-123.json']);
+      expect(adapter.paths, ['/assets/market/group-123.json']);
+    });
+  });
+
+  group('分类分页文件名', () {
+    // 服务端对不存在的资源返回 200 + SPA 首页 HTML(不是 404),所以这几条
+    // 路径一旦拼错不会响,只会拿到空列表或类型错误 —— 必须锁死。
+    test('全部分类走 page-N.json,不能带 all- 前缀', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
+
+      await service.getGroupsPageWithMeta(1);
+      await service.getGroupsPageWithMeta(2, topic: 'all');
+
+      expect(adapter.paths, [
+        '/assets/market/index/page-1.json',
+        '/assets/market/index/page-2.json',
+      ]);
+    });
+
+    test('具体分类走 {topic}-page-N.json', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
+
+      await service.getGroupsPageWithMeta(2, topic: 'x');
+      await service.getGroupsPage(1, topic: 'linux.do');
+
+      expect(adapter.paths, [
+        '/assets/market/index/x-page-2.json',
+        '/assets/market/index/linux.do-page-1.json',
+      ]);
+    });
+
+    test('totalPages 取页文件自带的元信息(各分类互不相同)', () async {
+      final adapter = _RecordingAdapter(totalPages: 6);
+      final service = await newService(adapter);
+
+      final (groups, totalPages) = await service.getGroupsPageWithMeta(1);
+
+      expect(totalPages, 6);
+      expect(groups, isEmpty);
+    });
+
+    test('缓存键按 topic 隔离,不同分类同页码不会互相命中', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
+
+      await service.getGroupsPage(1);
+      await service.getGroupsPage(1, topic: 'x');
+      // 同一 (topic, page) 第二次应命中缓存,不再发请求
+      await service.getGroupsPage(1, topic: 'x');
+
+      expect(adapter.paths, [
+        '/assets/market/index/page-1.json',
+        '/assets/market/index/x-page-1.json',
+      ]);
+    });
+  });
+
+  group('分类列表', () {
+    test('topics 走独立的 topics.json', () async {
+      final adapter = _RecordingAdapter();
+      final service = await newService(adapter);
+
+      await service.getTopics();
+
+      expect(adapter.paths, ['/assets/market/index/topics.json']);
+    });
   });
 }
 
-Dio _buildDio(List<String> paths) {
-  return Dio()..httpClientAdapter = _RecordingAdapter(paths);
-}
-
 class _RecordingAdapter implements HttpClientAdapter {
-  _RecordingAdapter(this.paths);
+  _RecordingAdapter({this.totalPages = 1});
 
-  final List<String> paths;
+  final int totalPages;
+  final List<String> paths = [];
 
   @override
   Future<ResponseBody> fetch(
@@ -51,12 +115,16 @@ class _RecordingAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     paths.add(options.uri.path);
+    // 同时满足分组详情 / 分页 / 分类三种解析,省掉多套 fixture
     return ResponseBody.fromString(
       jsonEncode({
         'id': 'group-123',
         'name': 'test',
         'icon': '🙂',
-        'emojis': [],
+        'emojis': <dynamic>[],
+        'groups': <dynamic>[],
+        'topics': <dynamic>[],
+        'totalPages': totalPages,
       }),
       200,
       headers: {


### PR DESCRIPTION
## Summary
- Cherry-pick the emoji/sticker market work from `main` onto `upstream/dev` (`f59627c1`, `0f3fc9f0`, `3971d036`).
- Fetch market group details using the canonical filename when the group id already starts with `group-`, avoiding `group-group-*`.
- Keep compatibility with legacy bare group ids and add regression coverage.

## Test
- `flutter test test/services/sticker_market_service_test.dart`
- `dart analyze lib/models/sticker.dart lib/providers/sticker_provider.dart lib/services/sticker_market_service.dart lib/widgets/markdown_editor/emoji_picker.dart lib/widgets/markdown_editor/sticker_market_sheet.dart lib/widgets/markdown_editor/sticker_picker.dart test/services/sticker_market_service_test.dart` (one existing `curly_braces_in_flow_control_structures` info in `emoji_picker.dart`)
