### PR TITLE
fix: preserve user-specific minimum post length

### DIFF
--- a/lib/plugins/plugin_context.dart
+++ b/lib/plugins/plugin_context.dart
@@ -65,6 +65,12 @@ class ComposerMinLengthContext {
   /// 是否为与非真人用户的私信
   final bool isPmWithNonHumanUser;
 
+  /// 当前用户是否有服务端明确下发的专属回复字数下限。
+  ///
+  /// 例如 linux.do 的 `premium_min_post_length`。这类值已经是针对当前用户
+  /// 计算出的有效限制，分类插件不能再用通用分类下限覆盖它。
+  final bool hasUserSpecificMinPostLength;
+
   /// 站点 `max_post_length`,用于给插件抬高的下限封顶
   final int maxPostLength;
 
@@ -73,6 +79,7 @@ class ComposerMinLengthContext {
     required this.isFirstPost,
     required this.isPrivateMessage,
     required this.isPmWithNonHumanUser,
+    this.hasUserSpecificMinPostLength = false,
     required this.maxPostLength,
   });
 

--- a/lib/plugins/warden/warden_plugin.dart
+++ b/lib/plugins/warden/warden_plugin.dart
@@ -23,6 +23,8 @@ import '../site_plugin.dart';
 ///
 /// 要点：
 /// - 私信（含与非真人用户的私信）完全不接管，沿用站点默认
+/// - 当前用户已有服务端明确下发的专属回复下限（如 premium）时不接管；
+///   该值比面向整个分类的通用规则更具体，不能把 4 字重新抬成 16 字
 /// - 首帖读 `warden_min_first_post_length`，回复读 `warden_min_post_length`
 /// - 值为 null/0/负数/非数字一律回退上一级结果（站点默认或会员优惠）
 /// - 生效时按站点 `max_post_length` 封顶，避免误配出无法满足的下限
