### PR TITLE
fix(flatpak): 添加 discourse
  scheme 支持以修复浏览器登录

### DIFF
--- a/flatpak/com.github.lingyan000.fluxdo.desktop
+++ b/flatpak/com.github.lingyan000.fluxdo.desktop
@@ -6,5 +6,5 @@ Icon=com.github.lingyan000.fluxdo
 Terminal=false
 Type=Application
 Categories=Network;
-MimeType=x-scheme-handler/fluxdo;
+MimeType=x-scheme-handler/fluxdo;x-scheme-handler/discourse;
 StartupWMClass=fluxdo


### PR DESCRIPTION
Flatpak 版本的 .desktop 文件缺少 discourse:// scheme 注册，导致浏览器授权后的
  discourse://auth_redirect 回调无法正确派发给应用，登录数据无法传回。与原生 Linux 版本保持一致。