@@ -42,6 +44,9 @@ class WardenPlugin extends SitePlugin {
   int composerMinPostLength(int value, ComposerMinLengthContext context) {
     // 对齐 `composer.privateMessage || composer.topic?.pm_with_non_human_user`
     if (context.isPrivateMessage || context.isPmWithNonHumanUser) return value;
+
+    // 服务端按当前用户/分组计算出的专属下限优先于分类通用规则。
+    if (context.hasUserSpecificMinPostLength) return value;
 
     final min = context.readCategoryInt(
       context.isFirstPost ? minFirstPostLengthField : minPostLengthField,

--- a/lib/services/composer_min_length_resolver.dart
+++ b/lib/services/composer_min_length_resolver.dart
@@ -9,11 +9,21 @@ import 'preloaded_data_service.dart';
 ///
 /// 分三层，对齐 Discourse：
 /// 1. 基础值：私信 / 首帖 / 普通回复各自的站点设置（[PreloadedDataService]
-///    内部已含 linux.do 的 `premium_min_post_length` 会员优惠）
-/// 2. 站点插件改写：如 warden 按分类抬高下限（[PluginRegistry]）
+///    内部已含 linux.do 的 `premium_min_post_length` 用户专属优惠）
+/// 2. 站点插件改写：如 warden 按分类抬高下限；但服务端已经针对当前用户
+///    下发的专属回复下限拥有更高优先级，不能再被通用分类规则覆盖
 /// 3. 结果即为编辑器与提交校验共用的下限
 class ComposerMinLengthResolver {
   const ComposerMinLengthResolver._();
+
+  static bool _hasPositiveIntOverride(Object? value) {
+    if (value is int) return value > 0;
+    if (value is String) {
+      final parsed = int.tryParse(value);
+      return parsed != null && parsed > 0;
+    }
+    return false;
+  }
 
   /// 解析最小正文字数
   ///
@@ -36,6 +46,17 @@ class ComposerMinLengthResolver {
         ? await preloaded.getMinFirstPostLength()
         : await preloaded.getMinPostLength();
 
+    // linux.do 会把 premium 等特殊分组针对“当前用户”计算后的回复下限
+    // 序列化到 currentUser。getMinPostLength() 已使用该值作为 base；这里再把
+    // “这是用户专属值”这一事实传给站点插件，避免 warden 用分类的通用 16 字
+    // 把 premium 的 4 字优惠错误覆盖。首帖/私信不使用该字段。
+    final hasUserSpecificMinPostLength =
+        !isFirstPost &&
+        !isPrivateMessage &&
+        _hasPositiveIntOverride(
+          preloaded.currentUserSync?['premium_min_post_length'],
+        );
+
     final maxPostLength = await preloaded.getMaxPostLength();
 
     return PluginRegistry.resolveMinPostLength(
@@ -45,6 +66,7 @@ class ComposerMinLengthResolver {
         isFirstPost: isFirstPost,
         isPrivateMessage: isPrivateMessage,
         isPmWithNonHumanUser: isPmWithNonHumanUser,
+        hasUserSpecificMinPostLength: hasUserSpecificMinPostLength,
         maxPostLength: maxPostLength,
       ),
     );

--- a/test/plugins/warden_user_specific_min_length_test.dart
+++ b/test/plugins/warden_user_specific_min_length_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluxdo/plugins/plugins.dart';
+
+ComposerMinLengthContext _context({
+  bool hasUserSpecificMinPostLength = false,
+}) => ComposerMinLengthContext(
+  categoryExtras: const {'warden_min_post_length': 16},
+  isFirstPost: false,
+  isPrivateMessage: false,
+  isPmWithNonHumanUser: false,
+  hasUserSpecificMinPostLength: hasUserSpecificMinPostLength,
+  maxPostLength: 32000,
+);
+
+void main() {
+  group('WardenPlugin user-specific minimum precedence', () {
+    const plugin = WardenPlugin();
+
+    test('ordinary user still uses category minimum', () {
+      expect(plugin.composerMinPostLength(8, _context()), 16);
+    });
+
+    test('premium/group-specific minimum wins over category minimum', () {
+      expect(
+        plugin.composerMinPostLength(
+          4,
+          _context(hasUserSpecificMinPostLength: true),
+        ),
+        4,
+      );
+    });
+  });
+}


### PR DESCRIPTION
问题

当前编辑器的最小正文字数解析流程中，"PreloadedDataService.getMinPostLength()" 已经会优先读取当前用户的 "premium_min_post_length"。

例如，对于处于 premium / 特殊分组的用户，服务端可能明确下发：

premium_min_post_length = 4

但随后 "ComposerMinLengthResolver" 会继续经过 "WardenPlugin"。如果当前分类配置了：

warden_min_post_length = 16

Warden 会直接用分类限制覆盖前面已经解析出的用户专属限制，最终导致客户端错误地要求该用户至少输入 16 字，而不是服务端针对该用户实际生效的 4 字。

修复

本 PR 为 "ComposerMinLengthContext" 增加了 "hasUserSpecificMinPostLength" 标记。

当满足以下条件时：

- 当前是普通回复，而不是首帖；
- 当前不是私信；
- "currentUser.premium_min_post_length" 是有效的正整数；

则认为当前基础限制已经是服务端针对该用户计算出的专属限制。

此时 "WardenPlugin" 会保留该值，不再使用面向整个分类的通用 "warden_min_post_length" 覆盖它。

行为变化

修复前：

premium_min_post_length = 4
warden_min_post_length = 16
=> 16

修复后：

premium_min_post_length = 4
warden_min_post_length = 16
=> 4

普通用户行为保持不变：

site min_post_length = 8
warden_min_post_length = 16
=> 16

首帖、私信、非真人用户私信以及 "max_post_length" 封顶逻辑均保持原有行为。

测试

新增回归测试覆盖：

- 普通用户仍使用分类 Warden 下限："8 -> 16"
- 存在用户专属限制时优先保留该值："4 -> 4"

这样可以避免分类级通用配置错误覆盖服务端已经针对当前用户计算出的有效最小字数限制。